### PR TITLE
Add RH0450: normalize XML doc element line alignment

### DIFF
--- a/Reihitsu.Analyzer.CodeFixes/CodeFixResources.cs
+++ b/Reihitsu.Analyzer.CodeFixes/CodeFixResources.cs
@@ -729,6 +729,11 @@ internal static class CodeFixResources
     internal static string RH0449Title => GetString(nameof(RH0449Title));
 
     /// <summary>
+    /// Gets the localized string for RH0450Title
+    /// </summary>
+    internal static string RH0450Title => GetString(nameof(RH0450Title));
+
+    /// <summary>
     /// Gets the localized string for RH0401Title
     /// </summary>
     internal static string RH0401Title => GetString(nameof(RH0401Title));

--- a/Reihitsu.Analyzer.CodeFixes/CodeFixResources.resx
+++ b/Reihitsu.Analyzer.CodeFixes/CodeFixResources.resx
@@ -357,6 +357,9 @@
   <data name="RH0449Title" xml:space="preserve">
     <value>Remove trailing period from XML documentation element text</value>
   </data>
+  <data name="RH0450Title" xml:space="preserve">
+    <value>Normalize XML documentation element text layout</value>
+  </data>
   <data name="RH0401Title" xml:space="preserve">
     <value>Replace documentation with &lt;inheritdoc/&gt;</value>
   </data>

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Documentation/RH0450TextAfterOpeningXmlTagMustBeOnSameLineAsClosingTagCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Documentation/RH0450TextAfterOpeningXmlTagMustBeOnSameLineAsClosingTagCodeFixProvider.cs
@@ -1,0 +1,80 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+using Reihitsu.Formatter;
+
+namespace Reihitsu.Analyzer.Rules.Documentation;
+
+/// <summary>
+/// Code fix provider for <see cref="RH0450TextAfterOpeningXmlTagMustBeOnSameLineAsClosingTagAnalyzer"/>
+/// </summary>
+[Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(RH0450TextAfterOpeningXmlTagMustBeOnSameLineAsClosingTagCodeFixProvider))]
+public class RH0450TextAfterOpeningXmlTagMustBeOnSameLineAsClosingTagCodeFixProvider : CodeFixProvider
+{
+    #region Methods
+
+    /// <summary>
+    /// Applies the code fix
+    /// </summary>
+    /// <param name="document">Document</param>
+    /// <param name="diagnosticSpan">Diagnostic span</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The updated document</returns>
+    private static async Task<Document> ApplyCodeFixAsync(Document document, TextSpan diagnosticSpan, CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+        if (root == null)
+        {
+            return document;
+        }
+
+        var diagnosticNode = root.FindNode(diagnosticSpan, findInsideTrivia: true, getInnermostNodeForTie: true);
+        var declaration = diagnosticNode.AncestorsAndSelf().FirstOrDefault(static obj => obj is MemberDeclarationSyntax or EnumMemberDeclarationSyntax);
+
+        if (declaration == null)
+        {
+            return document;
+        }
+
+        return await ReihitsuFormatter.FormatNodeInDocumentAsync(document, declaration, cancellationToken).ConfigureAwait(false);
+    }
+
+    #endregion // Methods
+
+    #region CodeFixProvider
+
+    /// <inheritdoc/>
+    public sealed override ImmutableArray<string> FixableDiagnosticIds => [RH0450TextAfterOpeningXmlTagMustBeOnSameLineAsClosingTagAnalyzer.DiagnosticId];
+
+    /// <inheritdoc/>
+    public sealed override FixAllProvider GetFixAllProvider()
+    {
+        return WellKnownFixAllProviders.BatchFixer;
+    }
+
+    /// <inheritdoc/>
+    public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            context.RegisterCodeFix(CodeAction.Create(CodeFixResources.RH0450Title,
+                                                      token => ApplyCodeFixAsync(context.Document, diagnostic.Location.SourceSpan, token),
+                                                      nameof(RH0450TextAfterOpeningXmlTagMustBeOnSameLineAsClosingTagCodeFixProvider)),
+                                    diagnostic);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    #endregion // CodeFixProvider
+}

--- a/Reihitsu.Analyzer.Package/README.MD
+++ b/Reihitsu.Analyzer.Package/README.MD
@@ -153,6 +153,7 @@ dotnet add package Reihitsu.Analyzer
 | [RH0447](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0447.md)| XML documentation elements must be on separate lines.| ✔| ✔|
 | [RH0448](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0448.md)| Summary element must span at least three lines.| ✔| ✔|
 | [RH0449](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0449.md)| XML documentation element text must not end with a period.| ✔| ✔|
+| [RH0450](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0450.md)| Content after opening XML tag must be on same line as closing tag.| ✔| ✔|
 || **Ordering**|||
 | [RH0601](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0601.md)| Constants must appear before fields.| ✔| ✔|
 | [RH0602](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0602.md)| Static elements must appear before instance elements.| ✔| ✔|

--- a/Reihitsu.Analyzer.Test/Documentation/RH0450TextAfterOpeningXmlTagMustBeOnSameLineAsClosingTagAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0450TextAfterOpeningXmlTagMustBeOnSameLineAsClosingTagAnalyzerTests.cs
@@ -1,0 +1,189 @@
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Analyzer.Rules.Documentation;
+using Reihitsu.Analyzer.Test.Base;
+
+namespace Reihitsu.Analyzer.Test.Documentation;
+
+/// <summary>
+/// Test methods for <see cref="RH0450TextAfterOpeningXmlTagMustBeOnSameLineAsClosingTagAnalyzer"/> and <see cref="RH0450TextAfterOpeningXmlTagMustBeOnSameLineAsClosingTagCodeFixProvider"/>
+/// </summary>
+[TestClass]
+public class RH0450TextAfterOpeningXmlTagMustBeOnSameLineAsClosingTagAnalyzerTests : AnalyzerTestsBase<RH0450TextAfterOpeningXmlTagMustBeOnSameLineAsClosingTagAnalyzer, RH0450TextAfterOpeningXmlTagMustBeOnSameLineAsClosingTagCodeFixProvider>
+{
+    /// <summary>
+    /// Verifies that single-line XML documentation elements do not produce diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForSingleLineXmlDocumentationElement()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    /// <param name="value">The value</param>
+                                    void Method(string value)
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that multiline XML documentation elements with content starting on the next line do not produce diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenTextStartsOnNewLine()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    /// <remarks>
+                                    /// First line
+                                    /// Second line
+                                    /// </remarks>
+                                    void Method()
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that elements with inline XML content on the opening-tag line are detected and fixed
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyMisalignedInlineXmlContentIsDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    /// {|#0:<summary><see cref="string"/>
+                                    /// values</summary>|}
+                                    void Method()
+                                    {
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     /// <summary>
+                                     /// <see cref="string"/>
+                                     /// values
+                                     /// </summary>
+                                     void Method()
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH0450TextAfterOpeningXmlTagMustBeOnSameLineAsClosingTagAnalyzer.DiagnosticId, AnalyzerResources.RH0450MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that a misaligned parameter element is detected and fixed by collapsing it to a single line
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyMisalignedParamElementIsDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    /// {|#0:<param name="value">The value
+                                    /// </param>|}
+                                    void Method(string value)
+                                    {
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     /// <param name="value">The value</param>
+                                     void Method(string value)
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH0450TextAfterOpeningXmlTagMustBeOnSameLineAsClosingTagAnalyzer.DiagnosticId, AnalyzerResources.RH0450MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that a misaligned summary element is detected and fixed by moving its content to the next line
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyMisalignedSummaryElementIsDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    /// {|#0:<summary>First line
+                                    /// Second line
+                                    /// </summary>|}
+                                    void Method()
+                                    {
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     /// <summary>
+                                     /// First line
+                                     /// Second line
+                                     /// </summary>
+                                     void Method()
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH0450TextAfterOpeningXmlTagMustBeOnSameLineAsClosingTagAnalyzer.DiagnosticId, AnalyzerResources.RH0450MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that a multiline remarks element is detected and fixed by moving the first content line below the opening tag
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyMisalignedMultilineRemarksElementIsDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    /// {|#0:<remarks>First line
+                                    /// Second line
+                                    /// </remarks>|}
+                                    void Method()
+                                    {
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     /// <remarks>
+                                     /// First line
+                                     /// Second line
+                                     /// </remarks>
+                                     void Method()
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH0450TextAfterOpeningXmlTagMustBeOnSameLineAsClosingTagAnalyzer.DiagnosticId, AnalyzerResources.RH0450MessageFormat));
+    }
+}

--- a/Reihitsu.Analyzer/AnalyzerResources.cs
+++ b/Reihitsu.Analyzer/AnalyzerResources.cs
@@ -1995,6 +1995,16 @@ internal static class AnalyzerResources
     internal static string RH0449Title => GetString(nameof(RH0449Title));
 
     /// <summary>
+    /// Gets the localized string for RH0450MessageFormat
+    /// </summary>
+    internal static string RH0450MessageFormat => GetString(nameof(RH0450MessageFormat));
+
+    /// <summary>
+    /// Gets the localized string for RH0450Title
+    /// </summary>
+    internal static string RH0450Title => GetString(nameof(RH0450Title));
+
+    /// <summary>
     /// Gets the localized string for RH0401MessageFormat
     /// </summary>
     internal static string RH0401MessageFormat => GetString(nameof(RH0401MessageFormat));

--- a/Reihitsu.Analyzer/AnalyzerResources.resx
+++ b/Reihitsu.Analyzer/AnalyzerResources.resx
@@ -681,6 +681,12 @@
   <data name="RH0449Title" xml:space="preserve">
     <value>XML documentation element text must not end with a period</value>
   </data>
+  <data name="RH0450MessageFormat" xml:space="preserve">
+    <value>Content after opening XML tag must be on same line as closing tag.</value>
+  </data>
+  <data name="RH0450Title" xml:space="preserve">
+    <value>Content after opening XML tag must be on same line as closing tag</value>
+  </data>
   <data name="RH0334MessageFormat" xml:space="preserve">
     <value>Keywords must be spaced correctly.</value>
   </data>

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0450TextAfterOpeningXmlTagMustBeOnSameLineAsClosingTagAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0450TextAfterOpeningXmlTagMustBeOnSameLineAsClosingTagAnalyzer.cs
@@ -1,0 +1,156 @@
+using System.Threading;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Enumerations;
+
+namespace Reihitsu.Analyzer.Rules.Documentation;
+
+/// <summary>
+/// RH0450: Text after opening XML tag must be on same line as closing tag
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class RH0450TextAfterOpeningXmlTagMustBeOnSameLineAsClosingTagAnalyzer : DiagnosticAnalyzerBase<RH0450TextAfterOpeningXmlTagMustBeOnSameLineAsClosingTagAnalyzer>
+{
+    #region Constants
+
+    /// <summary>
+    /// Diagnostic ID
+    /// </summary>
+    public const string DiagnosticId = "RH0450";
+
+    #endregion // Constants
+
+    #region Constructor
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public RH0450TextAfterOpeningXmlTagMustBeOnSameLineAsClosingTagAnalyzer()
+        : base(DiagnosticId, DiagnosticCategory.Documentation, nameof(AnalyzerResources.RH0450Title), nameof(AnalyzerResources.RH0450MessageFormat))
+    {
+    }
+
+    #endregion // Constructor
+
+    #region Methods
+
+    /// <summary>
+    /// Attempts to get the position of the first meaningful content within the XML element
+    /// </summary>
+    /// <param name="element">XML element</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <param name="position">Position of the first meaningful content</param>
+    /// <returns><see langword="true"/> if meaningful content was found</returns>
+    private static bool TryGetFirstMeaningfulContentPosition(XmlElementSyntax element, CancellationToken cancellationToken, out int position)
+    {
+        position = 0;
+
+        foreach (var node in element.Content)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (node is XmlTextSyntax textSyntax)
+            {
+                if (TryGetFirstMeaningfulContentPosition(textSyntax, cancellationToken, out position))
+                {
+                    return true;
+                }
+
+                continue;
+            }
+
+            position = node.SpanStart;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether the specified element violates the rule
+    /// </summary>
+    /// <param name="element">XML element</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns><see langword="true"/> if the element violates the rule</returns>
+    private static bool ViolatesRule(XmlElementSyntax element, CancellationToken cancellationToken)
+    {
+        if (TryGetFirstMeaningfulContentPosition(element, cancellationToken, out var firstContentPosition) == false)
+        {
+            return false;
+        }
+
+        var sourceText = element.SyntaxTree.GetText(cancellationToken);
+        var startTagLine = sourceText.Lines.GetLineFromPosition(element.StartTag.Span.Start).LineNumber;
+        var firstContentLine = sourceText.Lines.GetLineFromPosition(firstContentPosition).LineNumber;
+        var endTagLine = sourceText.Lines.GetLineFromPosition(element.EndTag.Span.Start).LineNumber;
+
+        return startTagLine == firstContentLine
+               && firstContentLine != endTagLine;
+    }
+
+    /// <summary>
+    /// Attempts to get the position of the first meaningful content within the XML text node
+    /// </summary>
+    /// <param name="textSyntax">XML text syntax</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <param name="position">Position of the first meaningful content</param>
+    /// <returns><see langword="true"/> if meaningful content was found</returns>
+    private static bool TryGetFirstMeaningfulContentPosition(XmlTextSyntax textSyntax, CancellationToken cancellationToken, out int position)
+    {
+        position = 0;
+
+        foreach (var token in textSyntax.TextTokens)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var tokenText = token.Text;
+
+            for (var index = 0; index < tokenText.Length; index++)
+            {
+                if (char.IsWhiteSpace(tokenText[index]) == false)
+                {
+                    position = token.SpanStart + index;
+
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Analyzes an XML documentation element
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnXmlElement(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not XmlElementSyntax element
+            || ViolatesRule(element, context.CancellationToken) == false)
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(CreateDiagnostic(element.GetLocation()));
+    }
+
+    #endregion // Methods
+
+    #region DiagnosticAnalyzer
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        base.Initialize(context);
+
+        context.RegisterSyntaxNodeAction(OnXmlElement, SyntaxKind.XmlElement);
+    }
+
+    #endregion // DiagnosticAnalyzer
+}

--- a/Reihitsu.Formatter.Test/Regression/FullPipeline/DocumentationElementTextLineAlignmentFullPipelineTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/FullPipeline/DocumentationElementTextLineAlignmentFullPipelineTests.cs
@@ -1,0 +1,143 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Formatter.Test.Helpers;
+
+namespace Reihitsu.Formatter.Test.Regression.FullPipeline;
+
+/// <summary>
+/// Full-pipeline regression tests for XML documentation element content line alignment
+/// </summary>
+[TestClass]
+public class DocumentationElementTextLineAlignmentFullPipelineTests : FormatterTestsBase
+{
+    #region Methods
+
+    /// <summary>
+    /// Verifies that a single-content-line documentation element is collapsed to one line
+    /// </summary>
+    [TestMethod]
+    public void CollapsesSingleContentLineElement()
+    {
+        const string input = """
+                             internal class TestClass
+                             {
+                                 /// <param name="value">The value
+                                 /// </param>
+                                 void Method(string value)
+                                 {
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    /// <param name="value">The value</param>
+                                    void Method(string value)
+                                    {
+                                    }
+                                }
+                                """;
+
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that multi-line content is moved below the opening tag
+    /// </summary>
+    [TestMethod]
+    public void MovesMultilineContentBelowOpeningTag()
+    {
+        const string input = """
+                             internal class TestClass
+                             {
+                                 /// <remarks>First line
+                                 /// Second line
+                                 /// </remarks>
+                                 void Method()
+                                 {
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    /// <remarks>
+                                    /// First line
+                                    /// Second line
+                                    /// </remarks>
+                                    void Method()
+                                    {
+                                    }
+                                }
+                                """;
+
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that summary elements remain expanded rather than being collapsed
+    /// </summary>
+    [TestMethod]
+    public void KeepsSummaryElementExpanded()
+    {
+        const string input = """
+                             internal class TestClass
+                             {
+                                 /// <summary>First line
+                                 /// Second line
+                                 /// </summary>
+                                 void Method()
+                                 {
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    /// <summary>
+                                    /// First line
+                                    /// Second line
+                                    /// </summary>
+                                    void Method()
+                                    {
+                                    }
+                                }
+                                """;
+
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that leading inline XML content is moved below the opening tag
+    /// </summary>
+    [TestMethod]
+    public void MovesLeadingInlineXmlContentBelowOpeningTag()
+    {
+        const string input = """
+                             internal class TestClass
+                             {
+                                 /// <summary><see cref="string"/>
+                                 /// values</summary>
+                                 void Method()
+                                 {
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    /// <summary>
+                                    /// <see cref="string"/>
+                                    /// values
+                                    /// </summary>
+                                    void Method()
+                                    {
+                                    }
+                                }
+                                """;
+
+        AssertRuleResult(input, expected);
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Formatter/Pipeline/DocumentationComments/DocumentationCommentFormattingPhase.cs
+++ b/Reihitsu.Formatter/Pipeline/DocumentationComments/DocumentationCommentFormattingPhase.cs
@@ -8,14 +8,14 @@ using Microsoft.CodeAnalysis.Text;
 namespace Reihitsu.Formatter.Pipeline.DocumentationComments;
 
 /// <summary>
-/// Normalizes XML documentation comments to repository-specific summary formatting
+/// Normalizes XML documentation comments to repository-specific layout rules
 /// </summary>
 internal static class DocumentationCommentFormattingPhase
 {
     #region Methods
 
     /// <summary>
-    /// Applies XML documentation summary formatting to the given syntax node
+    /// Applies XML documentation comment formatting to the given syntax node
     /// </summary>
     /// <param name="root">The syntax node to format</param>
     /// <param name="context">The formatting context</param>
@@ -36,16 +36,12 @@ internal static class DocumentationCommentFormattingPhase
                 continue;
             }
 
-            var summaryElement = documentationComment.Content
-                                                     .OfType<XmlElementSyntax>()
-                                                     .FirstOrDefault(static obj => string.Equals(obj.StartTag.Name.LocalName.ValueText, "summary", StringComparison.OrdinalIgnoreCase));
+            var updatedCommentText = NormalizeDocumentationComment(trivia, documentationComment, sourceText, cancellationToken);
 
-            if (summaryElement == null || SpansAtLeastThreeLines(summaryElement, sourceText))
+            if (updatedCommentText == null)
             {
                 continue;
             }
-
-            var updatedCommentText = ExpandSummaryElement(trivia, summaryElement, sourceText);
             var leadingTrivia = SyntaxFactory.ParseLeadingTrivia(updatedCommentText);
 
             if (leadingTrivia.Count > 0)
@@ -58,23 +54,51 @@ internal static class DocumentationCommentFormattingPhase
     }
 
     /// <summary>
-    /// Expands a summary element to the repository's three-line form
+    /// Builds a single-line form of the XML documentation element
     /// </summary>
-    /// <param name="documentationCommentTrivia">Documentation comment trivia</param>
-    /// <param name="summaryElement">Summary element</param>
+    /// <param name="element">XML element</param>
     /// <param name="sourceText">Source text</param>
-    /// <returns>The updated documentation comment text</returns>
-    private static string ExpandSummaryElement(SyntaxTrivia documentationCommentTrivia, XmlElementSyntax summaryElement, SourceText sourceText)
+    /// <param name="documentationPrefix">Documentation prefix for continuation lines</param>
+    /// <returns>The normalized single-line element text</returns>
+    private static string BuildCollapsedElement(XmlElementSyntax element, SourceText sourceText, string documentationPrefix)
     {
-        var documentationPrefix = GetDocumentationPrefix(sourceText, sourceText.Lines.GetLineFromPosition(summaryElement.StartTag.Span.Start));
-        var lineBreak = GetLineBreak(sourceText, sourceText.Lines.GetLineFromPosition(summaryElement.StartTag.Span.Start));
-        var contentLines = GetSummaryContentLines(summaryElement, sourceText, documentationPrefix);
-        var expandedSummary = $"<summary>{lineBreak}{documentationPrefix}{string.Join(lineBreak + documentationPrefix, contentLines)}{lineBreak}{documentationPrefix}</summary>";
-        var commentText = sourceText.ToString(documentationCommentTrivia.FullSpan);
-        var relativeStart = summaryElement.Span.Start - documentationCommentTrivia.FullSpan.Start;
-        var relativeEnd = summaryElement.Span.End - documentationCommentTrivia.FullSpan.Start;
+        var contentLines = GetElementContentLines(element, sourceText, documentationPrefix);
 
-        return commentText.Substring(0, relativeStart) + expandedSummary + commentText.Substring(relativeEnd);
+        return sourceText.ToString(element.StartTag.Span) + contentLines[0] + sourceText.ToString(element.EndTag.Span);
+    }
+
+    /// <summary>
+    /// Builds a multi-line form of the XML documentation element
+    /// </summary>
+    /// <param name="element">XML element</param>
+    /// <param name="sourceText">Source text</param>
+    /// <returns>The normalized multi-line element text</returns>
+    private static string BuildExpandedElement(XmlElementSyntax element, SourceText sourceText)
+    {
+        var documentationPrefix = GetDocumentationPrefix(sourceText, sourceText.Lines.GetLineFromPosition(element.StartTag.Span.Start));
+        var lineBreak = GetLineBreak(sourceText, sourceText.Lines.GetLineFromPosition(element.StartTag.Span.Start));
+        var contentLines = GetElementContentLines(element, sourceText, documentationPrefix);
+
+        return $"{sourceText.ToString(element.StartTag.Span)}{lineBreak}{documentationPrefix}{string.Join(lineBreak + documentationPrefix, contentLines)}{lineBreak}{documentationPrefix}{sourceText.ToString(element.EndTag.Span)}";
+    }
+
+    /// <summary>
+    /// Determines whether the specified element can be collapsed to a single line
+    /// </summary>
+    /// <param name="element">XML element</param>
+    /// <param name="sourceText">Source text</param>
+    /// <returns><see langword="true"/> if the element can be collapsed</returns>
+    private static bool CanCollapseToSingleLine(XmlElementSyntax element, SourceText sourceText)
+    {
+        if (IsSummaryElement(element))
+        {
+            return false;
+        }
+
+        var documentationPrefix = GetDocumentationPrefix(sourceText, sourceText.Lines.GetLineFromPosition(element.StartTag.Span.Start));
+        var contentLines = GetElementContentLines(element, sourceText, documentationPrefix);
+
+        return contentLines.Count == 1;
     }
 
     /// <summary>
@@ -105,15 +129,15 @@ internal static class DocumentationCommentFormattingPhase
     }
 
     /// <summary>
-    /// Extracts normalized summary content lines while preserving inline XML content
+    /// Extracts normalized element content lines while preserving inline XML content
     /// </summary>
-    /// <param name="summaryElement">Summary element</param>
+    /// <param name="element">XML element</param>
     /// <param name="sourceText">Source text</param>
     /// <param name="documentationPrefix">Documentation prefix for continuation lines</param>
     /// <returns>The normalized content lines</returns>
-    private static List<string> GetSummaryContentLines(XmlElementSyntax summaryElement, SourceText sourceText, string documentationPrefix)
+    private static List<string> GetElementContentLines(XmlElementSyntax element, SourceText sourceText, string documentationPrefix)
     {
-        var contentSpan = TextSpan.FromBounds(summaryElement.StartTag.Span.End, summaryElement.EndTag.Span.Start);
+        var contentSpan = TextSpan.FromBounds(element.StartTag.Span.End, element.EndTag.Span.Start);
         var rawContent = sourceText.ToString(contentSpan);
         var rawLines = rawContent.Replace("\r\n", "\n")
                                  .Replace('\r', '\n')
@@ -150,6 +174,37 @@ internal static class DocumentationCommentFormattingPhase
     }
 
     /// <summary>
+    /// Determines whether the specified element is a summary element
+    /// </summary>
+    /// <param name="element">Element</param>
+    /// <returns><see langword="true"/> if the element is a summary element</returns>
+    private static bool IsSummaryElement(XmlElementSyntax element)
+    {
+        return string.Equals(element.StartTag.Name.LocalName.ValueText, "summary", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Determines whether the specified element requires line-alignment normalization
+    /// </summary>
+    /// <param name="element">Element</param>
+    /// <param name="sourceText">Source text</param>
+    /// <returns><see langword="true"/> if the element requires normalization</returns>
+    private static bool NeedsLineAlignmentNormalization(XmlElementSyntax element, SourceText sourceText)
+    {
+        if (TryGetFirstMeaningfulContentPosition(element, out var firstContentPosition) == false)
+        {
+            return false;
+        }
+
+        var startTagLine = sourceText.Lines.GetLineFromPosition(element.StartTag.Span.Start).LineNumber;
+        var firstContentLine = sourceText.Lines.GetLineFromPosition(firstContentPosition).LineNumber;
+        var endTagLine = sourceText.Lines.GetLineFromPosition(element.EndTag.Span.Start).LineNumber;
+
+        return startTagLine == firstContentLine
+               && firstContentLine != endTagLine;
+    }
+
+    /// <summary>
     /// Determines whether the specified summary element already spans at least three lines
     /// </summary>
     /// <param name="summaryElement">Summary element</param>
@@ -161,6 +216,118 @@ internal static class DocumentationCommentFormattingPhase
         var endTagLine = sourceText.Lines.GetLineFromPosition(summaryElement.EndTag.Span.Start).LineNumber;
 
         return endTagLine - startTagLine >= 2;
+    }
+
+    /// <summary>
+    /// Normalizes a documentation comment if any supported XML element requires it
+    /// </summary>
+    /// <param name="documentationCommentTrivia">Documentation comment trivia</param>
+    /// <param name="documentationComment">Structured documentation comment</param>
+    /// <param name="sourceText">Source text</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The normalized comment text, or <see langword="null"/> if no change is required</returns>
+    private static string NormalizeDocumentationComment(SyntaxTrivia documentationCommentTrivia, DocumentationCommentTriviaSyntax documentationComment, SourceText sourceText, CancellationToken cancellationToken)
+    {
+        var candidates = documentationComment.DescendantNodes()
+                                             .OfType<XmlElementSyntax>()
+                                             .Where(obj => RequiresNormalization(obj, sourceText))
+                                             .ToList();
+
+        if (candidates.Count == 0)
+        {
+            return null;
+        }
+
+        var candidateSet = new HashSet<XmlElementSyntax>(candidates);
+        var normalizedCommentText = sourceText.ToString(documentationCommentTrivia.FullSpan);
+        var topLevelCandidates = candidates.Where(obj => obj.Ancestors().OfType<XmlElementSyntax>().Any(candidateSet.Contains) == false)
+                                           .OrderByDescending(obj => obj.Span.Start)
+                                           .ToList();
+
+        foreach (var element in topLevelCandidates)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var replacementText = CanCollapseToSingleLine(element, sourceText)
+                                      ? BuildCollapsedElement(element, sourceText, GetDocumentationPrefix(sourceText, sourceText.Lines.GetLineFromPosition(element.StartTag.Span.Start)))
+                                      : BuildExpandedElement(element, sourceText);
+            var relativeStart = element.Span.Start - documentationCommentTrivia.FullSpan.Start;
+            var relativeEnd = element.Span.End - documentationCommentTrivia.FullSpan.Start;
+
+            normalizedCommentText = normalizedCommentText.Substring(0, relativeStart) + replacementText + normalizedCommentText.Substring(relativeEnd);
+        }
+
+        return normalizedCommentText;
+    }
+
+    /// <summary>
+    /// Determines whether the specified element requires normalization
+    /// </summary>
+    /// <param name="element">Element</param>
+    /// <param name="sourceText">Source text</param>
+    /// <returns><see langword="true"/> if the element requires normalization</returns>
+    private static bool RequiresNormalization(XmlElementSyntax element, SourceText sourceText)
+    {
+        return (IsSummaryElement(element) && SpansAtLeastThreeLines(element, sourceText) == false)
+               || NeedsLineAlignmentNormalization(element, sourceText);
+    }
+
+    /// <summary>
+    /// Attempts to get the position of the first meaningful content within the XML element
+    /// </summary>
+    /// <param name="element">Element</param>
+    /// <param name="position">Position of the first meaningful content</param>
+    /// <returns><see langword="true"/> if meaningful content was found</returns>
+    private static bool TryGetFirstMeaningfulContentPosition(XmlElementSyntax element, out int position)
+    {
+        position = 0;
+
+        foreach (var node in element.Content)
+        {
+            if (node is XmlTextSyntax textSyntax)
+            {
+                if (TryGetFirstMeaningfulContentPosition(textSyntax, out position))
+                {
+                    return true;
+                }
+
+                continue;
+            }
+
+            position = node.SpanStart;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to get the position of the first meaningful content within the XML text node
+    /// </summary>
+    /// <param name="textSyntax">XML text syntax</param>
+    /// <param name="position">Position of the first meaningful content</param>
+    /// <returns><see langword="true"/> if meaningful content was found</returns>
+    private static bool TryGetFirstMeaningfulContentPosition(XmlTextSyntax textSyntax, out int position)
+    {
+        position = 0;
+
+        foreach (var token in textSyntax.TextTokens)
+        {
+            var tokenText = token.Text;
+
+            for (var index = 0; index < tokenText.Length; index++)
+            {
+                if (char.IsWhiteSpace(tokenText[index]) == false)
+                {
+                    position = token.SpanStart + index;
+
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     #endregion // Methods

--- a/Reihitsu.Formatter/ReihitsuFormatter.cs
+++ b/Reihitsu.Formatter/ReihitsuFormatter.cs
@@ -81,9 +81,11 @@ public static class ReihitsuFormatter
     /// newly generated or modified node rather than the full document
     /// </summary>
     /// <param name="node">The syntax node to format</param>
-    /// <param name="indentLevel">The indentation level of the node within its containing document.
+    /// <param name="indentLevel">
+    /// The indentation level of the node within its containing document.
     /// Required for newly generated nodes that are not yet inserted into a tree,
-    /// where the indentation level cannot be inferred from position</param>
+    /// where the indentation level cannot be inferred from position
+    /// </param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>A new SyntaxNode with formatting applied</returns>
     public static SyntaxNode FormatNode(SyntaxNode node, int indentLevel = -1, CancellationToken cancellationToken = default)

--- a/Reihitsu.sln
+++ b/Reihitsu.sln
@@ -213,6 +213,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		documentation\rules\RH0447.md = documentation\rules\RH0447.md
 		documentation\rules\RH0448.md = documentation\rules\RH0448.md
 		documentation\rules\RH0449.md = documentation\rules\RH0449.md
+		documentation\rules\RH0450.md = documentation\rules\RH0450.md
 		documentation\rules\RH0501.md = documentation\rules\RH0501.md
 		documentation\rules\RH0502.md = documentation\rules\RH0502.md
 		documentation\rules\RH0601.md = documentation\rules\RH0601.md

--- a/documentation/rules/RH0450.md
+++ b/documentation/rules/RH0450.md
@@ -1,0 +1,47 @@
+# RH0450 - Content after opening XML tag must be on same line as closing tag
+
+| Property | Value |
+|----------|-------|
+| **ID** | RH0450 |
+| **Category** | Documentation |
+| **Severity** | Warning |
+| **Code Fix** | ✓ |
+
+## Description
+
+This rule ensures that XML documentation content starting on the same line as an opening tag also ends on that same line.
+
+## Why is this a problem?
+
+When content starts immediately after an opening tag but the closing tag is pushed to a later line, the element reads like a broken single-line comment. Keeping the content and closing tag aligned makes XML documentation easier to scan and keeps comment structure consistent.
+
+## How to fix it
+
+Either keep the entire element on one line, or move the content to its own documentation line after the opening tag. Use whichever layout matches the amount of content in the element.
+
+## Examples
+
+### Violation
+
+```cs
+internal class TestClass
+{
+    /// <param name="value">The value
+    /// </param>
+    void Method(string value)
+    {
+    }
+}
+```
+
+### Correction
+
+```cs
+internal class TestClass
+{
+    /// <param name="value">The value</param>
+    void Method(string value)
+    {
+    }
+}
+```


### PR DESCRIPTION
Introduces analyzer and code fix for RH0450, enforcing that XML documentation content starting on the same line as the opening tag must also end on that line, or be moved to its own line. Updates resources, documentation, and README. Enhances formatter to support normalization. Adds analyzer, code fix, and full-pipeline regression tests.