### PR TITLE
Add RH0448: Enforce 3-line XML summary documentation

### DIFF
--- a/Reihitsu.Analyzer.CodeFixes/CodeFixResources.cs
+++ b/Reihitsu.Analyzer.CodeFixes/CodeFixResources.cs
@@ -719,6 +719,11 @@ internal static class CodeFixResources
     internal static string RH0447Title => GetString(nameof(RH0447Title));
 
     /// <summary>
+    /// Gets the localized string for RH0448Title.
+    /// </summary>
+    internal static string RH0448Title => GetString(nameof(RH0448Title));
+
+    /// <summary>
     /// Gets the localized string for RH0401Title.
     /// </summary>
     internal static string RH0401Title => GetString(nameof(RH0401Title));

--- a/Reihitsu.Analyzer.CodeFixes/CodeFixResources.resx
+++ b/Reihitsu.Analyzer.CodeFixes/CodeFixResources.resx
@@ -351,6 +351,9 @@
   <data name="RH0447Title" xml:space="preserve">
     <value>Move XML documentation element to next line</value>
   </data>
+  <data name="RH0448Title" xml:space="preserve">
+    <value>Expand summary to three lines</value>
+  </data>
   <data name="RH0401Title" xml:space="preserve">
     <value>Replace documentation with &lt;inheritdoc/&gt;</value>
   </data>

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Documentation/RH0448SummaryElementMustSpanAtLeastThreeLinesCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Documentation/RH0448SummaryElementMustSpanAtLeastThreeLinesCodeFixProvider.cs
@@ -1,0 +1,80 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+using Reihitsu.Formatter;
+
+namespace Reihitsu.Analyzer.Rules.Documentation;
+
+/// <summary>
+/// Code fix provider for <see cref="RH0448SummaryElementMustSpanAtLeastThreeLinesAnalyzer"/>.
+/// </summary>
+[Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(RH0448SummaryElementMustSpanAtLeastThreeLinesCodeFixProvider))]
+public class RH0448SummaryElementMustSpanAtLeastThreeLinesCodeFixProvider : CodeFixProvider
+{
+    #region Methods
+
+    /// <summary>
+    /// Applies the code fix.
+    /// </summary>
+    /// <param name="document">Document</param>
+    /// <param name="diagnosticSpan">Diagnostic span</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The updated document</returns>
+    private static async Task<Document> ApplyCodeFixAsync(Document document, TextSpan diagnosticSpan, CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+        if (root == null)
+        {
+            return document;
+        }
+
+        var diagnosticNode = root.FindNode(diagnosticSpan, findInsideTrivia: true, getInnermostNodeForTie: true);
+        var declaration = diagnosticNode.AncestorsAndSelf().FirstOrDefault(static obj => obj is MemberDeclarationSyntax or EnumMemberDeclarationSyntax);
+
+        if (declaration == null)
+        {
+            return document;
+        }
+
+        return await ReihitsuFormatter.FormatNodeInDocumentAsync(document, declaration, cancellationToken).ConfigureAwait(false);
+    }
+
+    #endregion // Methods
+
+    #region CodeFixProvider
+
+    /// <inheritdoc/>
+    public sealed override ImmutableArray<string> FixableDiagnosticIds => [RH0448SummaryElementMustSpanAtLeastThreeLinesAnalyzer.DiagnosticId];
+
+    /// <inheritdoc/>
+    public sealed override FixAllProvider GetFixAllProvider()
+    {
+        return WellKnownFixAllProviders.BatchFixer;
+    }
+
+    /// <inheritdoc/>
+    public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            context.RegisterCodeFix(CodeAction.Create(CodeFixResources.RH0448Title,
+                                                      token => ApplyCodeFixAsync(context.Document, diagnostic.Location.SourceSpan, token),
+                                                      nameof(RH0448SummaryElementMustSpanAtLeastThreeLinesCodeFixProvider)),
+                                    diagnostic);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    #endregion // CodeFixProvider
+}

--- a/Reihitsu.Analyzer.Package/README.MD
+++ b/Reihitsu.Analyzer.Package/README.MD
@@ -151,6 +151,7 @@ dotnet add package Reihitsu.Analyzer
 | [RH0445](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0445.md)| \<inheritdoc/> must be used with inheriting class.| ✔| ❌|
 | [RH0446](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0446.md)| Do not use placeholder elements.| ✔| ✔|
 | [RH0447](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0447.md)| XML documentation elements must be on separate lines.| ✔| ✔|
+| [RH0448](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0448.md)| Summary element must span at least three lines.| ✔| ✔|
 || **Ordering**|||
 | [RH0601](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0601.md)| Constants must appear before fields.| ✔| ✔|
 | [RH0602](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0602.md)| Static elements must appear before instance elements.| ✔| ✔|

--- a/Reihitsu.Analyzer.Test/Documentation/RH0448SummaryElementMustSpanAtLeastThreeLinesAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0448SummaryElementMustSpanAtLeastThreeLinesAnalyzerTests.cs
@@ -1,0 +1,186 @@
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Analyzer.Rules.Documentation;
+using Reihitsu.Analyzer.Test.Base;
+
+namespace Reihitsu.Analyzer.Test.Documentation;
+
+/// <summary>
+/// Test methods for <see cref="RH0448SummaryElementMustSpanAtLeastThreeLinesAnalyzer"/> and <see cref="RH0448SummaryElementMustSpanAtLeastThreeLinesCodeFixProvider"/>.
+/// </summary>
+[TestClass]
+public class RH0448SummaryElementMustSpanAtLeastThreeLinesAnalyzerTests : AnalyzerTestsBase<RH0448SummaryElementMustSpanAtLeastThreeLinesAnalyzer, RH0448SummaryElementMustSpanAtLeastThreeLinesCodeFixProvider>
+{
+    /// <summary>
+    /// Verifies that a correctly formatted three-line summary does not produce diagnostics.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForCorrectThreeLineSummary()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    /// <summary>
+                                    /// Summary text
+                                    /// </summary>
+                                    void Method()
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that a single-line summary is detected and fixed.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [TestMethod]
+    public async Task VerifySingleLineSummaryIsDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    /// {|#0:<summary>Summary text</summary>|}
+                                    void Method()
+                                    {
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     /// <summary>
+                                     /// Summary text
+                                     /// </summary>
+                                     void Method()
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH0448SummaryElementMustSpanAtLeastThreeLinesAnalyzer.DiagnosticId, AnalyzerResources.RH0448MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that a single-line summary with inline XML content is detected and fixed without breaking the content.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [TestMethod]
+    public async Task VerifySingleLineSummaryWithInlineXmlIsDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    /// {|#0:<summary>Uses <see cref="string"/> values</summary>|}
+                                    void Method()
+                                    {
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     /// <summary>
+                                     /// Uses <see cref="string"/> values
+                                     /// </summary>
+                                     void Method()
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH0448SummaryElementMustSpanAtLeastThreeLinesAnalyzer.DiagnosticId, AnalyzerResources.RH0448MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that a multiline summary with multiple content lines does not produce diagnostics.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForMultilineSummaryWithMultipleContentLines()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    /// <summary>
+                                    /// First line
+                                    /// Second line
+                                    /// </summary>
+                                    void Method()
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that a two-line summary with content on start-tag line produces a diagnostic.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticForTwoLineSummaryWithContentOnStartTagLine()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    /// {|#0:<summary>Summary text
+                                    /// </summary>|}
+                                    void Method()
+                                    {
+                                    }
+                                }
+                                """;
+
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     /// <summary>
+                                     /// Summary text
+                                     /// </summary>
+                                     void Method()
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData, Diagnostics(RH0448SummaryElementMustSpanAtLeastThreeLinesAnalyzer.DiagnosticId, AnalyzerResources.RH0448MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that an empty single-line summary is detected and fixed to the three-line form.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [TestMethod]
+    public async Task VerifyEmptySingleLineSummaryIsDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    /// {|#0:<summary></summary>|}
+                                    void Method()
+                                    {
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     /// <summary>
+                                     /// 
+                                     /// </summary>
+                                     void Method()
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH0448SummaryElementMustSpanAtLeastThreeLinesAnalyzer.DiagnosticId, AnalyzerResources.RH0448MessageFormat));
+    }
+}

--- a/Reihitsu.Analyzer/AnalyzerResources.cs
+++ b/Reihitsu.Analyzer/AnalyzerResources.cs
@@ -1975,6 +1975,16 @@ internal static class AnalyzerResources
     internal static string RH0447Title => GetString(nameof(RH0447Title));
 
     /// <summary>
+    /// Gets the localized string for RH0448MessageFormat.
+    /// </summary>
+    internal static string RH0448MessageFormat => GetString(nameof(RH0448MessageFormat));
+
+    /// <summary>
+    /// Gets the localized string for RH0448Title.
+    /// </summary>
+    internal static string RH0448Title => GetString(nameof(RH0448Title));
+
+    /// <summary>
     /// Gets the localized string for RH0401MessageFormat.
     /// </summary>
     internal static string RH0401MessageFormat => GetString(nameof(RH0401MessageFormat));

--- a/Reihitsu.Analyzer/AnalyzerResources.resx
+++ b/Reihitsu.Analyzer/AnalyzerResources.resx
@@ -669,6 +669,12 @@
   <data name="RH0447Title" xml:space="preserve">
     <value>XML documentation elements must be on separate lines</value>
   </data>
+  <data name="RH0448MessageFormat" xml:space="preserve">
+    <value>Summary element must span at least three lines.</value>
+  </data>
+  <data name="RH0448Title" xml:space="preserve">
+    <value>Summary element must span at least three lines</value>
+  </data>
   <data name="RH0334MessageFormat" xml:space="preserve">
     <value>Keywords must be spaced correctly.</value>
   </data>

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0448SummaryElementMustSpanAtLeastThreeLinesAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0448SummaryElementMustSpanAtLeastThreeLinesAnalyzer.cs
@@ -1,0 +1,87 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+
+using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Enumerations;
+
+namespace Reihitsu.Analyzer.Rules.Documentation;
+
+/// <summary>
+/// RH0448: Summary element must span at least three lines.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class RH0448SummaryElementMustSpanAtLeastThreeLinesAnalyzer : DiagnosticAnalyzerBase<RH0448SummaryElementMustSpanAtLeastThreeLinesAnalyzer>
+{
+    #region Constants
+
+    /// <summary>
+    /// Diagnostic ID
+    /// </summary>
+    public const string DiagnosticId = "RH0448";
+
+    #endregion // Constants
+
+    #region Constructor
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public RH0448SummaryElementMustSpanAtLeastThreeLinesAnalyzer()
+        : base(DiagnosticId, DiagnosticCategory.Documentation, nameof(AnalyzerResources.RH0448Title), nameof(AnalyzerResources.RH0448MessageFormat))
+    {
+    }
+
+    #endregion // Constructor
+
+    #region Methods
+
+    /// <summary>
+    /// Analyzes a single-line documentation comment.
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnDocumentationCommentTrivia(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not DocumentationCommentTriviaSyntax documentationComment)
+        {
+            return;
+        }
+
+        var summaryElement = documentationComment.Content
+                                                 .OfType<XmlElementSyntax>()
+                                                 .FirstOrDefault(element => element.StartTag.Name.LocalName.ValueText == "summary");
+
+        if (summaryElement == null)
+        {
+            return;
+        }
+
+        var sourceText = context.Node.SyntaxTree.GetText(context.CancellationToken);
+        var startTagSpan = summaryElement.StartTag.Span;
+        var endTagSpan = summaryElement.EndTag.Span;
+
+        var startTagLine = sourceText.Lines.GetLineFromPosition(startTagSpan.Start).LineNumber;
+        var endTagLine = sourceText.Lines.GetLineFromPosition(endTagSpan.Start).LineNumber;
+
+        if (endTagLine - startTagLine < 2)
+        {
+            context.ReportDiagnostic(CreateDiagnostic(summaryElement.GetLocation()));
+        }
+    }
+
+    #endregion // Methods
+
+    #region DiagnosticAnalyzer
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        base.Initialize(context);
+
+        context.RegisterSyntaxNodeAction(OnDocumentationCommentTrivia, SyntaxKind.SingleLineDocumentationCommentTrivia);
+    }
+
+    #endregion // DiagnosticAnalyzer
+}

--- a/Reihitsu.Formatter.Test/Regression/FullPipeline/DocumentationSummaryFormattingFullPipelineTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/FullPipeline/DocumentationSummaryFormattingFullPipelineTests.cs
@@ -1,0 +1,76 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Formatter.Test.Helpers;
+
+namespace Reihitsu.Formatter.Test.Regression.FullPipeline;
+
+/// <summary>
+/// Full-pipeline regression tests for XML documentation summary formatting.
+/// </summary>
+[TestClass]
+public class DocumentationSummaryFormattingFullPipelineTests : FormatterTestsBase
+{
+    #region Methods
+
+    /// <summary>
+    /// Verifies that single-line summary elements are expanded to three lines.
+    /// </summary>
+    [TestMethod]
+    public void ExpandsSingleLineSummaryElement()
+    {
+        const string input = """
+                             internal class TestClass
+                             {
+                                 /// <summary>Summary text</summary>
+                                 void Method()
+                                 {
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    /// <summary>
+                                    /// Summary text
+                                    /// </summary>
+                                    void Method()
+                                    {
+                                    }
+                                }
+                                """;
+
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that inline XML content remains on the same content line when the summary is expanded.
+    /// </summary>
+    [TestMethod]
+    public void ExpandsSingleLineSummaryElementWithInlineXmlContent()
+    {
+        const string input = """
+                             internal class TestClass
+                             {
+                                 /// <summary>Uses <see cref="string"/> values</summary>
+                                 void Method()
+                                 {
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    /// <summary>
+                                    /// Uses <see cref="string"/> values
+                                    /// </summary>
+                                    void Method()
+                                    {
+                                    }
+                                }
+                                """;
+
+        AssertRuleResult(input, expected);
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Formatter/Pipeline/DocumentationComments/DocumentationCommentFormattingPhase.cs
+++ b/Reihitsu.Formatter/Pipeline/DocumentationComments/DocumentationCommentFormattingPhase.cs
@@ -1,0 +1,167 @@
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Reihitsu.Formatter.Pipeline.DocumentationComments;
+
+/// <summary>
+/// Normalizes XML documentation comments to repository-specific summary formatting.
+/// </summary>
+internal static class DocumentationCommentFormattingPhase
+{
+    #region Methods
+
+    /// <summary>
+    /// Applies XML documentation summary formatting to the given syntax node.
+    /// </summary>
+    /// <param name="root">The syntax node to format.</param>
+    /// <param name="context">The formatting context.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The formatted syntax node.</returns>
+    public static SyntaxNode Execute(SyntaxNode root, FormattingContext context, CancellationToken cancellationToken)
+    {
+        var sourceText = root.SyntaxTree.GetText(cancellationToken);
+        var replacements = new Dictionary<SyntaxTrivia, SyntaxTrivia>();
+
+        foreach (var trivia in root.DescendantTrivia(descendIntoTrivia: true))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (trivia.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia) == false
+                || trivia.GetStructure() is not DocumentationCommentTriviaSyntax documentationComment)
+            {
+                continue;
+            }
+
+            var summaryElement = documentationComment.Content
+                                                     .OfType<XmlElementSyntax>()
+                                                     .FirstOrDefault(static obj => string.Equals(obj.StartTag.Name.LocalName.ValueText, "summary", StringComparison.OrdinalIgnoreCase));
+
+            if (summaryElement == null || SpansAtLeastThreeLines(summaryElement, sourceText))
+            {
+                continue;
+            }
+
+            var updatedCommentText = ExpandSummaryElement(trivia, summaryElement, sourceText);
+            var leadingTrivia = SyntaxFactory.ParseLeadingTrivia(updatedCommentText);
+
+            if (leadingTrivia.Count > 0)
+            {
+                replacements[trivia] = leadingTrivia[0];
+            }
+        }
+
+        return replacements.Count == 0 ? root : root.ReplaceTrivia(replacements.Keys, (oldTrivia, _) => replacements[oldTrivia]);
+    }
+
+    /// <summary>
+    /// Expands a summary element to the repository's three-line form.
+    /// </summary>
+    /// <param name="documentationCommentTrivia">Documentation comment trivia.</param>
+    /// <param name="summaryElement">Summary element.</param>
+    /// <param name="sourceText">Source text.</param>
+    /// <returns>The updated documentation comment text.</returns>
+    private static string ExpandSummaryElement(SyntaxTrivia documentationCommentTrivia, XmlElementSyntax summaryElement, SourceText sourceText)
+    {
+        var documentationPrefix = GetDocumentationPrefix(sourceText, sourceText.Lines.GetLineFromPosition(summaryElement.StartTag.Span.Start));
+        var lineBreak = GetLineBreak(sourceText, sourceText.Lines.GetLineFromPosition(summaryElement.StartTag.Span.Start));
+        var contentLines = GetSummaryContentLines(summaryElement, sourceText, documentationPrefix);
+        var expandedSummary = $"<summary>{lineBreak}{documentationPrefix}{string.Join(lineBreak + documentationPrefix, contentLines)}{lineBreak}{documentationPrefix}</summary>";
+        var commentText = sourceText.ToString(documentationCommentTrivia.FullSpan);
+        var relativeStart = summaryElement.Span.Start - documentationCommentTrivia.FullSpan.Start;
+        var relativeEnd = summaryElement.Span.End - documentationCommentTrivia.FullSpan.Start;
+
+        return commentText.Substring(0, relativeStart) + expandedSummary + commentText.Substring(relativeEnd);
+    }
+
+    /// <summary>
+    /// Gets the line break sequence for the affected line.
+    /// </summary>
+    /// <param name="sourceText">Source text.</param>
+    /// <param name="line">Affected line.</param>
+    /// <returns>The line break sequence.</returns>
+    private static string GetLineBreak(SourceText sourceText, TextLine line)
+    {
+        return line.EndIncludingLineBreak > line.End
+                   ? sourceText.ToString(TextSpan.FromBounds(line.End, line.EndIncludingLineBreak))
+                   : Environment.NewLine;
+    }
+
+    /// <summary>
+    /// Gets the documentation prefix for the specified line.
+    /// </summary>
+    /// <param name="sourceText">Source text.</param>
+    /// <param name="line">Affected line.</param>
+    /// <returns>The documentation prefix.</returns>
+    private static string GetDocumentationPrefix(SourceText sourceText, TextLine line)
+    {
+        var lineText = sourceText.ToString(line.Span);
+        var elementIndex = lineText.IndexOf('<');
+
+        return elementIndex >= 0 ? lineText.Substring(0, elementIndex) : string.Empty;
+    }
+
+    /// <summary>
+    /// Extracts normalized summary content lines while preserving inline XML content.
+    /// </summary>
+    /// <param name="summaryElement">Summary element.</param>
+    /// <param name="sourceText">Source text.</param>
+    /// <param name="documentationPrefix">Documentation prefix for continuation lines.</param>
+    /// <returns>The normalized content lines.</returns>
+    private static List<string> GetSummaryContentLines(XmlElementSyntax summaryElement, SourceText sourceText, string documentationPrefix)
+    {
+        var contentSpan = TextSpan.FromBounds(summaryElement.StartTag.Span.End, summaryElement.EndTag.Span.Start);
+        var rawContent = sourceText.ToString(contentSpan);
+        var rawLines = rawContent.Replace("\r\n", "\n")
+                                 .Replace('\r', '\n')
+                                 .Split('\n');
+        var contentLines = new List<string>();
+
+        foreach (var rawLine in rawLines)
+        {
+            var currentLine = rawLine;
+
+            if (currentLine.StartsWith(documentationPrefix, StringComparison.Ordinal))
+            {
+                currentLine = currentLine.Substring(documentationPrefix.Length);
+            }
+            else
+            {
+                var trimmedStart = currentLine.TrimStart(' ', '\t');
+
+                if (trimmedStart.StartsWith("///", StringComparison.Ordinal))
+                {
+                    currentLine = trimmedStart.Substring(3).TrimStart();
+                }
+            }
+
+            currentLine = currentLine.Trim();
+
+            if (string.IsNullOrWhiteSpace(currentLine) == false)
+            {
+                contentLines.Add(currentLine);
+            }
+        }
+
+        return contentLines.Count == 0 ? [string.Empty] : contentLines;
+    }
+
+    /// <summary>
+    /// Determines whether the specified summary element already spans at least three lines.
+    /// </summary>
+    /// <param name="summaryElement">Summary element.</param>
+    /// <param name="sourceText">Source text.</param>
+    /// <returns><see langword="true"/> if the summary spans at least three lines.</returns>
+    private static bool SpansAtLeastThreeLines(XmlElementSyntax summaryElement, SourceText sourceText)
+    {
+        var startTagLine = sourceText.Lines.GetLineFromPosition(summaryElement.StartTag.Span.Start).LineNumber;
+        var endTagLine = sourceText.Lines.GetLineFromPosition(summaryElement.EndTag.Span.Start).LineNumber;
+
+        return endTagLine - startTagLine >= 2;
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Formatter/Pipeline/FormattingPipeline.cs
+++ b/Reihitsu.Formatter/Pipeline/FormattingPipeline.cs
@@ -32,6 +32,11 @@ internal static class FormattingPipeline
 
         cancellationToken.ThrowIfCancellationRequested();
 
+        // Documentation comments (normalize summary layout)
+        current = DocumentationComments.DocumentationCommentFormattingPhase.Execute(current, context, cancellationToken);
+
+        cancellationToken.ThrowIfCancellationRequested();
+
         // Blank lines (insert/remove vertical whitespace)
         current = BlankLines.BlankLinePhase.Execute(current, context, cancellationToken);
 

--- a/Reihitsu.sln
+++ b/Reihitsu.sln
@@ -211,6 +211,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		documentation\rules\RH0445.md = documentation\rules\RH0445.md
 		documentation\rules\RH0446.md = documentation\rules\RH0446.md
 		documentation\rules\RH0447.md = documentation\rules\RH0447.md
+		documentation\rules\RH0448.md = documentation\rules\RH0448.md
 		documentation\rules\RH0501.md = documentation\rules\RH0501.md
 		documentation\rules\RH0502.md = documentation\rules\RH0502.md
 		documentation\rules\RH0601.md = documentation\rules\RH0601.md

--- a/documentation/rules/RH0448.md
+++ b/documentation/rules/RH0448.md
@@ -1,0 +1,48 @@
+# RH0448 - Summary element must span at least three lines
+
+| Property | Value |
+|----------|-------|
+| **ID** | RH0448 |
+| **Category** | Documentation |
+| **Severity** | Warning |
+| **Code Fix** | ✓ |
+
+## Description
+
+This rule ensures that XML documentation summary elements span at least three lines: one for the opening tag, one or more for the content, and one for the closing tag.
+
+## Why is this a problem?
+
+Single-line or two-line summary elements reduce readability and make documentation harder to scan. A consistent three-line format improves the visual structure of documentation comments.
+
+## How to fix it
+
+Expand the summary element to span at least three lines by placing the opening tag, content, and closing tag on separate lines.
+
+## Examples
+
+### Violation
+
+```cs
+internal class TestClass
+{
+    /// <summary>Summary text</summary>
+    void Method()
+    {
+    }
+}
+```
+
+### Correction
+
+```cs
+internal class TestClass
+{
+    /// <summary>
+    /// Summary text
+    /// </summary>
+    void Method()
+    {
+    }
+}
+```


### PR DESCRIPTION
Introduce analyzer and code fix for RH0448 to require `<summary>` elements in XML documentation to span at least three lines. Add formatter phase to normalize summary layout, update resources, documentation, and tests, and register the new rule in the solution and README.