### PR TITLE
Add RH0387: enforce type organization with regions

### DIFF
--- a/Reihitsu.Analyzer.Package/README.MD
+++ b/Reihitsu.Analyzer.Package/README.MD
@@ -106,6 +106,7 @@ dotnet add package Reihitsu.Analyzer
 | [RH0384](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0384.md)| Generic type constraints should be on their own line with proper indentation.| ✔| ✔|
 | [RH0385](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0385.md)| Code must not contain mixed line endings.| ✔| ❌|
 | [RH0386](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0386.md)| Region directives must use consistent indentation with containing code.| ✔| ✔|
+| [RH0387](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0387.md)| Types should be organized with regions.| ✔| ❌|
 || **Documentation**|||
 | [RH0401](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0401.md)| The \<inheritdoc/> Tag should be used if possible.| ✔| ✔|
 | [RH0402](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0402.md)| Elements must be documented.| ✔| ❌|

--- a/Reihitsu.Analyzer.Test/Formatting/RH0387TypesShouldBeOrganizedWithRegionsAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH0387TypesShouldBeOrganizedWithRegionsAnalyzerTests.cs
@@ -1,0 +1,296 @@
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Analyzer.Rules.Formatting;
+using Reihitsu.Analyzer.Test.Base;
+
+namespace Reihitsu.Analyzer.Test.Formatting;
+
+/// <summary>
+/// Test methods for <see cref="RH0387TypesShouldBeOrganizedWithRegionsAnalyzer"/>
+/// </summary>
+[TestClass]
+public class RH0387TypesShouldBeOrganizedWithRegionsAnalyzerTests : AnalyzerTestsBase<RH0387TypesShouldBeOrganizedWithRegionsAnalyzer>
+{
+    /// <summary>
+    /// Verifies that property-only classes do not require regions
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForPropertyOnlyClass()
+    {
+        const string testData = """
+                                internal class Example
+                                {
+                                    public string Name { get; set; }
+
+                                    internal int Age { get; set; }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that interfaces organized with regions do not produce diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenInterfaceMembersAreOrganizedWithRegions()
+    {
+        const string testData = """
+                                internal interface IExample
+                                {
+                                    #region Properties
+
+                                    string Name { get; }
+
+                                    #endregion // Properties
+
+                                    #region Events
+
+                                    event System.Action Saved;
+
+                                    #endregion // Events
+
+                                    #region Indexers
+
+                                    string this[int index] { get; }
+
+                                    #endregion // Indexers
+
+                                    #region Methods
+
+                                    void Load();
+
+                                    #endregion // Methods
+
+                                    #region Types
+
+                                    interface INested
+                                    {
+                                    }
+
+                                    #endregion // Types
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that mixed class members organized with regions do not produce diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenClassMembersAreOrganizedWithRegions()
+    {
+        const string testData = """
+                                internal class Example
+                                {
+                                    #region Fields
+
+                                    private string _name;
+
+                                    #endregion // Fields
+
+                                    #region Properties
+
+                                    public string Name => _name;
+
+                                    #endregion // Properties
+
+                                    #region Constructors
+
+                                    internal Example(string name)
+                                    {
+                                        _name = name;
+                                    }
+
+                                    #endregion // Constructors
+
+                                    #region Methods
+
+                                    internal void Save()
+                                    {
+                                    }
+
+                                    #endregion // Methods
+
+                                    #region Types
+
+                                    internal class Nested
+                                    {
+                                    }
+
+                                    #endregion // Types
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that classes with non-property members must use regions
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticWhenClassMembersAreNotOrganizedWithRegions()
+    {
+        const string testData = """
+                                internal class {|#0:Example|}
+                                {
+                                    private string _name;
+
+                                    public string Name { get; set; }
+
+                                    internal Example()
+                                    {
+                                    }
+
+                                    internal void Save()
+                                    {
+                                    }
+
+                                    internal class Nested
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(testData, Diagnostics(RH0387TypesShouldBeOrganizedWithRegionsAnalyzer.DiagnosticId, AnalyzerResources.RH0387MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that the property-only exception does not apply when methods are present
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticWhenTypeContainsPropertiesAndMethodsWithoutRegions()
+    {
+        const string testData = """
+                                internal class {|#0:Example|}
+                                {
+                                    public string Name { get; set; }
+
+                                    public int Age { get; set; }
+
+                                    public string Address { get; set; }
+
+                                    public string Phone { get; set; }
+
+                                    internal void Save()
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(testData, Diagnostics(RH0387TypesShouldBeOrganizedWithRegionsAnalyzer.DiagnosticId, AnalyzerResources.RH0387MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that a type is still reported when only some members are placed inside regions
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticWhenTypeContainsMembersOutsideRegions()
+    {
+        const string testData = """
+                                internal class {|#0:Example|}
+                                {
+                                    #region Fields
+
+                                    private string _name;
+
+                                    #endregion // Fields
+
+                                    #region Properties
+
+                                    public string Name { get; set; }
+
+                                    public int Age { get; set; }
+
+                                    #endregion // Properties
+
+                                    internal Example()
+                                    {
+                                    }
+
+                                    internal void Save()
+                                    {
+                                    }
+
+                                    internal class Nested
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(testData, Diagnostics(RH0387TypesShouldBeOrganizedWithRegionsAnalyzer.DiagnosticId, AnalyzerResources.RH0387MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that records with non-property members must use regions
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticWhenRecordMembersAreNotOrganizedWithRegions()
+    {
+        const string testData = """
+                                internal record {|#0:Example|}
+                                {
+                                    private readonly string _name;
+
+                                    public string Name { get; init; }
+
+                                    internal Example(string name)
+                                    {
+                                        _name = name;
+                                    }
+
+                                    internal void Save()
+                                    {
+                                    }
+
+                                    internal class Nested
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(testData, Diagnostics(RH0387TypesShouldBeOrganizedWithRegionsAnalyzer.DiagnosticId, AnalyzerResources.RH0387MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that structs with non-property members must use regions
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticWhenStructMembersAreNotOrganizedWithRegions()
+    {
+        const string testData = """
+                                internal struct {|#0:Example|}
+                                {
+                                    internal int Value;
+
+                                    internal string Name { get; set; }
+
+                                    public Example()
+                                    {
+                                        Name = string.Empty;
+                                    }
+
+                                    internal void Save()
+                                    {
+                                    }
+
+                                    internal class Nested
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(testData, Diagnostics(RH0387TypesShouldBeOrganizedWithRegionsAnalyzer.DiagnosticId, AnalyzerResources.RH0387MessageFormat));
+    }
+}

--- a/Reihitsu.Analyzer/AnalyzerResources.cs
+++ b/Reihitsu.Analyzer/AnalyzerResources.cs
@@ -965,6 +965,16 @@ internal static class AnalyzerResources
     internal static string RH0386Title => GetString(nameof(RH0386Title));
 
     /// <summary>
+    /// Gets the localized string for RH0387MessageFormat
+    /// </summary>
+    internal static string RH0387MessageFormat => GetString(nameof(RH0387MessageFormat));
+
+    /// <summary>
+    /// Gets the localized string for RH0387Title
+    /// </summary>
+    internal static string RH0387Title => GetString(nameof(RH0387Title));
+
+    /// <summary>
     /// Gets the localized string for RH0334MessageFormat
     /// </summary>
     internal static string RH0334MessageFormat => GetString(nameof(RH0334MessageFormat));

--- a/Reihitsu.Analyzer/AnalyzerResources.resx
+++ b/Reihitsu.Analyzer/AnalyzerResources.resx
@@ -981,6 +981,12 @@
   <data name="RH0386Title" xml:space="preserve">
     <value>Region directives must use consistent indentation with containing code</value>
   </data>
+  <data name="RH0387MessageFormat" xml:space="preserve">
+    <value>Types should be organized with regions.</value>
+  </data>
+  <data name="RH0387Title" xml:space="preserve">
+    <value>Types should be organized with regions</value>
+  </data>
   <data name="RH0601Title" xml:space="preserve">
     <value>Constants must appear before fields</value>
   </data>

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0304IfStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0304IfStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -14,10 +14,16 @@ namespace Reihitsu.Analyzer.Rules.Formatting;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH0304IfStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<IfStatementSyntax, RH0304IfStatementsShouldBePrecededByABlankLineAnalyzer>
 {
+    #region Constants
+
     /// <summary>
     /// Diagnostic ID
     /// </summary>
     public const string DiagnosticId = "RH0304";
+
+    #endregion // Constants
+
+    #region Constructor
 
     /// <summary>
     /// Constructor
@@ -26,6 +32,10 @@ public class RH0304IfStatementsShouldBePrecededByABlankLineAnalyzer : StatementS
         : base(DiagnosticId, DiagnosticCategory.Formatting, nameof(AnalyzerResources.RH0304Title), nameof(AnalyzerResources.RH0304MessageFormat), SyntaxKind.IfStatement)
     {
     }
+
+    #endregion // Constructor
+
+    #region StatementShouldBePrecededByABlankLineAnalyzerBase
 
     /// <inheritdoc />
     protected override SyntaxToken GetPreviousToken(IfStatementSyntax ifStatement)
@@ -45,4 +55,6 @@ public class RH0304IfStatementsShouldBePrecededByABlankLineAnalyzer : StatementS
     {
         return statement.IfKeyword.GetLocation();
     }
+
+    #endregion // StatementShouldBePrecededByABlankLineAnalyzerBase
 }

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0305WhileStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0305WhileStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -14,10 +14,16 @@ namespace Reihitsu.Analyzer.Rules.Formatting;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH0305WhileStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<WhileStatementSyntax, RH0305WhileStatementsShouldBePrecededByABlankLineAnalyzer>
 {
+    #region Constants
+
     /// <summary>
     /// Diagnostic ID
     /// </summary>
     public const string DiagnosticId = "RH0305";
+
+    #endregion // Constants
+
+    #region Constructor
 
     /// <summary>
     /// Constructor
@@ -26,6 +32,10 @@ public class RH0305WhileStatementsShouldBePrecededByABlankLineAnalyzer : Stateme
         : base(DiagnosticId, DiagnosticCategory.Formatting, nameof(AnalyzerResources.RH0305Title), nameof(AnalyzerResources.RH0305MessageFormat), SyntaxKind.WhileStatement)
     {
     }
+
+    #endregion // Constructor
+
+    #region StatementShouldBePrecededByABlankLineAnalyzerBase
 
     /// <inheritdoc />
     protected override SyntaxToken GetPreviousToken(WhileStatementSyntax whileStatement)
@@ -38,4 +48,6 @@ public class RH0305WhileStatementsShouldBePrecededByABlankLineAnalyzer : Stateme
     {
         return statement.WhileKeyword.GetLocation();
     }
+
+    #endregion // StatementShouldBePrecededByABlankLineAnalyzerBase
 }

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0306DoStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0306DoStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -14,10 +14,16 @@ namespace Reihitsu.Analyzer.Rules.Formatting;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH0306DoStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<DoStatementSyntax, RH0306DoStatementsShouldBePrecededByABlankLineAnalyzer>
 {
+    #region Constants
+
     /// <summary>
     /// Diagnostic ID
     /// </summary>
     public const string DiagnosticId = "RH0306";
+
+    #endregion // Constants
+
+    #region Constructor
 
     /// <summary>
     /// Constructor
@@ -26,6 +32,10 @@ public class RH0306DoStatementsShouldBePrecededByABlankLineAnalyzer : StatementS
         : base(DiagnosticId, DiagnosticCategory.Formatting, nameof(AnalyzerResources.RH0306Title), nameof(AnalyzerResources.RH0306MessageFormat), SyntaxKind.DoStatement)
     {
     }
+
+    #endregion // Constructor
+
+    #region StatementShouldBePrecededByABlankLineAnalyzerBase
 
     /// <inheritdoc />
     protected override SyntaxToken GetPreviousToken(DoStatementSyntax doStatement)
@@ -38,4 +48,6 @@ public class RH0306DoStatementsShouldBePrecededByABlankLineAnalyzer : StatementS
     {
         return statement.DoKeyword.GetLocation();
     }
+
+    #endregion // StatementShouldBePrecededByABlankLineAnalyzerBase
 }

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0307UsingStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0307UsingStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -14,10 +14,16 @@ namespace Reihitsu.Analyzer.Rules.Formatting;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH0307UsingStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<UsingStatementSyntax, RH0307UsingStatementsShouldBePrecededByABlankLineAnalyzer>
 {
+    #region Constants
+
     /// <summary>
     /// Diagnostic ID
     /// </summary>
     public const string DiagnosticId = "RH0307";
+
+    #endregion // Constants
+
+    #region Constructor
 
     /// <summary>
     /// Constructor
@@ -26,6 +32,10 @@ public class RH0307UsingStatementsShouldBePrecededByABlankLineAnalyzer : Stateme
         : base(DiagnosticId, DiagnosticCategory.Formatting, nameof(AnalyzerResources.RH0307Title), nameof(AnalyzerResources.RH0307MessageFormat), SyntaxKind.UsingStatement)
     {
     }
+
+    #endregion // Constructor
+
+    #region StatementShouldBePrecededByABlankLineAnalyzerBase
 
     /// <inheritdoc />
     protected override SyntaxToken GetPreviousToken(UsingStatementSyntax usingStatement)
@@ -40,4 +50,6 @@ public class RH0307UsingStatementsShouldBePrecededByABlankLineAnalyzer : Stateme
     {
         return statement.UsingKeyword.GetLocation();
     }
+
+    #endregion // StatementShouldBePrecededByABlankLineAnalyzerBase
 }

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0308ForeachStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0308ForeachStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -14,10 +14,16 @@ namespace Reihitsu.Analyzer.Rules.Formatting;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH0308ForeachStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<ForEachStatementSyntax, RH0308ForeachStatementsShouldBePrecededByABlankLineAnalyzer>
 {
+    #region Constants
+
     /// <summary>
     /// Diagnostic ID
     /// </summary>
     public const string DiagnosticId = "RH0308";
+
+    #endregion // Constants
+
+    #region Constructor
 
     /// <summary>
     /// Constructor
@@ -26,6 +32,10 @@ public class RH0308ForeachStatementsShouldBePrecededByABlankLineAnalyzer : State
         : base(DiagnosticId, DiagnosticCategory.Formatting, nameof(AnalyzerResources.RH0308Title), nameof(AnalyzerResources.RH0308MessageFormat), SyntaxKind.ForEachStatement)
     {
     }
+
+    #endregion // Constructor
+
+    #region StatementShouldBePrecededByABlankLineAnalyzerBase
 
     /// <inheritdoc />
     protected override SyntaxToken GetPreviousToken(ForEachStatementSyntax foreachStatement)
@@ -40,4 +50,6 @@ public class RH0308ForeachStatementsShouldBePrecededByABlankLineAnalyzer : State
     {
         return statement.ForEachKeyword.GetLocation();
     }
+
+    #endregion // StatementShouldBePrecededByABlankLineAnalyzerBase
 }

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0309ForStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0309ForStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -14,10 +14,16 @@ namespace Reihitsu.Analyzer.Rules.Formatting;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH0309ForStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<ForStatementSyntax, RH0309ForStatementsShouldBePrecededByABlankLineAnalyzer>
 {
+    #region Constants
+
     /// <summary>
     /// Diagnostic ID
     /// </summary>
     public const string DiagnosticId = "RH0309";
+
+    #endregion // Constants
+
+    #region Constructor
 
     /// <summary>
     /// Constructor
@@ -26,6 +32,10 @@ public class RH0309ForStatementsShouldBePrecededByABlankLineAnalyzer : Statement
         : base(DiagnosticId, DiagnosticCategory.Formatting, nameof(AnalyzerResources.RH0309Title), nameof(AnalyzerResources.RH0309MessageFormat), SyntaxKind.ForStatement)
     {
     }
+
+    #endregion // Constructor
+
+    #region StatementShouldBePrecededByABlankLineAnalyzerBase
 
     /// <inheritdoc />
     protected override SyntaxToken GetPreviousToken(ForStatementSyntax forStatement)
@@ -38,4 +48,6 @@ public class RH0309ForStatementsShouldBePrecededByABlankLineAnalyzer : Statement
     {
         return statement.ForKeyword.GetLocation();
     }
+
+    #endregion // StatementShouldBePrecededByABlankLineAnalyzerBase
 }

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0310ReturnStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0310ReturnStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -14,10 +14,16 @@ namespace Reihitsu.Analyzer.Rules.Formatting;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH0310ReturnStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<ReturnStatementSyntax, RH0310ReturnStatementsShouldBePrecededByABlankLineAnalyzer>
 {
+    #region Constants
+
     /// <summary>
     /// Diagnostic ID
     /// </summary>
     public const string DiagnosticId = "RH0310";
+
+    #endregion // Constants
+
+    #region Constructor
 
     /// <summary>
     /// Constructor
@@ -26,6 +32,10 @@ public class RH0310ReturnStatementsShouldBePrecededByABlankLineAnalyzer : Statem
         : base(DiagnosticId, DiagnosticCategory.Formatting, nameof(AnalyzerResources.RH0310Title), nameof(AnalyzerResources.RH0310MessageFormat), SyntaxKind.ReturnStatement)
     {
     }
+
+    #endregion // Constructor
+
+    #region StatementShouldBePrecededByABlankLineAnalyzerBase
 
     /// <inheritdoc />
     protected override SyntaxToken GetPreviousToken(ReturnStatementSyntax returnStatement)
@@ -38,4 +48,6 @@ public class RH0310ReturnStatementsShouldBePrecededByABlankLineAnalyzer : Statem
     {
         return statement.ReturnKeyword.GetLocation();
     }
+
+    #endregion // StatementShouldBePrecededByABlankLineAnalyzerBase
 }

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0311GotoStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0311GotoStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -14,10 +14,16 @@ namespace Reihitsu.Analyzer.Rules.Formatting;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH0311GotoStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<GotoStatementSyntax, RH0311GotoStatementsShouldBePrecededByABlankLineAnalyzer>
 {
+    #region Constants
+
     /// <summary>
     /// Diagnostic ID
     /// </summary>
     public const string DiagnosticId = "RH0311";
+
+    #endregion // Constants
+
+    #region Constructor
 
     /// <summary>
     /// Constructor
@@ -26,6 +32,10 @@ public class RH0311GotoStatementsShouldBePrecededByABlankLineAnalyzer : Statemen
         : base(DiagnosticId, DiagnosticCategory.Formatting, nameof(AnalyzerResources.RH0311Title), nameof(AnalyzerResources.RH0311MessageFormat), SyntaxKind.GotoStatement)
     {
     }
+
+    #endregion // Constructor
+
+    #region StatementShouldBePrecededByABlankLineAnalyzerBase
 
     /// <inheritdoc />
     protected override SyntaxToken GetPreviousToken(GotoStatementSyntax gotoStatement)
@@ -38,4 +48,6 @@ public class RH0311GotoStatementsShouldBePrecededByABlankLineAnalyzer : Statemen
     {
         return statement.GotoKeyword.GetLocation();
     }
+
+    #endregion // StatementShouldBePrecededByABlankLineAnalyzerBase
 }

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0312BreakStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0312BreakStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -14,10 +14,16 @@ namespace Reihitsu.Analyzer.Rules.Formatting;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH0312BreakStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<BreakStatementSyntax, RH0312BreakStatementsShouldBePrecededByABlankLineAnalyzer>
 {
+    #region Constants
+
     /// <summary>
     /// Diagnostic ID
     /// </summary>
     public const string DiagnosticId = "RH0312";
+
+    #endregion // Constants
+
+    #region Constructor
 
     /// <summary>
     /// Constructor
@@ -26,6 +32,10 @@ public class RH0312BreakStatementsShouldBePrecededByABlankLineAnalyzer : Stateme
         : base(DiagnosticId, DiagnosticCategory.Formatting, nameof(AnalyzerResources.RH0312Title), nameof(AnalyzerResources.RH0312MessageFormat), SyntaxKind.BreakStatement)
     {
     }
+
+    #endregion // Constructor
+
+    #region Methods
 
     /// <inheritdoc />
     protected override SyntaxToken GetPreviousToken(BreakStatementSyntax breakStatement)
@@ -45,4 +55,6 @@ public class RH0312BreakStatementsShouldBePrecededByABlankLineAnalyzer : Stateme
         return statement.BreakKeyword.GetPreviousToken().IsKind(SyntaxKind.CloseBraceToken) == false
                && statement.Parent?.IsKind(SyntaxKind.SwitchSection) != true;
     }
+
+    #endregion // Methods
 }

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0313BreakStatementsShouldBeFollowedByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0313BreakStatementsShouldBeFollowedByABlankLineAnalyzer.cs
@@ -14,10 +14,16 @@ namespace Reihitsu.Analyzer.Rules.Formatting;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH0313BreakStatementsShouldBeFollowedByABlankLineAnalyzer : StatementShouldBeFollowedByABlankLineAnalyzerBase<BreakStatementSyntax, RH0313BreakStatementsShouldBeFollowedByABlankLineAnalyzer>
 {
+    #region Constants
+
     /// <summary>
     /// Diagnostic ID
     /// </summary>
     public const string DiagnosticId = "RH0313";
+
+    #endregion // Constants
+
+    #region Constructor
 
     /// <summary>
     /// Constructor
@@ -26,6 +32,10 @@ public class RH0313BreakStatementsShouldBeFollowedByABlankLineAnalyzer : Stateme
         : base(DiagnosticId, DiagnosticCategory.Formatting, nameof(AnalyzerResources.RH0313Title), nameof(AnalyzerResources.RH0313MessageFormat), SyntaxKind.BreakStatement)
     {
     }
+
+    #endregion // Constructor
+
+    #region StatementShouldBeFollowedByABlankLineAnalyzerBase
 
     /// <inheritdoc />
     protected override SyntaxToken GetNextToken(BreakStatementSyntax breakStatement)
@@ -45,4 +55,6 @@ public class RH0313BreakStatementsShouldBeFollowedByABlankLineAnalyzer : Stateme
     {
         return statement.BreakKeyword.GetLocation();
     }
+
+    #endregion // StatementShouldBeFollowedByABlankLineAnalyzerBase
 }

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0314ContinueStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0314ContinueStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -14,10 +14,16 @@ namespace Reihitsu.Analyzer.Rules.Formatting;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH0314ContinueStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<ContinueStatementSyntax, RH0314ContinueStatementsShouldBePrecededByABlankLineAnalyzer>
 {
+    #region Constants
+
     /// <summary>
     /// Diagnostic ID
     /// </summary>
     public const string DiagnosticId = "RH0314";
+
+    #endregion // Constants
+
+    #region Constructor
 
     /// <summary>
     /// Constructor
@@ -26,6 +32,10 @@ public class RH0314ContinueStatementsShouldBePrecededByABlankLineAnalyzer : Stat
         : base(DiagnosticId, DiagnosticCategory.Formatting, nameof(AnalyzerResources.RH0314Title), nameof(AnalyzerResources.RH0314MessageFormat), SyntaxKind.ContinueStatement)
     {
     }
+
+    #endregion // Constructor
+
+    #region StatementShouldBePrecededByABlankLineAnalyzerBase
 
     /// <inheritdoc />
     protected override SyntaxToken GetPreviousToken(ContinueStatementSyntax continueStatement)
@@ -38,4 +48,6 @@ public class RH0314ContinueStatementsShouldBePrecededByABlankLineAnalyzer : Stat
     {
         return statement.ContinueKeyword.GetLocation();
     }
+
+    #endregion // StatementShouldBePrecededByABlankLineAnalyzerBase
 }

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0315ThrowStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0315ThrowStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -14,10 +14,16 @@ namespace Reihitsu.Analyzer.Rules.Formatting;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH0315ThrowStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<ThrowStatementSyntax, RH0315ThrowStatementsShouldBePrecededByABlankLineAnalyzer>
 {
+    #region Constants
+
     /// <summary>
     /// Diagnostic ID
     /// </summary>
     public const string DiagnosticId = "RH0315";
+
+    #endregion // Constants
+
+    #region Constructor
 
     /// <summary>
     /// Constructor
@@ -26,6 +32,10 @@ public class RH0315ThrowStatementsShouldBePrecededByABlankLineAnalyzer : Stateme
         : base(DiagnosticId, DiagnosticCategory.Formatting, nameof(AnalyzerResources.RH0315Title), nameof(AnalyzerResources.RH0315MessageFormat), SyntaxKind.ThrowStatement)
     {
     }
+
+    #endregion // Constructor
+
+    #region StatementShouldBePrecededByABlankLineAnalyzerBase
 
     /// <inheritdoc />
     protected override SyntaxToken GetPreviousToken(ThrowStatementSyntax throwStatement)
@@ -38,4 +48,6 @@ public class RH0315ThrowStatementsShouldBePrecededByABlankLineAnalyzer : Stateme
     {
         return statement.ThrowKeyword.GetLocation();
     }
+
+    #endregion // StatementShouldBePrecededByABlankLineAnalyzerBase
 }

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0316SwitchStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0316SwitchStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -14,10 +14,16 @@ namespace Reihitsu.Analyzer.Rules.Formatting;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH0316SwitchStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<SwitchStatementSyntax, RH0316SwitchStatementsShouldBePrecededByABlankLineAnalyzer>
 {
+    #region Constants
+
     /// <summary>
     /// Diagnostic ID
     /// </summary>
     public const string DiagnosticId = "RH0316";
+
+    #endregion // Constants
+
+    #region Constructor
 
     /// <summary>
     /// Constructor
@@ -26,6 +32,10 @@ public class RH0316SwitchStatementsShouldBePrecededByABlankLineAnalyzer : Statem
         : base(DiagnosticId, DiagnosticCategory.Formatting, nameof(AnalyzerResources.RH0316Title), nameof(AnalyzerResources.RH0316MessageFormat), SyntaxKind.SwitchStatement)
     {
     }
+
+    #endregion // Constructor
+
+    #region StatementShouldBePrecededByABlankLineAnalyzerBase
 
     /// <inheritdoc />
     protected override SyntaxToken GetPreviousToken(SwitchStatementSyntax switchStatement)
@@ -38,4 +48,6 @@ public class RH0316SwitchStatementsShouldBePrecededByABlankLineAnalyzer : Statem
     {
         return statement.SwitchKeyword.GetLocation();
     }
+
+    #endregion // StatementShouldBePrecededByABlankLineAnalyzerBase
 }

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0317CheckedStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0317CheckedStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -14,10 +14,16 @@ namespace Reihitsu.Analyzer.Rules.Formatting;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH0317CheckedStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<CheckedStatementSyntax, RH0317CheckedStatementsShouldBePrecededByABlankLineAnalyzer>
 {
+    #region Constants
+
     /// <summary>
     /// Diagnostic ID
     /// </summary>
     public const string DiagnosticId = "RH0317";
+
+    #endregion // Constants
+
+    #region Constructor
 
     /// <summary>
     /// Constructor
@@ -26,6 +32,10 @@ public class RH0317CheckedStatementsShouldBePrecededByABlankLineAnalyzer : State
         : base(DiagnosticId, DiagnosticCategory.Formatting, nameof(AnalyzerResources.RH0317Title), nameof(AnalyzerResources.RH0317MessageFormat), SyntaxKind.CheckedStatement)
     {
     }
+
+    #endregion // Constructor
+
+    #region StatementShouldBePrecededByABlankLineAnalyzerBase
 
     /// <inheritdoc />
     protected override SyntaxToken GetPreviousToken(CheckedStatementSyntax checkedStatement)
@@ -38,4 +48,6 @@ public class RH0317CheckedStatementsShouldBePrecededByABlankLineAnalyzer : State
     {
         return statement.Keyword.GetLocation();
     }
+
+    #endregion // StatementShouldBePrecededByABlankLineAnalyzerBase
 }

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0318UncheckedStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0318UncheckedStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -14,10 +14,16 @@ namespace Reihitsu.Analyzer.Rules.Formatting;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH0318UncheckedStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<CheckedStatementSyntax, RH0318UncheckedStatementsShouldBePrecededByABlankLineAnalyzer>
 {
+    #region Constants
+
     /// <summary>
     /// Diagnostic ID
     /// </summary>
     public const string DiagnosticId = "RH0318";
+
+    #endregion // Constants
+
+    #region Constructor
 
     /// <summary>
     /// Constructor
@@ -26,6 +32,10 @@ public class RH0318UncheckedStatementsShouldBePrecededByABlankLineAnalyzer : Sta
         : base(DiagnosticId, DiagnosticCategory.Formatting, nameof(AnalyzerResources.RH0318Title), nameof(AnalyzerResources.RH0318MessageFormat), SyntaxKind.UncheckedStatement)
     {
     }
+
+    #endregion // Constructor
+
+    #region StatementShouldBePrecededByABlankLineAnalyzerBase
 
     /// <inheritdoc />
     protected override SyntaxToken GetPreviousToken(CheckedStatementSyntax uncheckedStatement)
@@ -38,4 +48,6 @@ public class RH0318UncheckedStatementsShouldBePrecededByABlankLineAnalyzer : Sta
     {
         return statement.Keyword.GetLocation();
     }
+
+    #endregion // StatementShouldBePrecededByABlankLineAnalyzerBase
 }

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0319FixedStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0319FixedStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -14,10 +14,16 @@ namespace Reihitsu.Analyzer.Rules.Formatting;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH0319FixedStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<FixedStatementSyntax, RH0319FixedStatementsShouldBePrecededByABlankLineAnalyzer>
 {
+    #region Constants
+
     /// <summary>
     /// Diagnostic ID
     /// </summary>
     public const string DiagnosticId = "RH0319";
+
+    #endregion // Constants
+
+    #region Constructor
 
     /// <summary>
     /// Constructor
@@ -26,6 +32,10 @@ public class RH0319FixedStatementsShouldBePrecededByABlankLineAnalyzer : Stateme
         : base(DiagnosticId, DiagnosticCategory.Formatting, nameof(AnalyzerResources.RH0319Title), nameof(AnalyzerResources.RH0319MessageFormat), SyntaxKind.FixedStatement)
     {
     }
+
+    #endregion // Constructor
+
+    #region StatementShouldBePrecededByABlankLineAnalyzerBase
 
     /// <inheritdoc />
     protected override SyntaxToken GetPreviousToken(FixedStatementSyntax fixedStatement)
@@ -38,4 +48,6 @@ public class RH0319FixedStatementsShouldBePrecededByABlankLineAnalyzer : Stateme
     {
         return statement.FixedKeyword.GetLocation();
     }
+
+    #endregion // StatementShouldBePrecededByABlankLineAnalyzerBase
 }

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0320LockStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0320LockStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -14,10 +14,16 @@ namespace Reihitsu.Analyzer.Rules.Formatting;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH0320LockStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<LockStatementSyntax, RH0320LockStatementsShouldBePrecededByABlankLineAnalyzer>
 {
+    #region Constants
+
     /// <summary>
     /// Diagnostic ID
     /// </summary>
     public const string DiagnosticId = "RH0320";
+
+    #endregion // Constants
+
+    #region Constructor
 
     /// <summary>
     /// Constructor
@@ -26,6 +32,10 @@ public class RH0320LockStatementsShouldBePrecededByABlankLineAnalyzer : Statemen
         : base(DiagnosticId, DiagnosticCategory.Formatting, nameof(AnalyzerResources.RH0320Title), nameof(AnalyzerResources.RH0320MessageFormat), SyntaxKind.LockStatement)
     {
     }
+
+    #endregion // Constructor
+
+    #region StatementShouldBePrecededByABlankLineAnalyzerBase
 
     /// <inheritdoc />
     protected override SyntaxToken GetPreviousToken(LockStatementSyntax lockStatement)
@@ -38,4 +48,6 @@ public class RH0320LockStatementsShouldBePrecededByABlankLineAnalyzer : Statemen
     {
         return statement.LockKeyword.GetLocation();
     }
+
+    #endregion // StatementShouldBePrecededByABlankLineAnalyzerBase
 }

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0321YieldStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0321YieldStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -14,10 +14,16 @@ namespace Reihitsu.Analyzer.Rules.Formatting;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH0321YieldStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<YieldStatementSyntax, RH0321YieldStatementsShouldBePrecededByABlankLineAnalyzer>
 {
+    #region Constants
+
     /// <summary>
     /// Diagnostic ID
     /// </summary>
     public const string DiagnosticId = "RH0321";
+
+    #endregion // Constants
+
+    #region Constructor
 
     /// <summary>
     /// Constructor
@@ -26,6 +32,10 @@ public class RH0321YieldStatementsShouldBePrecededByABlankLineAnalyzer : Stateme
         : base(DiagnosticId, DiagnosticCategory.Formatting, nameof(AnalyzerResources.RH0321Title), nameof(AnalyzerResources.RH0321MessageFormat), SyntaxKind.YieldReturnStatement)
     {
     }
+
+    #endregion // Constructor
+
+    #region Methods
 
     /// <inheritdoc />
     protected override bool IsRelevant(YieldStatementSyntax statement)
@@ -54,4 +64,6 @@ public class RH0321YieldStatementsShouldBePrecededByABlankLineAnalyzer : Stateme
     {
         return statement.YieldKeyword.GetLocation();
     }
+
+    #endregion // Methods
 }

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0387TypesShouldBeOrganizedWithRegionsAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0387TypesShouldBeOrganizedWithRegionsAnalyzer.cs
@@ -1,0 +1,193 @@
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Core;
+using Reihitsu.Analyzer.Enumerations;
+
+namespace Reihitsu.Analyzer.Rules.Formatting;
+
+/// <summary>
+/// RH0387: Types should be organized with regions
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class RH0387TypesShouldBeOrganizedWithRegionsAnalyzer : DiagnosticAnalyzerBase<RH0387TypesShouldBeOrganizedWithRegionsAnalyzer>
+{
+    #region Constants
+
+    /// <summary>
+    /// Diagnostic ID
+    /// </summary>
+    public const string DiagnosticId = "RH0387";
+
+    #endregion // Constants
+
+    #region Constructor
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public RH0387TypesShouldBeOrganizedWithRegionsAnalyzer()
+        : base(DiagnosticId, DiagnosticCategory.Formatting, nameof(AnalyzerResources.RH0387Title), nameof(AnalyzerResources.RH0387MessageFormat))
+    {
+    }
+
+    #endregion // Constructor
+
+    #region Methods
+
+    /// <summary>
+    /// Determines whether the directive belongs to the current type declaration
+    /// </summary>
+    /// <param name="typeDeclaration">Type declaration</param>
+    /// <param name="directiveTrivia">Directive trivia</param>
+    /// <returns><see langword="true"/> if the directive belongs to the current type</returns>
+    private static bool BelongsToType(TypeDeclarationSyntax typeDeclaration, SyntaxTrivia directiveTrivia)
+    {
+        if ((directiveTrivia.IsKind(SyntaxKind.RegionDirectiveTrivia) == false
+             && directiveTrivia.IsKind(SyntaxKind.EndRegionDirectiveTrivia) == false)
+            || RegionDirectiveUtilities.IsWithinElementBody(directiveTrivia))
+        {
+            return false;
+        }
+
+        var containingType = directiveTrivia.Token.Parent?.AncestorsAndSelf().OfType<TypeDeclarationSyntax>().FirstOrDefault();
+
+        return containingType == typeDeclaration;
+    }
+
+    /// <summary>
+    /// Gets the top-level region pairs declared for the current type
+    /// </summary>
+    /// <param name="typeDeclaration">Type declaration</param>
+    /// <returns>Region pairs</returns>
+    private static IReadOnlyList<(SyntaxTrivia Region, SyntaxTrivia EndRegion)> GetTopLevelRegions(TypeDeclarationSyntax typeDeclaration)
+    {
+        var regions = new List<(SyntaxTrivia Region, SyntaxTrivia EndRegion)>();
+        var regionStack = new Stack<SyntaxTrivia>();
+
+        foreach (var directiveTrivia in typeDeclaration.DescendantTrivia(descendIntoTrivia: true))
+        {
+            if (BelongsToType(typeDeclaration, directiveTrivia) == false)
+            {
+                continue;
+            }
+
+            if (directiveTrivia.IsKind(SyntaxKind.RegionDirectiveTrivia))
+            {
+                regionStack.Push(directiveTrivia);
+            }
+            else if (regionStack.Count > 0)
+            {
+                regions.Add((regionStack.Pop(), directiveTrivia));
+            }
+        }
+
+        return regions;
+    }
+
+    /// <summary>
+    /// Determines whether the member must be organized by this rule
+    /// </summary>
+    /// <param name="memberDeclaration">Member declaration</param>
+    /// <returns><see langword="true"/> if the member is relevant</returns>
+    private static bool IsRelevantMember(MemberDeclarationSyntax memberDeclaration)
+    {
+        return memberDeclaration is BaseTypeDeclarationSyntax
+                                 or DelegateDeclarationSyntax
+                                 or FieldDeclarationSyntax
+                                 or ConstructorDeclarationSyntax
+                                 or DestructorDeclarationSyntax
+                                 or PropertyDeclarationSyntax
+                                 or IndexerDeclarationSyntax
+                                 or EventDeclarationSyntax
+                                 or EventFieldDeclarationSyntax
+                                 or MethodDeclarationSyntax
+                                 or OperatorDeclarationSyntax
+                                 or ConversionOperatorDeclarationSyntax;
+    }
+
+    /// <summary>
+    /// Determines whether the type is exempt because it only contains properties
+    /// </summary>
+    /// <param name="members">Members</param>
+    /// <returns><see langword="true"/> if the type is exempt</returns>
+    private static bool IsPropertyOnlyType(IReadOnlyList<MemberDeclarationSyntax> members)
+    {
+        return members.Count > 0
+               && members.All(obj => obj is PropertyDeclarationSyntax);
+    }
+
+    /// <summary>
+    /// Determines whether the member is contained in a top-level region
+    /// </summary>
+    /// <param name="memberDeclaration">Member declaration</param>
+    /// <param name="regions">Region pairs</param>
+    /// <returns><see langword="true"/> if contained in a region</returns>
+    private static bool IsWithinRegion(MemberDeclarationSyntax memberDeclaration, IReadOnlyList<(SyntaxTrivia Region, SyntaxTrivia EndRegion)> regions)
+    {
+        return regions.Any(obj => memberDeclaration.SpanStart >= obj.Region.Span.End
+                                  && memberDeclaration.Span.End <= obj.EndRegion.SpanStart);
+    }
+
+    /// <summary>
+    /// Analyze the type declaration
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnTypeDeclaration(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not TypeDeclarationSyntax typeDeclaration)
+        {
+            return;
+        }
+
+        var relevantMembers = typeDeclaration.Members.Where(IsRelevantMember)
+                                                     .ToArray();
+
+        if (relevantMembers.Length == 0
+            || IsPropertyOnlyType(relevantMembers))
+        {
+            return;
+        }
+
+        var distinctMemberKindCount = relevantMembers.Select(OrderingDeclarationUtilities.GetMemberKind)
+                                                     .Distinct()
+                                                     .Count();
+
+        if (distinctMemberKindCount < 2)
+        {
+            return;
+        }
+
+        var regions = GetTopLevelRegions(typeDeclaration);
+
+        if (regions.Count == 0
+            || relevantMembers.Any(memberDeclaration => IsWithinRegion(memberDeclaration, regions) == false))
+        {
+            context.ReportDiagnostic(CreateDiagnostic(typeDeclaration.Identifier.GetLocation()));
+        }
+    }
+
+    #endregion // Methods
+
+    #region DiagnosticAnalyzer
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        base.Initialize(context);
+
+        context.RegisterSyntaxNodeAction(OnTypeDeclaration,
+                                         SyntaxKind.ClassDeclaration,
+                                         SyntaxKind.StructDeclaration,
+                                         SyntaxKind.InterfaceDeclaration,
+                                         SyntaxKind.RecordDeclaration,
+                                         SyntaxKind.RecordStructDeclaration);
+    }
+
+    #endregion // DiagnosticAnalyzer
+}

--- a/Reihitsu.Analyzer/Rules/Naming/RH0225FileScopedNamespaceCasingAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Naming/RH0225FileScopedNamespaceCasingAnalyzer.cs
@@ -38,6 +38,8 @@ public class RH0225FileScopedNamespaceCasingAnalyzer : CasingAnalyzerBase<RH0225
 
     #endregion // Constructor
 
+    #region Methods
+
     /// <summary>
     /// Get all locations and names of the name syntax node
     /// </summary>
@@ -68,6 +70,8 @@ public class RH0225FileScopedNamespaceCasingAnalyzer : CasingAnalyzerBase<RH0225
                 break;
         }
     }
+
+    #endregion // Methods
 
     #region CasingAnalyzerBase
 

--- a/Reihitsu.Analyzer/Rules/Naming/RH0226NamespaceCasingAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Naming/RH0226NamespaceCasingAnalyzer.cs
@@ -38,6 +38,8 @@ public class RH0226NamespaceCasingAnalyzer : CasingAnalyzerBase<RH0226NamespaceC
 
     #endregion // Constructor
 
+    #region Methods
+
     /// <summary>
     /// Get all locations and names of the name syntax node
     /// </summary>
@@ -68,6 +70,8 @@ public class RH0226NamespaceCasingAnalyzer : CasingAnalyzerBase<RH0226NamespaceC
                 break;
         }
     }
+
+    #endregion // Methods
 
     #region CasingAnalyzerBase
 

--- a/Reihitsu.sln
+++ b/Reihitsu.sln
@@ -167,6 +167,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		documentation\rules\RH0384.md = documentation\rules\RH0384.md
 		documentation\rules\RH0385.md = documentation\rules\RH0385.md
 		documentation\rules\RH0386.md = documentation\rules\RH0386.md
+		documentation\rules\RH0387.md = documentation\rules\RH0387.md
 		documentation\rules\RH0401.md = documentation\rules\RH0401.md
 		documentation\rules\RH0402.md = documentation\rules\RH0402.md
 		documentation\rules\RH0403.md = documentation\rules\RH0403.md

--- a/documentation/rules/RH0387.md
+++ b/documentation/rules/RH0387.md
@@ -1,0 +1,76 @@
+# RH0387 — Types should be organized with regions
+
+| Property | Value |
+|----------|-------|
+| **ID** | RH0387 |
+| **Category** | Formatting |
+| **Severity** | Warning |
+| **Code Fix** | ❌ |
+
+## Description
+
+This rule requires types organize members inside `#region` blocks.
+
+## Why is this a problem?
+
+Region-based organization makes it easier to find fields, constructors, methods, nested types, and other members quickly.
+
+## How to fix it
+
+Wrap the direct members of the type in clearly named type-level regions. Property-only types are exempt, but larger types with fields, constructors, methods, nested types, and similar members should use regions such as `Fields`, `Properties`, `Constructors`, and `Methods`.
+
+## Examples
+
+### Violation
+
+```cs
+internal class DataService
+{
+    private string _name;
+
+    public string Name { get; set; }
+
+    public DataService()
+    {
+    }
+
+    public void Save()
+    {
+    }
+}
+```
+
+### Correction
+
+```cs
+internal class DataService
+{
+    #region Fields
+
+    private string _name;
+
+    #endregion // Fields
+
+    #region Properties
+
+    public string Name { get; set; }
+
+    #endregion // Properties
+
+    #region Constructors
+
+    public DataService()
+    {
+    }
+
+    #endregion // Constructors
+
+    #region Methods
+
+    public void Save()
+    {
+    }
+
+    #endregion // Methods
+}
+```


### PR DESCRIPTION
Introduces analyzer RH0387 to require types with multiple member kinds to be organized using #region blocks, exempting property-only types. Includes implementation, localized resources, documentation, solution registration, and comprehensive unit tests. Updates README and adds region markers/method docs to some existing analyzers. No code fix is provided for this rule.