### PR TITLE
Add RH0385: detect and normalize mixed line endings

### DIFF
--- a/Reihitsu.Analyzer.Package/README.MD
+++ b/Reihitsu.Analyzer.Package/README.MD
@@ -103,6 +103,7 @@ dotnet add package Reihitsu.Analyzer
 | [RH0332](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0332.md)| Arguments should either all be on one line or each on its own line.| ✔| ✔|
 | [RH0333](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0333.md)| Multi-line arguments should be aligned.| ✔| ✔|
 | [RH0384](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0384.md)| Generic type constraints should be on their own line with proper indentation.| ✔| ✔|
+| [RH0385](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0385.md)| Code must not contain mixed line endings.| ✔| ❌|
 || **Documentation**|||
 | [RH0401](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0401.md)| The \<inheritdoc/> Tag should be used if possible.| ✔| ✔|
 | [RH0402](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0402.md)| Elements must be documented.| ✔| ❌|

--- a/Reihitsu.Analyzer.Test/Formatting/RH0385CodeMustNotContainMixedLineEndingsAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH0385CodeMustNotContainMixedLineEndingsAnalyzerTests.cs
@@ -1,0 +1,112 @@
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Analyzer.Rules.Formatting;
+using Reihitsu.Analyzer.Test.Base;
+
+namespace Reihitsu.Analyzer.Test.Formatting;
+
+/// <summary>
+/// Test methods for <see cref="RH0385CodeMustNotContainMixedLineEndingsAnalyzer"/>
+/// </summary>
+[TestClass]
+public class RH0385CodeMustNotContainMixedLineEndingsAnalyzerTests : AnalyzerTestsBase<RH0385CodeMustNotContainMixedLineEndingsAnalyzer>
+{
+    /// <summary>
+    /// Verifies that LF-only files do not produce diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenFileUsesLfOnly()
+    {
+        const string testData = "internal class TestClass\n"
+                                + "{\n"
+                                + "    void Method()\n"
+                                + "    {\n"
+                                + "    }\n"
+                                + "}";
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that CRLF-only files do not produce diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenFileUsesCrLfOnly()
+    {
+        const string testData = "internal class TestClass\r\n"
+                                + "{\r\n"
+                                + "    void Method()\r\n"
+                                + "    {\r\n"
+                                + "    }\r\n"
+                                + "}";
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that CRLF line endings are detected when LF is predominant
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCrLfLineEndingsAreDetectedWhenLfIsPredominant()
+    {
+        const string testData = "{|#0:internal class TestClass\r\n|}"
+                                + "{\n"
+                                + "{|#1:    void Method()\r\n|}"
+                                + "    {\n"
+                                + "    }\n"
+                                + "}";
+
+        await Verify(testData, Diagnostics(RH0385CodeMustNotContainMixedLineEndingsAnalyzer.DiagnosticId, AnalyzerResources.RH0385MessageFormat, 2));
+    }
+
+    /// <summary>
+    /// Verifies that LF line endings are detected when CRLF is predominant
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyLfLineEndingsAreDetectedWhenCrLfIsPredominant()
+    {
+        const string testData = "internal class TestClass\r\n"
+                                + "{|#0:{\n|}"
+                                + "    void Method()\r\n"
+                                + "    {\r\n"
+                                + "    }\r\n"
+                                + "}";
+
+        await Verify(testData, Diagnostics(RH0385CodeMustNotContainMixedLineEndingsAnalyzer.DiagnosticId, AnalyzerResources.RH0385MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that ties use the first encountered line ending as the predominant style
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFirstEncounteredLineEndingWinsWhenCountsAreTied()
+    {
+        const string testData = "internal class TestClass\r\n"
+                                + "{|#0:{\n|}"
+                                + "}";
+
+        await Verify(testData, Diagnostics(RH0385CodeMustNotContainMixedLineEndingsAnalyzer.DiagnosticId, AnalyzerResources.RH0385MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that line endings embedded in verbatim strings do not produce diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyLineEndingsInsideVerbatimStringsDoNotProduceDiagnostics()
+    {
+        const string testData = "internal class TestClass\r\n"
+                                + "{\r\n"
+                                + "    string Value = @\"line1\nline2\";\r\n"
+                                + "}";
+
+        await Verify(testData);
+    }
+}

--- a/Reihitsu.Analyzer/AnalyzerResources.cs
+++ b/Reihitsu.Analyzer/AnalyzerResources.cs
@@ -935,6 +935,16 @@ internal static class AnalyzerResources
     internal static string RH0384Title => GetString(nameof(RH0384Title));
 
     /// <summary>
+    /// Gets the localized string for RH0385MessageFormat
+    /// </summary>
+    internal static string RH0385MessageFormat => GetString(nameof(RH0385MessageFormat));
+
+    /// <summary>
+    /// Gets the localized string for RH0385Title
+    /// </summary>
+    internal static string RH0385Title => GetString(nameof(RH0385Title));
+
+    /// <summary>
     /// Gets the localized string for RH0334MessageFormat
     /// </summary>
     internal static string RH0334MessageFormat => GetString(nameof(RH0334MessageFormat));

--- a/Reihitsu.Analyzer/AnalyzerResources.resx
+++ b/Reihitsu.Analyzer/AnalyzerResources.resx
@@ -963,6 +963,12 @@
   <data name="RH0384Title" xml:space="preserve">
     <value>Generic type constraints should be on their own line with proper indentation</value>
   </data>
+  <data name="RH0385MessageFormat" xml:space="preserve">
+    <value>Code must not contain mixed line endings.</value>
+  </data>
+  <data name="RH0385Title" xml:space="preserve">
+    <value>Code must not contain mixed line endings</value>
+  </data>
   <data name="RH0601Title" xml:space="preserve">
     <value>Constants must appear before fields</value>
   </data>

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0385CodeMustNotContainMixedLineEndingsAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0385CodeMustNotContainMixedLineEndingsAnalyzer.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+
+using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Enumerations;
+
+namespace Reihitsu.Analyzer.Rules.Formatting;
+
+/// <summary>
+/// RH0385: Code must not contain mixed line endings
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class RH0385CodeMustNotContainMixedLineEndingsAnalyzer : DiagnosticAnalyzerBase<RH0385CodeMustNotContainMixedLineEndingsAnalyzer>
+{
+    #region Constants
+
+    /// <summary>
+    /// Diagnostic ID
+    /// </summary>
+    public const string DiagnosticId = "RH0385";
+
+    #endregion // Constants
+
+    #region Constructor
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public RH0385CodeMustNotContainMixedLineEndingsAnalyzer()
+        : base(DiagnosticId, DiagnosticCategory.Formatting, nameof(AnalyzerResources.RH0385Title), nameof(AnalyzerResources.RH0385MessageFormat))
+    {
+    }
+
+    #endregion // Constructor
+
+    #region Methods
+
+    /// <summary>
+    /// Gets the predominant line ending used by the file
+    /// </summary>
+    /// <param name="endOfLineTrivia">End-of-line trivia in source order</param>
+    /// <param name="counts">Line-ending counts</param>
+    /// <returns>The predominant line ending</returns>
+    private static string GetPredominantLineEnding(IReadOnlyList<SyntaxTrivia> endOfLineTrivia, IReadOnlyDictionary<string, int> counts)
+    {
+        var predominantCount = 0;
+
+        foreach (var currentCount in counts.Values)
+        {
+            if (currentCount > predominantCount)
+            {
+                predominantCount = currentCount;
+            }
+        }
+
+        foreach (var trivia in endOfLineTrivia)
+        {
+            var lineEnding = trivia.ToString();
+
+            if (counts[lineEnding] == predominantCount)
+            {
+                return lineEnding;
+            }
+        }
+
+        return endOfLineTrivia[0].ToString();
+    }
+
+    /// <summary>
+    /// Analyzes the syntax tree for mixed line endings
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnSyntaxTree(SyntaxTreeAnalysisContext context)
+    {
+        var root = context.Tree.GetRoot(context.CancellationToken);
+        var sourceText = context.Tree.GetText(context.CancellationToken);
+        var endOfLineTrivia = new List<SyntaxTrivia>();
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        foreach (var trivia in root.DescendantTrivia(descendIntoTrivia: true))
+        {
+            if (trivia.IsKind(SyntaxKind.EndOfLineTrivia) == false)
+            {
+                continue;
+            }
+
+            var lineEnding = trivia.ToString();
+
+            endOfLineTrivia.Add(trivia);
+            counts[lineEnding] = counts.TryGetValue(lineEnding, out var count)
+                                     ? count + 1
+                                     : 1;
+        }
+
+        if (counts.Count <= 1)
+        {
+            return;
+        }
+
+        var predominantLineEnding = GetPredominantLineEnding(endOfLineTrivia, counts);
+
+        foreach (var trivia in endOfLineTrivia)
+        {
+            if (trivia.ToString() != predominantLineEnding)
+            {
+                var line = sourceText.Lines.GetLineFromPosition(trivia.SpanStart);
+
+                context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, TextSpan.FromBounds(line.Start, line.EndIncludingLineBreak))));
+            }
+        }
+    }
+
+    #endregion // Methods
+
+    #region DiagnosticAnalyzer
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        base.Initialize(context);
+
+        context.RegisterSyntaxTreeAction(OnSyntaxTree);
+    }
+
+    #endregion // DiagnosticAnalyzer
+}

--- a/Reihitsu.Formatter.Test/Unit/LineBreaks/LineBreakRewriterTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/LineBreaks/LineBreakRewriterTests.cs
@@ -593,14 +593,42 @@ public class LineBreakRewriterTests
     }
 
     /// <summary>
+    /// Verifies that inserted separator line breaks use the configured end-of-line sequence
+    /// </summary>
+    [TestMethod]
+    public void SplitsMixedLineArgumentsUsingConfiguredLineFeed()
+    {
+        // Arrange
+        const string input = "class Foo\n{\n    void Bar()\n    {\n        Call(\"a\", \"b\",\n             \"c\");\n    }\n\n    void Call(string a, string b, string c) { }\n}\n";
+
+        // Act
+        var result = ExecuteLineBreakPhase(input, "\n");
+
+        // Assert
+        Assert.Contains("Call(\"a\",\n", result, "Inserted separator line breaks should use LF from the formatting context.");
+        Assert.DoesNotContain("\r\n", result, "Inserted separator line breaks should not fall back to CRLF.");
+    }
+
+    /// <summary>
     /// Executes the <see cref="LineBreakPhase"/> on the given C# source text
     /// </summary>
     /// <param name="input">The C# source text to format</param>
     /// <returns>The formatted source text</returns>
     private string ExecuteLineBreakPhase(string input)
     {
+        return ExecuteLineBreakPhase(input, Environment.NewLine);
+    }
+
+    /// <summary>
+    /// Executes the <see cref="LineBreakPhase"/> on the given C# source text using an explicit end-of-line sequence
+    /// </summary>
+    /// <param name="input">The C# source text to format</param>
+    /// <param name="endOfLine">The end-of-line sequence for the formatting context</param>
+    /// <returns>The formatted source text</returns>
+    private string ExecuteLineBreakPhase(string input, string endOfLine)
+    {
         var tree = CSharpSyntaxTree.ParseText(input, cancellationToken: TestContext.CancellationTokenSource.Token);
-        var context = new FormattingContext(Environment.NewLine);
+        var context = new FormattingContext(endOfLine);
         var result = LineBreakPhase.Execute(tree.GetRoot(TestContext.CancellationTokenSource.Token), context, TestContext.CancellationTokenSource.Token);
 
         return result.ToFullString();

--- a/Reihitsu.Formatter.Test/Unit/ReihitsuFormatterHelpersTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/ReihitsuFormatterHelpersTests.cs
@@ -61,6 +61,44 @@ public class ReihitsuFormatterHelpersTests
     }
 
     /// <summary>
+    /// Verifies that <see cref="ReihitsuFormatterHelpers.DetectEndOfLine"/> returns the predominant line ending when the source mixes styles
+    /// </summary>
+    [TestMethod]
+    public void DetectEndOfLineReturnsPredominantLineFeedWhenSourceHasMixedLineEndings()
+    {
+        // Arrange
+        const string input = "namespace Test;\nclass Foo { }\r\nclass Bar { }\n";
+
+        var tree = CSharpSyntaxTree.ParseText(input, cancellationToken: TestContext.CancellationTokenSource.Token);
+        var root = tree.GetRoot(TestContext.CancellationTokenSource.Token);
+
+        // Act
+        var result = ReihitsuFormatterHelpers.DetectEndOfLine(root);
+
+        // Assert
+        Assert.AreEqual("\n", result);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ReihitsuFormatterHelpers.DetectEndOfLine"/> returns the predominant CRLF line ending when the source mixes styles
+    /// </summary>
+    [TestMethod]
+    public void DetectEndOfLineReturnsPredominantCarriageReturnLineFeedWhenSourceHasMixedLineEndings()
+    {
+        // Arrange
+        const string input = "namespace Test;\r\nclass Foo { }\nclass Bar { }\r\n";
+
+        var tree = CSharpSyntaxTree.ParseText(input, cancellationToken: TestContext.CancellationTokenSource.Token);
+        var root = tree.GetRoot(TestContext.CancellationTokenSource.Token);
+
+        // Act
+        var result = ReihitsuFormatterHelpers.DetectEndOfLine(root);
+
+        // Assert
+        Assert.AreEqual("\r\n", result);
+    }
+
+    /// <summary>
     /// Verifies that <see cref="ReihitsuFormatterHelpers.DetectEndOfLine"/> falls back to <see cref="System.Environment.NewLine"/> when no end-of-line trivia is found
     /// </summary>
     [TestMethod]

--- a/Reihitsu.Formatter.Test/Unit/ReihitsuFormatterTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/ReihitsuFormatterTests.cs
@@ -417,6 +417,39 @@ public class ReihitsuFormatterTests : FormatterTestsBase
     }
 
     /// <summary>
+    /// Verifies that <see cref="ReihitsuFormatter.FormatSyntaxTree"/> normalizes mixed line endings to the predominant style
+    /// </summary>
+    [TestMethod]
+    public void FormatSyntaxTreeNormalizesMixedLineEndingsToPredominantStyle()
+    {
+        // Arrange — the source mixes CRLF and LF, but LF is predominant
+        const string input = "namespace Test;\n\npublic class Foo\r\n{\n    public int Bar()\r\n    {\n        var x = 1;\r\n        return x;\n    }\n}\r\n";
+        var expected = Lf("""
+                          namespace Test;
+
+                          public class Foo
+                          {
+                              public int Bar()
+                              {
+                                  var x = 1;
+
+                                  return x;
+                              }
+                          }
+                          """);
+
+        var tree = CSharpSyntaxTree.ParseText(input, cancellationToken: TestContext.CancellationTokenSource.Token);
+
+        // Act
+        var result = ReihitsuFormatter.FormatSyntaxTree(tree, TestContext.CancellationTokenSource.Token);
+        var actual = result.GetRoot(TestContext.CancellationTokenSource.Token).ToFullString();
+
+        // Assert
+        Assert.AreEqual(expected, actual, "Output should normalize all line endings to the predominant style.");
+        Assert.DoesNotContain("\r\n", actual, "Output should not contain non-predominant CRLF line endings.");
+    }
+
+    /// <summary>
     /// Verifies that <see cref="ReihitsuFormatter.FormatSyntaxTree"/> throws <see cref="OperationCanceledException"/> when cancellation is requested
     /// </summary>
     [TestMethod]

--- a/Reihitsu.Formatter/Pipeline/FormattingPipeline.cs
+++ b/Reihitsu.Formatter/Pipeline/FormattingPipeline.cs
@@ -71,6 +71,11 @@ internal static class FormattingPipeline
         // Cleanup (trailing whitespace, consecutive blank lines, EOF)
         current = Cleanup.CleanupPhase.Execute(current, cancellationToken);
 
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Line ending normalization (rewrite all EOL trivia to the chosen style)
+        current = LineEndings.LineEndingNormalizationPhase.Execute(current, context, cancellationToken);
+
         return current;
     }
 

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/LineBreakRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/LineBreakRewriter.cs
@@ -191,60 +191,64 @@ internal sealed class LineBreakRewriter : CSharpSyntaxRewriter
     /// line breaks are inserted after each separator that lacks one
     /// </summary>
     /// <param name="node">The argument list node</param>
+    /// <param name="endOfLine">The end-of-line sequence to insert when splitting arguments</param>
     /// <returns>The argument list with arguments on separate lines</returns>
-    private static ArgumentListSyntax EnsureArgumentsOnSeparateLines(ArgumentListSyntax node)
+    private static ArgumentListSyntax EnsureArgumentsOnSeparateLines(ArgumentListSyntax node, string endOfLine)
     {
         if (node.Arguments.Count <= 1)
         {
             return node;
         }
 
-        return EnsureSeparatorsHaveEndOfLine(node, node.Arguments);
+        return EnsureSeparatorsHaveEndOfLine(node, node.Arguments, endOfLine);
     }
 
     /// <summary>
     /// Ensures that all arguments in a multi-line bracketed argument list start on their own line
     /// </summary>
     /// <param name="node">The bracketed argument list node</param>
+    /// <param name="endOfLine">The end-of-line sequence to insert when splitting arguments</param>
     /// <returns>The argument list with arguments on separate lines</returns>
-    private static BracketedArgumentListSyntax EnsureBracketedArgumentsOnSeparateLines(BracketedArgumentListSyntax node)
+    private static BracketedArgumentListSyntax EnsureBracketedArgumentsOnSeparateLines(BracketedArgumentListSyntax node, string endOfLine)
     {
         if (node.Arguments.Count <= 1)
         {
             return node;
         }
 
-        return EnsureSeparatorsHaveEndOfLine(node, node.Arguments);
+        return EnsureSeparatorsHaveEndOfLine(node, node.Arguments, endOfLine);
     }
 
     /// <summary>
     /// Ensures that all arguments in a multi-line attribute argument list start on their own line
     /// </summary>
     /// <param name="node">The attribute argument list node</param>
+    /// <param name="endOfLine">The end-of-line sequence to insert when splitting arguments</param>
     /// <returns>The argument list with arguments on separate lines</returns>
-    private static AttributeArgumentListSyntax EnsureAttributeArgumentsOnSeparateLines(AttributeArgumentListSyntax node)
+    private static AttributeArgumentListSyntax EnsureAttributeArgumentsOnSeparateLines(AttributeArgumentListSyntax node, string endOfLine)
     {
         if (node.Arguments.Count <= 1)
         {
             return node;
         }
 
-        return EnsureSeparatorsHaveEndOfLine(node, node.Arguments);
+        return EnsureSeparatorsHaveEndOfLine(node, node.Arguments, endOfLine);
     }
 
     /// <summary>
     /// Ensures that all parameters in a multi-line parameter list start on their own line
     /// </summary>
     /// <param name="node">The parameter list node</param>
+    /// <param name="endOfLine">The end-of-line sequence to insert when splitting parameters</param>
     /// <returns>The parameter list with parameters on separate lines</returns>
-    private static ParameterListSyntax EnsureParametersOnSeparateLines(ParameterListSyntax node)
+    private static ParameterListSyntax EnsureParametersOnSeparateLines(ParameterListSyntax node, string endOfLine)
     {
         if (node.Parameters.Count <= 1)
         {
             return node;
         }
 
-        return EnsureSeparatorsHaveEndOfLine(node, node.Parameters);
+        return EnsureSeparatorsHaveEndOfLine(node, node.Parameters, endOfLine);
     }
 
     /// <summary>
@@ -256,8 +260,9 @@ internal sealed class LineBreakRewriter : CSharpSyntaxRewriter
     /// <typeparam name="TElement">The type of the elements in the separated list</typeparam>
     /// <param name="node">The containing syntax node</param>
     /// <param name="list">The separated syntax list to process</param>
+    /// <param name="endOfLine">The end-of-line sequence to add after separators that need splitting</param>
     /// <returns>The node with updated separators</returns>
-    private static TNode EnsureSeparatorsHaveEndOfLine<TNode, TElement>(TNode node, SeparatedSyntaxList<TElement> list)
+    private static TNode EnsureSeparatorsHaveEndOfLine<TNode, TElement>(TNode node, SeparatedSyntaxList<TElement> list, string endOfLine)
         where TNode : SyntaxNode
         where TElement : SyntaxNode
     {
@@ -282,7 +287,7 @@ internal sealed class LineBreakRewriter : CSharpSyntaxRewriter
                                        .Where(trivia => trivia.IsKind(SyntaxKind.WhitespaceTrivia) == false)
                                        .ToList();
 
-            newTrailing.Add(SyntaxFactory.EndOfLine(Environment.NewLine));
+            newTrailing.Add(SyntaxFactory.EndOfLine(endOfLine));
 
             tokensToReplace.Add(separator);
             replacementMap[separator] = separator.WithTrailingTrivia(SyntaxFactory.TriviaList(newTrailing));
@@ -1817,7 +1822,7 @@ internal sealed class LineBreakRewriter : CSharpSyntaxRewriter
 
         node = CollapseFirstArgumentToSameLine(node);
 
-        return EnsureArgumentsOnSeparateLines(node);
+        return EnsureArgumentsOnSeparateLines(node, _context.EndOfLine);
     }
 
     /// <inheritdoc/>
@@ -1834,7 +1839,7 @@ internal sealed class LineBreakRewriter : CSharpSyntaxRewriter
 
         node = CollapseFirstBracketedArgumentToSameLine(node);
 
-        return EnsureBracketedArgumentsOnSeparateLines(node);
+        return EnsureBracketedArgumentsOnSeparateLines(node, _context.EndOfLine);
     }
 
     /// <inheritdoc/>
@@ -1851,7 +1856,7 @@ internal sealed class LineBreakRewriter : CSharpSyntaxRewriter
 
         node = CollapseFirstAttributeArgumentToSameLine(node);
 
-        return EnsureAttributeArgumentsOnSeparateLines(node);
+        return EnsureAttributeArgumentsOnSeparateLines(node, _context.EndOfLine);
     }
 
     /// <inheritdoc/>
@@ -1868,7 +1873,7 @@ internal sealed class LineBreakRewriter : CSharpSyntaxRewriter
 
         node = CollapseFirstParameterToSameLine(node);
 
-        return EnsureParametersOnSeparateLines(node);
+        return EnsureParametersOnSeparateLines(node, _context.EndOfLine);
     }
 
     /// <inheritdoc/>

--- a/Reihitsu.Formatter/Pipeline/LineEndings/LineEndingNormalizationPhase.cs
+++ b/Reihitsu.Formatter/Pipeline/LineEndings/LineEndingNormalizationPhase.cs
@@ -1,0 +1,37 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Reihitsu.Formatter.Pipeline.LineEndings;
+
+/// <summary>
+/// Normalizes all end-of-line trivia in the syntax tree to the formatter context value
+/// </summary>
+internal static class LineEndingNormalizationPhase
+{
+    #region Methods
+
+    /// <summary>
+    /// Rewrites all end-of-line trivia to <see cref="FormattingContext.EndOfLine"/>
+    /// </summary>
+    /// <param name="root">The root syntax node to normalize</param>
+    /// <param name="context">The active formatting context</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The normalized syntax node</returns>
+    public static SyntaxNode Execute(SyntaxNode root, FormattingContext context, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var endOfLinesToReplace = root.DescendantTrivia(descendIntoTrivia: true)
+                                      .Where(trivia => trivia.IsKind(SyntaxKind.EndOfLineTrivia) && trivia.ToString() != context.EndOfLine)
+                                      .ToArray();
+
+        if (endOfLinesToReplace.Length == 0)
+        {
+            return root;
+        }
+
+        return root.ReplaceTrivia(endOfLinesToReplace, (_, _) => SyntaxFactory.EndOfLine(context.EndOfLine));
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Formatter/ReihitsuFormatterHelpers.cs
+++ b/Reihitsu.Formatter/ReihitsuFormatterHelpers.cs
@@ -21,12 +21,33 @@ internal static class ReihitsuFormatterHelpers
     /// <returns>The detected end-of-line sequence</returns>
     internal static string DetectEndOfLine(SyntaxNode node)
     {
-        var firstEndOfLine = node.DescendantTrivia()
-                                 .FirstOrDefault(t => t.IsKind(SyntaxKind.EndOfLineTrivia));
+        var endOfLines = node.DescendantTrivia(descendIntoTrivia: true)
+                             .Where(static trivia => trivia.IsKind(SyntaxKind.EndOfLineTrivia))
+                             .Select(static trivia => trivia.ToString())
+                             .ToList();
 
-        if (firstEndOfLine != default)
+        if (endOfLines.Count == 0)
         {
-            return firstEndOfLine.ToString();
+            return Environment.NewLine;
+        }
+
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        foreach (var endOfLine in endOfLines)
+        {
+            counts[endOfLine] = counts.TryGetValue(endOfLine, out var count)
+                                    ? count + 1
+                                    : 1;
+        }
+
+        var predominantCount = counts.Values.Max();
+
+        foreach (var endOfLine in endOfLines)
+        {
+            if (counts[endOfLine] == predominantCount)
+            {
+                return endOfLine;
+            }
         }
 
         return Environment.NewLine;

--- a/Reihitsu.sln
+++ b/Reihitsu.sln
@@ -164,6 +164,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		documentation\rules\RH0382.md = documentation\rules\RH0382.md
 		documentation\rules\RH0383.md = documentation\rules\RH0383.md
 		documentation\rules\RH0384.md = documentation\rules\RH0384.md
+		documentation\rules\RH0385.md = documentation\rules\RH0385.md
 		documentation\rules\RH0401.md = documentation\rules\RH0401.md
 		documentation\rules\RH0402.md = documentation\rules\RH0402.md
 		documentation\rules\RH0403.md = documentation\rules\RH0403.md

--- a/documentation/rules/RH0385.md
+++ b/documentation/rules/RH0385.md
@@ -1,0 +1,20 @@
+# RH0385 — Code must not contain mixed line endings
+
+| Property | Value |
+|----------|-------|
+| **ID** | RH0385 |
+| **Category** | Formatting |
+| **Severity** | Warning |
+| **Code Fix** | ❌ |
+
+## Description
+
+This rule requires a file to use one line-ending style consistently. A source file should not mix CRLF and LF line endings.
+
+## Why is this a problem?
+
+Mixed line endings create noisy diffs, make formatting less predictable, and can cause avoidable churn when a formatter or editor normalizes the file.
+
+## How to fix it
+
+Convert the lines that use a different line ending so the entire file uses a single style. In practice, keep the file on either CRLF or LF and configure your editor to preserve that choice.


### PR DESCRIPTION
Introduce analyzer rule RH0385 to detect mixed line endings in source files, with documentation, resources, and tests. Add a formatter phase to normalize all line endings to the predominant style. Update helpers and line break logic to respect the configured end-of-line sequence. Expand and update related unit tests and documentation.