### PR TITLE
Add RH0388: Disallow 'implementation' in region labels

### DIFF
--- a/Reihitsu.Analyzer.Package/README.MD
+++ b/Reihitsu.Analyzer.Package/README.MD
@@ -107,6 +107,7 @@ dotnet add package Reihitsu.Analyzer
 | [RH0385](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0385.md)| Code must not contain mixed line endings.| ✔| ❌|
 | [RH0386](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0386.md)| Region directives must use consistent indentation with containing code.| ✔| ✔|
 | [RH0387](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0387.md)| Types should be organized with regions.| ✔| ❌|
+| [RH0388](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0388.md)| Region descriptions should not end with implementation.| ✔| ❌|
 || **Documentation**|||
 | [RH0401](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0401.md)| The \<inheritdoc/> Tag should be used if possible.| ✔| ✔|
 | [RH0402](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0402.md)| Elements must be documented.| ✔| ❌|

--- a/Reihitsu.Analyzer.Test/Formatting/RH0388RegionDescriptionsShouldNotEndWithImplementationAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH0388RegionDescriptionsShouldNotEndWithImplementationAnalyzerTests.cs
@@ -1,0 +1,107 @@
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Analyzer.Rules.Formatting;
+using Reihitsu.Analyzer.Test.Base;
+
+namespace Reihitsu.Analyzer.Test.Formatting;
+
+/// <summary>
+/// Test methods for <see cref="RH0388RegionDescriptionsShouldNotEndWithImplementationAnalyzer"/>
+/// </summary>
+[TestClass]
+public class RH0388RegionDescriptionsShouldNotEndWithImplementationAnalyzerTests : AnalyzerTestsBase<RH0388RegionDescriptionsShouldNotEndWithImplementationAnalyzer>
+{
+    /// <summary>
+    /// Verifies that concise region descriptions do not produce diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForConciseDescriptions()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    #region Methods
+
+                                    public void DoWork()
+                                    {
+                                    }
+
+                                    #endregion // Methods
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that region descriptions ending with implementation are detected
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyRegionDescriptionsEndingWithImplementationAreDetected()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    {|#0:#region Methods implementation|}
+
+                                    public void DoWork()
+                                    {
+                                    }
+
+                                    {|#1:#endregion // Methods implementation|}
+                                }
+                                """;
+
+        await Verify(testData, Diagnostics(RH0388RegionDescriptionsShouldNotEndWithImplementationAnalyzer.DiagnosticId, AnalyzerResources.RH0388MessageFormat, 2));
+    }
+
+    /// <summary>
+    /// Verifies that case-insensitive implementation suffixes are detected
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyImplementationSuffixIsDetectedCaseInsensitively()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    {|#0:#region IDisposable IMPLEMENTATION|}
+
+                                    public void Dispose()
+                                    {
+                                    }
+
+                                    {|#1:#endregion // IDisposable IMPLEMENTATION|}
+                                }
+                                """;
+
+        await Verify(testData, Diagnostics(RH0388RegionDescriptionsShouldNotEndWithImplementationAnalyzer.DiagnosticId, AnalyzerResources.RH0388MessageFormat, 2));
+    }
+
+    /// <summary>
+    /// Verifies that words merely containing implementation are not detected
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDescriptionsContainingImplementationAsPartOfAnotherWordAreIgnored()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    #region ImplementationDetails
+
+                                    public void DoWork()
+                                    {
+                                    }
+
+                                    #endregion // ImplementationDetails
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+}

--- a/Reihitsu.Analyzer/AnalyzerResources.cs
+++ b/Reihitsu.Analyzer/AnalyzerResources.cs
@@ -975,6 +975,16 @@ internal static class AnalyzerResources
     internal static string RH0387Title => GetString(nameof(RH0387Title));
 
     /// <summary>
+    /// Gets the localized string for RH0388MessageFormat
+    /// </summary>
+    internal static string RH0388MessageFormat => GetString(nameof(RH0388MessageFormat));
+
+    /// <summary>
+    /// Gets the localized string for RH0388Title
+    /// </summary>
+    internal static string RH0388Title => GetString(nameof(RH0388Title));
+
+    /// <summary>
     /// Gets the localized string for RH0334MessageFormat
     /// </summary>
     internal static string RH0334MessageFormat => GetString(nameof(RH0334MessageFormat));

--- a/Reihitsu.Analyzer/AnalyzerResources.resx
+++ b/Reihitsu.Analyzer/AnalyzerResources.resx
@@ -987,6 +987,12 @@
   <data name="RH0387Title" xml:space="preserve">
     <value>Types should be organized with regions</value>
   </data>
+  <data name="RH0388MessageFormat" xml:space="preserve">
+    <value>Region descriptions should not end with implementation.</value>
+  </data>
+  <data name="RH0388Title" xml:space="preserve">
+    <value>Region descriptions should not end with implementation</value>
+  </data>
   <data name="RH0601Title" xml:space="preserve">
     <value>Constants must appear before fields</value>
   </data>

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0388RegionDescriptionsShouldNotEndWithImplementationAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0388RegionDescriptionsShouldNotEndWithImplementationAnalyzer.cs
@@ -1,0 +1,137 @@
+using System;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Enumerations;
+
+namespace Reihitsu.Analyzer.Rules.Formatting;
+
+/// <summary>
+/// Region descriptions should not end with implementation
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class RH0388RegionDescriptionsShouldNotEndWithImplementationAnalyzer : DiagnosticAnalyzerBase<RH0388RegionDescriptionsShouldNotEndWithImplementationAnalyzer>
+{
+    #region Constants
+
+    /// <summary>
+    /// Diagnostic ID
+    /// </summary>
+    public const string DiagnosticId = "RH0388";
+
+    /// <summary>
+    /// Forbidden suffix
+    /// </summary>
+    private const string ForbiddenSuffix = "implementation";
+
+    #endregion // Constants
+
+    #region Constructor
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public RH0388RegionDescriptionsShouldNotEndWithImplementationAnalyzer()
+        : base(DiagnosticId, DiagnosticCategory.Formatting, nameof(AnalyzerResources.RH0388Title), nameof(AnalyzerResources.RH0388MessageFormat))
+    {
+    }
+
+    #endregion // Constructor
+
+    #region Methods
+
+    /// <summary>
+    /// Determines whether the specified description ends with the forbidden suffix
+    /// </summary>
+    /// <param name="description">Description to inspect</param>
+    /// <returns><see langword="true"/> if the suffix is present</returns>
+    private static bool EndsWithForbiddenSuffix(string description)
+    {
+        var trimmedDescription = description.Trim();
+
+        if (trimmedDescription.EndsWith(ForbiddenSuffix, StringComparison.OrdinalIgnoreCase) == false)
+        {
+            return false;
+        }
+
+        return trimmedDescription.Length == ForbiddenSuffix.Length
+               || char.IsWhiteSpace(trimmedDescription[trimmedDescription.Length - ForbiddenSuffix.Length - 1]);
+    }
+
+    /// <summary>
+    /// Gets the description of an endregion directive
+    /// </summary>
+    /// <param name="directive">Directive</param>
+    /// <returns>Description text</returns>
+    private static string GetEndRegionDescription(EndRegionDirectiveTriviaSyntax directive)
+    {
+        var description = (directive.EndRegionKeyword.TrailingTrivia.ToFullString()
+                           + directive.EndOfDirectiveToken.LeadingTrivia.ToFullString()).Trim();
+
+        if (description.StartsWith("//", StringComparison.Ordinal))
+        {
+            description = description.Substring(2).TrimStart();
+        }
+
+        return description;
+    }
+
+    /// <summary>
+    /// Gets the description of a region directive
+    /// </summary>
+    /// <param name="directive">Directive</param>
+    /// <returns>Description text</returns>
+    private static string GetRegionDescription(RegionDirectiveTriviaSyntax directive)
+    {
+        var messageTrivia = directive.EndOfDirectiveToken.LeadingTrivia.FirstOrDefault(static trivia => trivia.IsKind(SyntaxKind.PreprocessingMessageTrivia));
+
+        return messageTrivia == default
+                   ? string.Empty
+                   : messageTrivia.ToString().Trim();
+    }
+
+    /// <summary>
+    /// Analyzes endregion directives
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnEndRegion(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is EndRegionDirectiveTriviaSyntax node
+            && EndsWithForbiddenSuffix(GetEndRegionDescription(node)))
+        {
+            context.ReportDiagnostic(CreateDiagnostic(node.GetLocation()));
+        }
+    }
+
+    /// <summary>
+    /// Analyzes region directives
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnRegion(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is RegionDirectiveTriviaSyntax node
+            && EndsWithForbiddenSuffix(GetRegionDescription(node)))
+        {
+            context.ReportDiagnostic(CreateDiagnostic(node.GetLocation()));
+        }
+    }
+
+    #endregion // Methods
+
+    #region DiagnosticAnalyzer
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        base.Initialize(context);
+
+        context.RegisterSyntaxNodeAction(OnRegion, SyntaxKind.RegionDirectiveTrivia);
+        context.RegisterSyntaxNodeAction(OnEndRegion, SyntaxKind.EndRegionDirectiveTrivia);
+    }
+
+    #endregion // DiagnosticAnalyzer
+}

--- a/Reihitsu.sln
+++ b/Reihitsu.sln
@@ -168,6 +168,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		documentation\rules\RH0385.md = documentation\rules\RH0385.md
 		documentation\rules\RH0386.md = documentation\rules\RH0386.md
 		documentation\rules\RH0387.md = documentation\rules\RH0387.md
+		documentation\rules\RH0388.md = documentation\rules\RH0388.md
 		documentation\rules\RH0401.md = documentation\rules\RH0401.md
 		documentation\rules\RH0402.md = documentation\rules\RH0402.md
 		documentation\rules\RH0403.md = documentation\rules\RH0403.md

--- a/documentation/rules/RH0388.md
+++ b/documentation/rules/RH0388.md
@@ -1,0 +1,52 @@
+# RH0388 — Region descriptions should not end with implementation
+
+| Property | Value |
+|----------|-------|
+| **ID** | RH0388 |
+| **Category** | Formatting |
+| **Severity** | Warning |
+| **Code Fix** | ❌ |
+
+## Description
+
+This rule disallows `#region` and `#endregion` descriptions that end with the word `implementation`.
+
+## Why is this a problem?
+
+The word `implementation` does not usually add useful information to a region label. It makes region names longer without helping the reader understand what the region groups.
+
+## How to fix it
+
+Remove the trailing `implementation` word and keep only the meaningful part of the region description. Make the `#endregion` comment match the updated `#region` text.
+
+## Examples
+
+### Violation
+
+```cs
+internal class Example
+{
+    #region IDisposable implementation
+
+    public void Dispose()
+    {
+    }
+
+    #endregion // IDisposable implementation
+}
+```
+
+### Correction
+
+```cs
+internal class Example
+{
+    #region IDisposable
+
+    public void Dispose()
+    {
+    }
+
+    #endregion // IDisposable
+}
+```


### PR DESCRIPTION
Introduces analyzer RH0388 to warn when #region or #endregion descriptions end with "implementation". Includes analyzer logic, localized resources, comprehensive unit tests, rule documentation, and updates to the solution and README.