### PR TITLE
Add RH0387: region directives indentation analyzer

### DIFF
--- a/Reihitsu.Analyzer.Package/README.MD
+++ b/Reihitsu.Analyzer.Package/README.MD
@@ -106,6 +106,7 @@ dotnet add package Reihitsu.Analyzer
 | [RH0384](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0384.md)| Generic type constraints should be on their own line with proper indentation.| ✔| ✔|
 | [RH0385](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0385.md)| Code must not contain mixed line endings.| ✔| ❌|
 | [RH0386](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0386.md)| Region directives must use consistent indentation with containing code.| ✔| ✔|
+| [RH0387](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0387.md)| Region directives must use consistent indentation.| ✔| ❌|
 || **Documentation**|||
 | [RH0401](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0401.md)| The \<inheritdoc/> Tag should be used if possible.| ✔| ✔|
 | [RH0402](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0402.md)| Elements must be documented.| ✔| ❌|

--- a/Reihitsu.Analyzer.Test/Formatting/RH0387RegionDirectivesMustUseConsistentIndentationAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH0387RegionDirectivesMustUseConsistentIndentationAnalyzerTests.cs
@@ -1,0 +1,127 @@
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Analyzer.Rules.Formatting;
+using Reihitsu.Analyzer.Test.Base;
+
+namespace Reihitsu.Analyzer.Test.Formatting;
+
+/// <summary>
+/// Test methods for <see cref="RH0387RegionDirectivesMustUseConsistentIndentationAnalyzer"/>
+/// </summary>
+[TestClass]
+public class RH0387RegionDirectivesMustUseConsistentIndentationAnalyzerTests : AnalyzerTestsBase<RH0387RegionDirectivesMustUseConsistentIndentationAnalyzer>
+{
+    /// <summary>
+    /// Verifies that correctly indented regions do not produce diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForCorrectlyIndentedRegions()
+    {
+        const string testData = """
+                                namespace Sample
+                                {
+                                    internal class TestClass
+                                    {
+                                        #region Fields
+
+                                        private readonly int _value;
+
+                                        #endregion // Fields
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that misindented type-level regions are detected
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyMisindentedTypeLevelRegionsAreDetected()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                {|#0:#region Fields|}
+
+                                    private readonly int _value;
+
+                                {|#1:#endregion // Fields|}
+                                }
+                                """;
+
+        await Verify(testData, Diagnostics(RH0387RegionDirectivesMustUseConsistentIndentationAnalyzer.DiagnosticId, AnalyzerResources.RH0387MessageFormat, 2));
+    }
+
+    /// <summary>
+    /// Verifies that misindented namespace-level regions are detected
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyMisindentedNamespaceLevelRegionsAreDetected()
+    {
+        const string testData = """
+                                namespace Sample
+                                {
+                                {|#0:#region Types|}
+
+                                    internal class TestClass
+                                    {
+                                    }
+
+                                {|#1:#endregion // Types|}
+                                }
+                                """;
+
+        await Verify(testData, Diagnostics(RH0387RegionDirectivesMustUseConsistentIndentationAnalyzer.DiagnosticId, AnalyzerResources.RH0387MessageFormat, 2));
+    }
+
+    /// <summary>
+    /// Verifies that file-scoped namespace regions can stay at file indentation level
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForFileScopedNamespaceRegions()
+    {
+        const string testData = """
+                                namespace Sample;
+
+                                #region Types
+
+                                internal class TestClass
+                                {
+                                }
+
+                                #endregion // Types
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that regions within method bodies are ignored by this analyzer
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyRegionsWithinMethodBodiesAreIgnored()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method()
+                                    {
+                                #region Helper
+                                        var value = 1;
+                                #endregion // Helper
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+}

--- a/Reihitsu.Analyzer/AnalyzerResources.cs
+++ b/Reihitsu.Analyzer/AnalyzerResources.cs
@@ -965,6 +965,15 @@ internal static class AnalyzerResources
     internal static string RH0386Title => GetString(nameof(RH0386Title));
 
     /// <summary>
+    /// Gets the localized string for RH0387MessageFormat
+    /// </summary>
+    internal static string RH0387MessageFormat => GetString(nameof(RH0387MessageFormat));
+
+    /// <summary>
+    /// Gets the localized string for RH0387Title
+    /// </summary>
+    internal static string RH0387Title => GetString(nameof(RH0387Title));
+
     /// Gets the localized string for RH0334MessageFormat
     /// </summary>
     internal static string RH0334MessageFormat => GetString(nameof(RH0334MessageFormat));

--- a/Reihitsu.Analyzer/AnalyzerResources.resx
+++ b/Reihitsu.Analyzer/AnalyzerResources.resx
@@ -981,6 +981,12 @@
   <data name="RH0386Title" xml:space="preserve">
     <value>Region directives must use consistent indentation with containing code</value>
   </data>
+  <data name="RH0387MessageFormat" xml:space="preserve">
+    <value>Region directives must use consistent indentation.</value>
+  </data>
+  <data name="RH0387Title" xml:space="preserve">
+    <value>Region directives must use consistent indentation</value>
+  </data>
   <data name="RH0601Title" xml:space="preserve">
     <value>Constants must appear before fields</value>
   </data>

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0387RegionDirectivesMustUseConsistentIndentationAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0387RegionDirectivesMustUseConsistentIndentationAnalyzer.cs
@@ -1,0 +1,146 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+
+using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Core;
+using Reihitsu.Analyzer.Enumerations;
+
+namespace Reihitsu.Analyzer.Rules.Formatting;
+
+/// <summary>
+/// Region directives must use consistent indentation
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class RH0387RegionDirectivesMustUseConsistentIndentationAnalyzer : DiagnosticAnalyzerBase<RH0387RegionDirectivesMustUseConsistentIndentationAnalyzer>
+{
+    #region Constants
+
+    /// <summary>
+    /// Diagnostic ID
+    /// </summary>
+    public const string DiagnosticId = "RH0387";
+
+    /// <summary>
+    /// Indent size
+    /// </summary>
+    private const int IndentSize = 4;
+
+    #endregion // Constants
+
+    #region Constructor
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public RH0387RegionDirectivesMustUseConsistentIndentationAnalyzer()
+        : base(DiagnosticId, DiagnosticCategory.Formatting, nameof(AnalyzerResources.RH0387Title), nameof(AnalyzerResources.RH0387MessageFormat))
+    {
+    }
+
+    #endregion // Constructor
+
+    #region Methods
+
+    /// <summary>
+    /// Gets the expected indentation for a region directive
+    /// </summary>
+    /// <param name="directiveTrivia">Directive trivia</param>
+    /// <param name="sourceText">Source text</param>
+    /// <returns>Expected indentation</returns>
+    private static int GetExpectedIndentation(SyntaxTrivia directiveTrivia, SourceText sourceText)
+    {
+        for (var currentNode = directiveTrivia.Token.Parent; currentNode != null; currentNode = currentNode.Parent)
+        {
+            if (currentNode.Span.Contains(directiveTrivia.SpanStart) == false)
+            {
+                continue;
+            }
+
+            switch (currentNode)
+            {
+                case TypeDeclarationSyntax typeDeclaration when typeDeclaration.OpenBraceToken.RawKind != 0:
+                    return GetLineIndentation(sourceText, typeDeclaration.OpenBraceToken.SpanStart) + IndentSize;
+
+                case NamespaceDeclarationSyntax namespaceDeclaration:
+                    return GetLineIndentation(sourceText, namespaceDeclaration.OpenBraceToken.SpanStart) + IndentSize;
+
+                case FileScopedNamespaceDeclarationSyntax fileScopedNamespaceDeclaration:
+                    return GetLineIndentation(sourceText, fileScopedNamespaceDeclaration.NamespaceKeyword.SpanStart);
+
+                case CompilationUnitSyntax:
+                    return 0;
+            }
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Gets the indentation of the line containing the specified position
+    /// </summary>
+    /// <param name="sourceText">Source text</param>
+    /// <param name="position">Position</param>
+    /// <returns>Indentation width</returns>
+    private static int GetLineIndentation(SourceText sourceText, int position)
+    {
+        var line = sourceText.Lines.GetLineFromPosition(position);
+        var lineText = FormattingTextAnalysisUtilities.GetLineText(sourceText, line);
+        var indentation = 0;
+
+        while (indentation < lineText.Length
+               && lineText[indentation] == ' ')
+        {
+            indentation++;
+        }
+
+        return indentation;
+    }
+
+    /// <summary>
+    /// Analyzes the syntax tree
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnSyntaxTree(SyntaxTreeAnalysisContext context)
+    {
+        var syntaxRoot = context.Tree.GetRoot(context.CancellationToken);
+        var sourceText = context.Tree.GetText(context.CancellationToken);
+
+        foreach (var directiveTrivia in syntaxRoot.DescendantTrivia(descendIntoTrivia: true))
+        {
+            if ((directiveTrivia.IsKind(SyntaxKind.RegionDirectiveTrivia) == false
+                 && directiveTrivia.IsKind(SyntaxKind.EndRegionDirectiveTrivia) == false)
+                || RegionDirectiveUtilities.IsWithinElementBody(directiveTrivia))
+            {
+                continue;
+            }
+
+            var line = sourceText.Lines.GetLineFromPosition(directiveTrivia.SpanStart);
+            var lineText = FormattingTextAnalysisUtilities.GetLineText(sourceText, line);
+            var trimmedLineText = lineText.TrimStart();
+            var actualIndentation = lineText.Length - trimmedLineText.Length;
+            var expectedIndentation = GetExpectedIndentation(directiveTrivia, sourceText);
+
+            if (actualIndentation != expectedIndentation)
+            {
+                context.ReportDiagnostic(CreateDiagnostic(directiveTrivia.GetLocation()));
+            }
+        }
+    }
+
+    #endregion // Methods
+
+    #region DiagnosticAnalyzer
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        base.Initialize(context);
+
+        context.RegisterSyntaxTreeAction(OnSyntaxTree);
+    }
+
+    #endregion // DiagnosticAnalyzer
+}

--- a/Reihitsu.sln
+++ b/Reihitsu.sln
@@ -167,6 +167,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		documentation\rules\RH0384.md = documentation\rules\RH0384.md
 		documentation\rules\RH0385.md = documentation\rules\RH0385.md
 		documentation\rules\RH0386.md = documentation\rules\RH0386.md
+		documentation\rules\RH0387.md = documentation\rules\RH0387.md
 		documentation\rules\RH0401.md = documentation\rules\RH0401.md
 		documentation\rules\RH0402.md = documentation\rules\RH0402.md
 		documentation\rules\RH0403.md = documentation\rules\RH0403.md

--- a/documentation/rules/RH0387.md
+++ b/documentation/rules/RH0387.md
@@ -1,0 +1,48 @@
+# RH0387 — Region directives must use consistent indentation
+
+| Property | Value |
+|----------|-------|
+| **ID** | RH0387 |
+| **Category** | Formatting |
+| **Severity** | Warning |
+| **Code Fix** | ❌ |
+
+## Description
+
+This rule requires `#region` and `#endregion` directives to use the same indentation level as the code scope they organize.
+
+## Why is this a problem?
+
+Misindented region directives make the structure of a file harder to scan. When region markers do not line up with the members or types they contain, the visual nesting of the code becomes unclear.
+
+## How to fix it
+
+Indent the region directives to the same level as the members, types, or namespace contents inside the region. Running the Reihitsu formatter can also correct the indentation.
+
+## Examples
+
+### Violation
+
+```cs
+internal class Example
+{
+#region Fields
+
+    private string _name;
+
+#endregion // Fields
+}
+```
+
+### Correction
+
+```cs
+internal class Example
+{
+    #region Fields
+
+    private string _name;
+
+    #endregion // Fields
+}
+```


### PR DESCRIPTION
Implements RH0387 analyzer to enforce consistent indentation for #region and #endregion directives. Adds unit tests, resource strings, rule documentation, and updates the README and solution file to reflect the new rule.