### PR TITLE
Add RH0451: Disallow text after closing XML doc tags

### DIFF
--- a/Reihitsu.Analyzer.CodeFixes/CodeFixResources.cs
+++ b/Reihitsu.Analyzer.CodeFixes/CodeFixResources.cs
@@ -734,6 +734,11 @@ internal static class CodeFixResources
     internal static string RH0450Title => GetString(nameof(RH0450Title));
 
     /// <summary>
+    /// Gets the localized string for RH0451Title
+    /// </summary>
+    internal static string RH0451Title => GetString(nameof(RH0451Title));
+
+    /// <summary>
     /// Gets the localized string for RH0401Title
     /// </summary>
     internal static string RH0401Title => GetString(nameof(RH0401Title));

--- a/Reihitsu.Analyzer.CodeFixes/CodeFixResources.resx
+++ b/Reihitsu.Analyzer.CodeFixes/CodeFixResources.resx
@@ -360,6 +360,9 @@
   <data name="RH0450Title" xml:space="preserve">
     <value>Normalize XML documentation element text layout</value>
   </data>
+  <data name="RH0451Title" xml:space="preserve">
+    <value>Remove trailing XML documentation content</value>
+  </data>
   <data name="RH0401Title" xml:space="preserve">
     <value>Replace documentation with &lt;inheritdoc/&gt;</value>
   </data>

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Documentation/DocumentationCommentCodeFixUtilities.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Documentation/DocumentationCommentCodeFixUtilities.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Reihitsu.Analyzer.Rules.Documentation;
+
+/// <summary>
+/// Shared helpers for documentation-comment line-break code fixes
+/// </summary>
+internal static class DocumentationCommentCodeFixUtilities
+{
+    #region Methods
+
+    /// <summary>
+    /// Moves the diagnostic content to the next documentation comment line
+    /// </summary>
+    /// <param name="document">Document</param>
+    /// <param name="diagnosticSpan">Diagnostic span</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The updated document</returns>
+    internal static async Task<Document> MoveContentToNextDocumentationLineAsync(Document document, TextSpan diagnosticSpan, CancellationToken cancellationToken)
+    {
+        var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        var affectedLine = sourceText.Lines.GetLineFromPosition(diagnosticSpan.Start);
+        var replacementStart = diagnosticSpan.Start;
+
+        while (replacementStart > affectedLine.Start
+               && IsHorizontalWhitespace(sourceText[replacementStart - 1]))
+        {
+            replacementStart--;
+        }
+
+        var replacementSpan = TextSpan.FromBounds(replacementStart, diagnosticSpan.Start);
+        var insertionText = GetLineBreak(sourceText, affectedLine) + GetDocumentationPrefix(sourceText, affectedLine);
+
+        return document.WithText(sourceText.Replace(replacementSpan, insertionText));
+    }
+
+    /// <summary>
+    /// Gets the documentation prefix for the specified line
+    /// </summary>
+    /// <param name="sourceText">Source text</param>
+    /// <param name="line">Line</param>
+    /// <returns>Documentation prefix</returns>
+    private static string GetDocumentationPrefix(SourceText sourceText, TextLine line)
+    {
+        var lineText = sourceText.ToString(line.Span);
+        var elementIndex = lineText.IndexOf('<');
+
+        return elementIndex >= 0 ? lineText.Substring(0, elementIndex) : string.Empty;
+    }
+
+    /// <summary>
+    /// Gets the line break sequence for the affected line
+    /// </summary>
+    /// <param name="sourceText">Source text</param>
+    /// <param name="line">Affected line</param>
+    /// <returns>Line break sequence</returns>
+    private static string GetLineBreak(SourceText sourceText, TextLine line)
+    {
+        return line.EndIncludingLineBreak > line.End
+                   ? sourceText.ToString(TextSpan.FromBounds(line.End, line.EndIncludingLineBreak))
+                   : Environment.NewLine;
+    }
+
+    /// <summary>
+    /// Determines whether the specified character is horizontal whitespace
+    /// </summary>
+    /// <param name="value">Character to inspect</param>
+    /// <returns><see langword="true"/> if the character is a space or tab</returns>
+    private static bool IsHorizontalWhitespace(char value)
+    {
+        return value is ' ' or '\t';
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Documentation/RH0447XmlDocumentationElementsMustBeOnSeparateLinesCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Documentation/RH0447XmlDocumentationElementsMustBeOnSeparateLinesCodeFixProvider.cs
@@ -26,59 +26,9 @@ public class RH0447XmlDocumentationElementsMustBeOnSeparateLinesCodeFixProvider 
     /// <param name="diagnosticSpan">Diagnostic span</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>The updated document</returns>
-    private static async Task<Document> ApplyCodeFixAsync(Document document, TextSpan diagnosticSpan, CancellationToken cancellationToken)
+    private static Task<Document> ApplyCodeFixAsync(Document document, TextSpan diagnosticSpan, CancellationToken cancellationToken)
     {
-        var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-        var affectedLine = sourceText.Lines.GetLineFromPosition(diagnosticSpan.Start);
-        var replacementStart = diagnosticSpan.Start;
-
-        while (replacementStart > affectedLine.Start
-               && IsHorizontalWhitespace(sourceText[replacementStart - 1]))
-        {
-            replacementStart--;
-        }
-
-        var replacementSpan = TextSpan.FromBounds(replacementStart, diagnosticSpan.Start);
-        var insertionText = GetLineBreak(sourceText, affectedLine) + GetDocumentationPrefix(sourceText, affectedLine);
-
-        return document.WithText(sourceText.Replace(replacementSpan, insertionText));
-    }
-
-    /// <summary>
-    /// Gets the line break sequence for the affected line
-    /// </summary>
-    /// <param name="sourceText">Source text</param>
-    /// <param name="line">Affected line</param>
-    /// <returns>Line break sequence</returns>
-    private static string GetLineBreak(SourceText sourceText, TextLine line)
-    {
-        return line.EndIncludingLineBreak > line.End
-                   ? sourceText.ToString(TextSpan.FromBounds(line.End, line.EndIncludingLineBreak))
-                   : Environment.NewLine;
-    }
-
-    /// <summary>
-    /// Gets the documentation prefix for the specified line
-    /// </summary>
-    /// <param name="sourceText">Source text</param>
-    /// <param name="line">Line</param>
-    /// <returns>Documentation prefix</returns>
-    private static string GetDocumentationPrefix(SourceText sourceText, TextLine line)
-    {
-        var lineText = sourceText.ToString(line.Span);
-        var elementIndex = lineText.IndexOf('<');
-
-        return elementIndex >= 0 ? lineText.Substring(0, elementIndex) : string.Empty;
-    }
-
-    /// <summary>
-    /// Determines whether the specified character is horizontal whitespace
-    /// </summary>
-    /// <param name="value">Character to inspect</param>
-    /// <returns><see langword="true"/> if the character is a space or tab</returns>
-    private static bool IsHorizontalWhitespace(char value)
-    {
-        return value == ' ' || value == '\t';
+        return DocumentationCommentCodeFixUtilities.MoveContentToNextDocumentationLineAsync(document, diagnosticSpan, cancellationToken);
     }
 
     #endregion // Methods

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Documentation/RH0451NoContentShouldAppearAfterClosingXmlTagsCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Documentation/RH0451NoContentShouldAppearAfterClosingXmlTagsCodeFixProvider.cs
@@ -1,0 +1,74 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Reihitsu.Analyzer.Rules.Documentation;
+
+/// <summary>
+/// Code fix provider for <see cref="RH0451NoContentShouldAppearAfterClosingXmlTagsAnalyzer"/>
+/// </summary>
+[Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(RH0451NoContentShouldAppearAfterClosingXmlTagsCodeFixProvider))]
+public class RH0451NoContentShouldAppearAfterClosingXmlTagsCodeFixProvider : CodeFixProvider
+{
+    #region Methods
+
+    /// <summary>
+    /// Applies the code fix
+    /// </summary>
+    /// <param name="document">Document</param>
+    /// <param name="diagnosticSpan">Diagnostic span</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The updated document</returns>
+    private static async Task<Document> ApplyCodeFixAsync(Document document, TextSpan diagnosticSpan, CancellationToken cancellationToken)
+    {
+        var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        var affectedLine = sourceText.Lines.GetLineFromPosition(diagnosticSpan.Start);
+        var replacementStart = diagnosticSpan.Start;
+
+        while (replacementStart > affectedLine.Start
+               && (sourceText[replacementStart - 1] == ' ' || sourceText[replacementStart - 1] == '\t'))
+        {
+            replacementStart--;
+        }
+
+        var replacementSpan = TextSpan.FromBounds(replacementStart, diagnosticSpan.End);
+
+        return document.WithText(sourceText.Replace(replacementSpan, string.Empty));
+    }
+
+    #endregion // Methods
+
+    #region CodeFixProvider
+
+    /// <inheritdoc/>
+    public sealed override ImmutableArray<string> FixableDiagnosticIds => [RH0451NoContentShouldAppearAfterClosingXmlTagsAnalyzer.DiagnosticId];
+
+    /// <inheritdoc/>
+    public sealed override FixAllProvider GetFixAllProvider()
+    {
+        return WellKnownFixAllProviders.BatchFixer;
+    }
+
+    /// <inheritdoc/>
+    public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            context.RegisterCodeFix(CodeAction.Create(CodeFixResources.RH0451Title,
+                                                      token => ApplyCodeFixAsync(context.Document, diagnostic.Location.SourceSpan, token),
+                                                      nameof(RH0451NoContentShouldAppearAfterClosingXmlTagsCodeFixProvider)),
+                                    diagnostic);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    #endregion // CodeFixProvider
+}

--- a/Reihitsu.Analyzer.Package/README.MD
+++ b/Reihitsu.Analyzer.Package/README.MD
@@ -154,6 +154,7 @@ dotnet add package Reihitsu.Analyzer
 | [RH0448](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0448.md)| Summary element must span at least three lines.| ✔| ✔|
 | [RH0449](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0449.md)| XML documentation element text must not end with a period.| ✔| ✔|
 | [RH0450](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0450.md)| Content after opening XML tag must be on same line as closing tag.| ✔| ✔|
+| [RH0451](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0451.md)| No content should appear after closing XML tags.| ✔| ✔|
 || **Ordering**|||
 | [RH0601](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0601.md)| Constants must appear before fields.| ✔| ✔|
 | [RH0602](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0602.md)| Static elements must appear before instance elements.| ✔| ✔|

--- a/Reihitsu.Analyzer.Test/Documentation/RH0451NoContentShouldAppearAfterClosingXmlTagsAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0451NoContentShouldAppearAfterClosingXmlTagsAnalyzerTests.cs
@@ -1,0 +1,134 @@
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Analyzer.Rules.Documentation;
+using Reihitsu.Analyzer.Test.Base;
+
+namespace Reihitsu.Analyzer.Test.Documentation;
+
+/// <summary>
+/// Test methods for <see cref="RH0451NoContentShouldAppearAfterClosingXmlTagsAnalyzer"/> and <see cref="RH0451NoContentShouldAppearAfterClosingXmlTagsCodeFixProvider"/>
+/// </summary>
+[TestClass]
+public class RH0451NoContentShouldAppearAfterClosingXmlTagsAnalyzerTests : AnalyzerTestsBase<RH0451NoContentShouldAppearAfterClosingXmlTagsAnalyzer, RH0451NoContentShouldAppearAfterClosingXmlTagsCodeFixProvider>
+{
+    /// <summary>
+    /// Verifies that text on the next documentation line does not produce diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenTextStartsOnNextLine()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    /// <summary>Summary.</summary>
+                                    /// Additional text
+                                    void Method()
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that another XML element after a closing tag is not reported by this analyzer
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenAnotherElementFollowsClosingTag()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    /// <summary>Summary.</summary><remarks>More details.</remarks>
+                                    void Method()
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that inline nested XML content remains allowed inside a larger element
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForNestedInlineXmlContent()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    /// <summary>Uses <see cref="string"/> values.</summary>
+                                    void Method()
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that text after a closing tag is detected and removed
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyTextAfterClosingTagIsDetectedAndRemoved()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    /// <summary>Summary.</summary> {|#0:Additional text|}
+                                    void Method()
+                                    {
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     /// <summary>Summary.</summary>
+                                     void Method()
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH0451NoContentShouldAppearAfterClosingXmlTagsAnalyzer.DiagnosticId, AnalyzerResources.RH0451MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that text after a self-closing tag is detected and removed
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyTextAfterSelfClosingTagIsDetectedAndRemoved()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    /// <inheritdoc/> {|#0:Additional text|}
+                                    void Method()
+                                    {
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     /// <inheritdoc/>
+                                     void Method()
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH0451NoContentShouldAppearAfterClosingXmlTagsAnalyzer.DiagnosticId, AnalyzerResources.RH0451MessageFormat));
+    }
+}

--- a/Reihitsu.Analyzer/AnalyzerResources.cs
+++ b/Reihitsu.Analyzer/AnalyzerResources.cs
@@ -2005,6 +2005,16 @@ internal static class AnalyzerResources
     internal static string RH0450Title => GetString(nameof(RH0450Title));
 
     /// <summary>
+    /// Gets the localized string for RH0451MessageFormat
+    /// </summary>
+    internal static string RH0451MessageFormat => GetString(nameof(RH0451MessageFormat));
+
+    /// <summary>
+    /// Gets the localized string for RH0451Title
+    /// </summary>
+    internal static string RH0451Title => GetString(nameof(RH0451Title));
+
+    /// <summary>
     /// Gets the localized string for RH0401MessageFormat
     /// </summary>
     internal static string RH0401MessageFormat => GetString(nameof(RH0401MessageFormat));

--- a/Reihitsu.Analyzer/AnalyzerResources.resx
+++ b/Reihitsu.Analyzer/AnalyzerResources.resx
@@ -687,6 +687,12 @@
   <data name="RH0450Title" xml:space="preserve">
     <value>Content after opening XML tag must be on same line as closing tag</value>
   </data>
+  <data name="RH0451MessageFormat" xml:space="preserve">
+    <value>No content should appear after closing XML tags.</value>
+  </data>
+  <data name="RH0451Title" xml:space="preserve">
+    <value>No content should appear after closing XML tags</value>
+  </data>
   <data name="RH0334MessageFormat" xml:space="preserve">
     <value>Keywords must be spaced correctly.</value>
   </data>

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0451NoContentShouldAppearAfterClosingXmlTagsAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0451NoContentShouldAppearAfterClosingXmlTagsAnalyzer.cs
@@ -1,0 +1,151 @@
+using System.Threading;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+
+using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Enumerations;
+
+namespace Reihitsu.Analyzer.Rules.Documentation;
+
+/// <summary>
+/// RH0451: No content should appear after closing XML tags
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class RH0451NoContentShouldAppearAfterClosingXmlTagsAnalyzer : DiagnosticAnalyzerBase<RH0451NoContentShouldAppearAfterClosingXmlTagsAnalyzer>
+{
+    #region Constants
+
+    /// <summary>
+    /// Diagnostic ID
+    /// </summary>
+    public const string DiagnosticId = "RH0451";
+
+    #endregion // Constants
+
+    #region Constructor
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public RH0451NoContentShouldAppearAfterClosingXmlTagsAnalyzer()
+        : base(DiagnosticId, DiagnosticCategory.Documentation, nameof(AnalyzerResources.RH0451Title), nameof(AnalyzerResources.RH0451MessageFormat))
+    {
+    }
+
+    #endregion // Constructor
+
+    #region Methods
+
+    /// <summary>
+    /// Determines whether the specified node is a direct XML documentation element
+    /// </summary>
+    /// <param name="node">Node</param>
+    /// <returns><see langword="true"/> if the node is an element</returns>
+    private static bool IsDirectElement(XmlNodeSyntax node)
+    {
+        return node is XmlElementSyntax or XmlEmptyElementSyntax;
+    }
+
+    /// <summary>
+    /// Determines whether two positions occupy the same source line
+    /// </summary>
+    /// <param name="previousNode">Previous node</param>
+    /// <param name="currentPosition">Current position</param>
+    /// <param name="sourceText">Source text</param>
+    /// <returns><see langword="true"/> if both positions share a line</returns>
+    private static bool SharesLine(XmlNodeSyntax previousNode, int currentPosition, SourceText sourceText)
+    {
+        var previousEnd = previousNode.Span.End == previousNode.Span.Start ? previousNode.Span.End : previousNode.Span.End - 1;
+        var previousEndLine = sourceText.Lines.GetLineFromPosition(previousEnd).LineNumber;
+        var currentLine = sourceText.Lines.GetLineFromPosition(currentPosition).LineNumber;
+
+        return previousEndLine == currentLine;
+    }
+
+    /// <summary>
+    /// Attempts to get the first meaningful text span inside the XML text node
+    /// </summary>
+    /// <param name="textSyntax">XML text syntax</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <param name="span">Span of the first meaningful text</param>
+    /// <returns><see langword="true"/> if meaningful text was found</returns>
+    private static bool TryGetFirstMeaningfulTextSpan(XmlTextSyntax textSyntax, CancellationToken cancellationToken, out TextSpan span)
+    {
+        span = default;
+
+        foreach (var token in textSyntax.TextTokens)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var tokenText = token.Text;
+
+            for (var index = 0; index < tokenText.Length; index++)
+            {
+                if (char.IsWhiteSpace(tokenText[index]) == false)
+                {
+                    span = TextSpan.FromBounds(token.SpanStart + index, token.Span.End);
+
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Analyzes a documentation comment
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnDocumentationCommentTrivia(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not DocumentationCommentTriviaSyntax documentationComment)
+        {
+            return;
+        }
+
+        var sourceText = context.Node.SyntaxTree.GetText(context.CancellationToken);
+        XmlNodeSyntax previousElement = null;
+
+        foreach (var node in documentationComment.Content)
+        {
+            context.CancellationToken.ThrowIfCancellationRequested();
+
+            if (node is XmlTextSyntax textSyntax)
+            {
+                if (TryGetFirstMeaningfulTextSpan(textSyntax, context.CancellationToken, out var span))
+                {
+                    if (previousElement != null
+                        && SharesLine(previousElement, span.Start, sourceText))
+                    {
+                        context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Node.SyntaxTree, span)));
+                    }
+
+                    previousElement = null;
+                }
+
+                continue;
+            }
+
+            previousElement = IsDirectElement(node) ? node : null;
+        }
+    }
+
+    #endregion // Methods
+
+    #region DiagnosticAnalyzer
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        base.Initialize(context);
+
+        context.RegisterSyntaxNodeAction(OnDocumentationCommentTrivia, SyntaxKind.SingleLineDocumentationCommentTrivia);
+    }
+
+    #endregion // DiagnosticAnalyzer
+}

--- a/Reihitsu.sln
+++ b/Reihitsu.sln
@@ -214,6 +214,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		documentation\rules\RH0448.md = documentation\rules\RH0448.md
 		documentation\rules\RH0449.md = documentation\rules\RH0449.md
 		documentation\rules\RH0450.md = documentation\rules\RH0450.md
+		documentation\rules\RH0451.md = documentation\rules\RH0451.md
 		documentation\rules\RH0501.md = documentation\rules\RH0501.md
 		documentation\rules\RH0502.md = documentation\rules\RH0502.md
 		documentation\rules\RH0601.md = documentation\rules\RH0601.md

--- a/documentation/rules/RH0451.md
+++ b/documentation/rules/RH0451.md
@@ -1,0 +1,46 @@
+# RH0451 - No content should appear after closing XML tags
+
+| Property | Value |
+|----------|-------|
+| **ID** | RH0451 |
+| **Category** | Documentation |
+| **Severity** | Warning |
+| **Code Fix** | ✓ |
+
+## Description
+
+This rule ensures that no plain text appears after a completed XML documentation tag on the same documentation comment line.
+
+## Why is this a problem?
+
+Trailing text after a finished XML tag is not part of valid XML documentation. Keeping only XML content after the tag avoids malformed documentation and makes the comment structure unambiguous.
+
+## How to fix it
+
+Remove the trailing text. If that content was meant to be documentation, place it inside a valid XML element instead of leaving it after a closed tag.
+
+## Examples
+
+### Violation
+
+```cs
+internal class TestClass
+{
+    /// <summary>Summary.</summary> Additional text
+    void Method()
+    {
+    }
+}
+```
+
+### Correction
+
+```cs
+internal class TestClass
+{
+    /// <summary>Summary.</summary>
+    void Method()
+    {
+    }
+}
+```


### PR DESCRIPTION
Introduce analyzer RH0451 to detect and remove text after closing XML documentation tags on the same line. Add code fix provider and comprehensive tests. Register resources, update .resx files, and add rule documentation. Refactor RH0447 code fix to use shared DocumentationCommentCodeFixUtilities. Update solution and README to include RH0451.