### PR TITLE
Add RH0113 analyzer: disallow nested types

### DIFF
--- a/Reihitsu.Analyzer.Package/README.MD
+++ b/Reihitsu.Analyzer.Package/README.MD
@@ -39,6 +39,7 @@ dotnet add package Reihitsu.Analyzer
 | [RH0110](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0110.md)| Unnecessary delegate parentheses should be removed.| ✔| ✔|
 | [RH0111](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0111.md)| Unnecessary attribute constructor parentheses should be removed.| ✔| ✔|
 | [RH0112](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0112.md)| File may only contain a single top-level type.| ✔| ❌|
+| [RH0113](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0113.md)| Nested types should not be used.| ✔| ❌|
 || **Naming**|||
 | [RH0201](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0201.md)| The name of the type should match the filename.| ✔| ✔|
 | [RH0202](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0202.md)| Class names should be in PascalCase.| ✔| ✔|

--- a/Reihitsu.Analyzer.Test/Design/RH0113NestedTypesShouldNotBeUsedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Design/RH0113NestedTypesShouldNotBeUsedAnalyzerTests.cs
@@ -1,0 +1,196 @@
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Analyzer.Rules.Design;
+using Reihitsu.Analyzer.Test.Base;
+
+namespace Reihitsu.Analyzer.Test.Design;
+
+/// <summary>
+/// Test methods for <see cref="RH0113NestedTypesShouldNotBeUsedAnalyzer"/>
+/// </summary>
+[TestClass]
+public class RH0113NestedTypesShouldNotBeUsedAnalyzerTests : AnalyzerTestsBase<RH0113NestedTypesShouldNotBeUsedAnalyzer>
+{
+    /// <summary>
+    /// Verifying that nested classes trigger diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNestedClassesTriggerDiagnostics()
+    {
+        const string source = """
+                              namespace Example;
+
+                              internal class Container
+                              {
+                                  private class {|#0:Nested|}
+                                  {
+                                  }
+                              }
+                              """;
+
+        await Verify(source, Diagnostics(RH0113NestedTypesShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH0113MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying that nested structs trigger diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNestedStructsTriggerDiagnostics()
+    {
+        const string source = """
+                              namespace Example;
+
+                              internal struct Container
+                              {
+                                  private struct {|#0:Nested|}
+                                  {
+                                  }
+                              }
+                              """;
+
+        await Verify(source, Diagnostics(RH0113NestedTypesShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH0113MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying that nested interfaces trigger diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNestedInterfacesTriggerDiagnostics()
+    {
+        const string source = """
+                              namespace Example;
+
+                              internal interface IContainer
+                              {
+                                  interface {|#0:INested|}
+                                  {
+                                  }
+                              }
+                              """;
+
+        await Verify(source, Diagnostics(RH0113NestedTypesShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH0113MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying that nested records trigger diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNestedRecordsTriggerDiagnostics()
+    {
+        const string source = """
+                              namespace Example;
+
+                              internal record Container(string Name)
+                              {
+                                  private record {|#0:Nested|}(int Id);
+                              }
+                              """;
+
+        await Verify(source, Diagnostics(RH0113NestedTypesShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH0113MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying that nested enums trigger diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNestedEnumsTriggerDiagnostics()
+    {
+        const string source = """
+                              namespace Example;
+
+                              internal class Container
+                              {
+                                  private enum {|#0:NestedEnum|}
+                                  {
+                                      One,
+                                  }
+                              }
+                              """;
+
+        await Verify(source, Diagnostics(RH0113NestedTypesShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH0113MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying that nested delegates trigger diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNestedDelegatesTriggerDiagnostics()
+    {
+        const string source = """
+                              namespace Example;
+
+                              internal class Container
+                              {
+                                  private delegate void {|#0:NestedDelegate|}(int value);
+                              }
+                              """;
+
+        await Verify(source, Diagnostics(RH0113NestedTypesShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH0113MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying that generic nested types trigger diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyGenericNestedTypesTriggerDiagnostics()
+    {
+        const string source = """
+                              namespace Example;
+
+                              internal readonly record struct Container<T>(T Value)
+                              {
+                                  private class {|#0:NestedClass|}<TItem>
+                                  {
+                                  }
+
+                                  private readonly record struct {|#1:NestedRecord|}<TItem>(TItem Value);
+                              }
+                              """;
+
+        await Verify(source, Diagnostics(RH0113NestedTypesShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH0113MessageFormat, 2));
+    }
+
+    /// <summary>
+    /// Verifying that top-level types do not trigger diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyTopLevelTypesDoNotTriggerDiagnostics()
+    {
+        const string source = """
+                              namespace Example;
+
+                              internal class ClassType
+                              {
+                              }
+
+                              internal struct StructType
+                              {
+                              }
+
+                              internal interface IInterfaceType
+                              {
+                              }
+
+                              internal record RecordType(string Name);
+
+                              internal enum EnumType
+                              {
+                                  One,
+                              }
+
+                              internal delegate void DelegateType(int value);
+                              """;
+
+        await Verify(source);
+    }
+}

--- a/Reihitsu.Analyzer/AnalyzerResources.cs
+++ b/Reihitsu.Analyzer/AnalyzerResources.cs
@@ -265,6 +265,16 @@ internal static class AnalyzerResources
     internal static string RH0112Title => GetString(nameof(RH0112Title));
 
     /// <summary>
+    /// Gets the localized string for RH0113MessageFormat
+    /// </summary>
+    internal static string RH0113MessageFormat => GetString(nameof(RH0113MessageFormat));
+
+    /// <summary>
+    /// Gets the localized string for RH0113Title
+    /// </summary>
+    internal static string RH0113Title => GetString(nameof(RH0113Title));
+
+    /// <summary>
     /// Gets the localized string for RH0201MessageFormat
     /// </summary>
     internal static string RH0201MessageFormat => GetString(nameof(RH0201MessageFormat));

--- a/Reihitsu.Analyzer/AnalyzerResources.resx
+++ b/Reihitsu.Analyzer/AnalyzerResources.resx
@@ -267,6 +267,12 @@
   <data name="RH0112Title" xml:space="preserve">
     <value>File may only contain a single top-level type.</value>
   </data>
+  <data name="RH0113MessageFormat" xml:space="preserve">
+    <value>Nested types should not be used.</value>
+  </data>
+  <data name="RH0113Title" xml:space="preserve">
+    <value>Nested types should not be used.</value>
+  </data>
   <data name="RH0201MessageFormat" xml:space="preserve">
     <value>The name of the class/struct/enum should match the filename.</value>
   </data>

--- a/Reihitsu.Analyzer/Rules/Design/RH0113NestedTypesShouldNotBeUsedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Design/RH0113NestedTypesShouldNotBeUsedAnalyzer.cs
@@ -1,0 +1,98 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Enumerations;
+
+namespace Reihitsu.Analyzer.Rules.Design;
+
+/// <summary>
+/// RH0113: Nested types should not be used
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class RH0113NestedTypesShouldNotBeUsedAnalyzer : DiagnosticAnalyzerBase<RH0113NestedTypesShouldNotBeUsedAnalyzer>
+{
+    #region Constants
+
+    /// <summary>
+    /// Diagnostic ID
+    /// </summary>
+    public const string DiagnosticId = "RH0113";
+
+    #endregion // Constants
+
+    #region Constructor
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public RH0113NestedTypesShouldNotBeUsedAnalyzer()
+        : base(DiagnosticId, DiagnosticCategory.Design, nameof(AnalyzerResources.RH0113Title), nameof(AnalyzerResources.RH0113MessageFormat))
+    {
+    }
+
+    #endregion // Constructor
+
+    #region Methods
+
+    /// <summary>
+    /// Getting the identifier location of the declaration
+    /// </summary>
+    /// <param name="memberDeclaration">Member declaration</param>
+    /// <returns>Identifier location</returns>
+    private static Location GetIdentifierLocation(MemberDeclarationSyntax memberDeclaration)
+    {
+        return memberDeclaration switch
+               {
+                   BaseTypeDeclarationSyntax baseTypeDeclaration => baseTypeDeclaration.Identifier.GetLocation(),
+                   DelegateDeclarationSyntax delegateDeclaration => delegateDeclaration.Identifier.GetLocation(),
+                   _ => memberDeclaration.GetLocation(),
+               };
+    }
+
+    /// <summary>
+    /// Determining whether the declaration is a nested type
+    /// </summary>
+    /// <param name="memberDeclaration">Member declaration</param>
+    /// <returns>True when the declaration is a nested type</returns>
+    private static bool IsNestedTypeDeclaration(MemberDeclarationSyntax memberDeclaration)
+    {
+        return memberDeclaration is BaseTypeDeclarationSyntax or DelegateDeclarationSyntax;
+    }
+
+    /// <summary>
+    /// Analyzing all syntax trees
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnSyntaxTree(SyntaxTreeAnalysisContext context)
+    {
+        if (context.Tree.GetRoot(context.CancellationToken) is not CompilationUnitSyntax root)
+        {
+            return;
+        }
+
+        var nestedTypeDeclarations = root.DescendantNodes(static node => node is CompilationUnitSyntax or BaseNamespaceDeclarationSyntax or TypeDeclarationSyntax)
+                                         .OfType<MemberDeclarationSyntax>()
+                                         .Where(static memberDeclaration => memberDeclaration.Parent is TypeDeclarationSyntax && IsNestedTypeDeclaration(memberDeclaration));
+
+        foreach (var nestedTypeDeclaration in nestedTypeDeclarations)
+        {
+            context.ReportDiagnostic(CreateDiagnostic(GetIdentifierLocation(nestedTypeDeclaration)));
+        }
+    }
+
+    #endregion // Methods
+
+    #region DiagnosticAnalyzer
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        base.Initialize(context);
+
+        context.RegisterSyntaxTreeAction(OnSyntaxTree);
+    }
+
+    #endregion // DiagnosticAnalyzer
+}

--- a/Reihitsu.sln
+++ b/Reihitsu.sln
@@ -52,6 +52,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		documentation\rules\RH0110.md = documentation\rules\RH0110.md
 		documentation\rules\RH0111.md = documentation\rules\RH0111.md
 		documentation\rules\RH0112.md = documentation\rules\RH0112.md
+		documentation\rules\RH0113.md = documentation\rules\RH0113.md
 		documentation\rules\RH0201.md = documentation\rules\RH0201.md
 		documentation\rules\RH0202.md = documentation\rules\RH0202.md
 		documentation\rules\RH0203.md = documentation\rules\RH0203.md

--- a/documentation/rules/RH0113.md
+++ b/documentation/rules/RH0113.md
@@ -1,0 +1,61 @@
+# RH0113 — Nested types should not be used
+
+| Property | Value |
+|----------|-------|
+| **ID** | RH0113 |
+| **Category** | Design |
+| **Severity** | Warning |
+| **Code Fix** | ❌ |
+
+## Description
+
+Do not declare one type inside another type. This rule applies to nested classes, structs, interfaces, records, enums, and delegates.
+
+## Why is this a problem?
+
+Nested types make code harder to discover, reuse, and test in isolation. They also hide important declarations inside unrelated files and make ownership less obvious during review and maintenance.
+
+## How to fix it
+
+Move the nested type to a top-level declaration. Put it in its own file when appropriate and keep the containing type focused on its own behavior.
+
+## Examples
+
+### Violation
+
+```cs
+namespace Example;
+
+internal class OrderService
+{
+    private enum ResultKind
+    {
+        Success,
+        Failure,
+    }
+
+    private delegate void ResultHandler(ResultKind kind);
+}
+```
+
+### Correction
+
+```cs
+namespace Example;
+
+internal class OrderService
+{
+}
+```
+
+```cs
+namespace Example;
+
+internal enum ResultKind
+{
+    Success,
+    Failure,
+}
+
+internal delegate void ResultHandler(ResultKind kind);
+```


### PR DESCRIPTION
Implements RH0113NestedTypesShouldNotBeUsedAnalyzer to report diagnostics for nested classes, structs, interfaces, records, enums, and delegates. Adds localized resources, comprehensive unit tests, and documentation. Updates solution and README to include the new rule.