### PR TITLE
Add RH0389 analyzer: enforce 4-space indentation

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -3,15 +3,18 @@ project_name: "Reihitsu"
 
 
 # list of languages for which language servers are started; choose from:
-#   al                  bash                clojure             cpp                 csharp
-#   csharp_omnisharp    dart                elixir              elm                 erlang
-#   fortran             fsharp              go                  groovy              haskell
-#   java                julia               kotlin              lua                 markdown
-#   matlab              nix                 pascal              perl                php
-#   php_phpactor        powershell          python              python_jedi         r
-#   rego                ruby                ruby_solargraph     rust                scala
-#   swift               terraform           toml                typescript          typescript_vts
-#   vue                 yaml                zig
+#   al                  ansible             bash                clojure             cpp
+#   cpp_ccls            crystal             csharp              csharp_omnisharp    dart
+#   elixir              elm                 erlang              fortran             fsharp
+#   go                  groovy              haskell             haxe                hlsl
+#   java                json                julia               kotlin              lean4
+#   lua                 luau                markdown            matlab              msl
+#   nix                 ocaml               pascal              perl                php
+#   php_phpactor        powershell          python              python_jedi         python_ty
+#   r                   rego                ruby                ruby_solargraph     rust
+#   scala               solidity            swift               systemverilog       terraform
+#   toml                typescript          typescript_vts      vue                 yaml
+#   zig
 #   (This list may be outdated. For the current list, see values of Language enum here:
 #   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
 #   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
@@ -59,53 +62,17 @@ read_only: false
 
 # list of tool names to exclude.
 # This extends the existing exclusions (e.g. from the global configuration)
-#
-# Below is the complete list of tools for convenience.
-# To make sure you have the latest list of tools, and to view their descriptions, 
-# execute `uv run scripts/print_tool_overview.py`.
-#
-#  * `activate_project`: Activates a project by name.
-#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
-#  * `create_text_file`: Creates/overwrites a file in the project directory.
-#  * `delete_lines`: Deletes a range of lines within a file.
-#  * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
-#  * `execute_shell_command`: Executes a shell command.
-#  * `find_referencing_code_snippets`: Finds code snippets in which the symbol at the given location is referenced.
-#  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
-#  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
-#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
-#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
-#  * `initial_instructions`: Gets the initial instructions for the current project.
-#     Should only be used in settings where the system prompt cannot be set,
-#     e.g. in clients you have no control over, like Claude Desktop.
-#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
-#  * `insert_at_line`: Inserts content at a given line in a file.
-#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
-#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
-#  * `list_memories`: Lists memories in Serena's project-specific memory store.
-#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
-#  * `prepare_for_new_conversation`: Provides instructions for preparing for a new conversation (in order to continue with the necessary context).
-#  * `read_file`: Reads a file within the project directory.
-#  * `read_memory`: Reads the memory with the given name from Serena's project-specific memory store.
-#  * `remove_project`: Removes a project from the Serena configuration.
-#  * `replace_lines`: Replaces a range of lines within a file with new content.
-#  * `replace_symbol_body`: Replaces the full definition of a symbol.
-#  * `restart_language_server`: Restarts the language server, may be necessary when edits not through Serena happen.
-#  * `search_for_pattern`: Performs a search for a pattern in the project.
-#  * `summarize_changes`: Provides instructions for summarizing the changes made to the codebase.
-#  * `switch_modes`: Activates modes by providing a list of their names
-#  * `think_about_collected_information`: Thinking tool for pondering the completeness of collected information.
-#  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
-#  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
-#  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 excluded_tools: []
 
 # list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
 # This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 included_optional_tools: []
 
 # fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
 # This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 fixed_tools: []
 
 # list of mode names to that are always to be included in the set of active modes
@@ -116,11 +83,14 @@ fixed_tools: []
 # Set this to a list of mode names to always include the respective modes for this project.
 base_modes:
 
-# list of mode names that are to be activated by default.
-# The full set of modes to be activated is base_modes + default_modes.
-# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
 # Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
 # This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 default_modes:
 
 # initial prompt for the project. It will always be given to the LLM upon activating the project
@@ -150,3 +120,8 @@ ignored_memory_patterns: []
 # Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
 # No documentation on options means no options are available.
 ls_specific_settings: {}
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:

--- a/Reihitsu.Analyzer.CodeFixes/CodeFixResources.cs
+++ b/Reihitsu.Analyzer.CodeFixes/CodeFixResources.cs
@@ -414,6 +414,11 @@ internal static class CodeFixResources
     internal static string RH0386Title => GetString(nameof(RH0386Title));
 
     /// <summary>
+    /// Gets the localized string for RH0389Title
+    /// </summary>
+    internal static string RH0389Title => GetString(nameof(RH0389Title));
+
+    /// <summary>
     /// Gets the localized string for RH0334Title
     /// </summary>
     internal static string RH0334Title => GetString(nameof(RH0334Title));

--- a/Reihitsu.Analyzer.CodeFixes/CodeFixResources.resx
+++ b/Reihitsu.Analyzer.CodeFixes/CodeFixResources.resx
@@ -513,6 +513,9 @@
   <data name="RH0386Title" xml:space="preserve">
     <value>Normalize region directive indentation</value>
   </data>
+  <data name="RH0389Title" xml:space="preserve">
+    <value>Normalize indentation</value>
+  </data>
   <data name="RH0601Title" xml:space="preserve">
     <value>Move constant field</value>
   </data>

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0389IndentationMustUseFourSpacesPerScopeLevelCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0389IndentationMustUseFourSpacesPerScopeLevelCodeFixProvider.cs
@@ -1,0 +1,66 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+using Reihitsu.Formatter;
+
+namespace Reihitsu.Analyzer.Rules.Formatting;
+
+/// <summary>
+/// Code fix provider for <see cref="RH0389IndentationMustUseFourSpacesPerScopeLevelAnalyzer"/>
+/// </summary>
+[Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(RH0389IndentationMustUseFourSpacesPerScopeLevelCodeFixProvider))]
+public class RH0389IndentationMustUseFourSpacesPerScopeLevelCodeFixProvider : CodeFixProvider
+{
+    #region Methods
+
+    /// <summary>
+    /// Applies the code fix
+    /// </summary>
+    /// <param name="document">Document</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The updated document</returns>
+    private static async Task<Document> ApplyCodeFixAsync(Document document, CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+        return root == null
+                   ? document
+                   : await ReihitsuFormatter.FormatNodeInDocumentAsync(document, root, cancellationToken).ConfigureAwait(false);
+    }
+
+    #endregion // Methods
+
+    #region CodeFixProvider
+
+    /// <inheritdoc/>
+    public sealed override ImmutableArray<string> FixableDiagnosticIds => [RH0389IndentationMustUseFourSpacesPerScopeLevelAnalyzer.DiagnosticId];
+
+    /// <inheritdoc/>
+    public sealed override FixAllProvider GetFixAllProvider()
+    {
+        return WellKnownFixAllProviders.BatchFixer;
+    }
+
+    /// <inheritdoc/>
+    public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            context.RegisterCodeFix(CodeAction.Create(CodeFixResources.RH0389Title,
+                                                      token => ApplyCodeFixAsync(context.Document, token),
+                                                      nameof(RH0389IndentationMustUseFourSpacesPerScopeLevelCodeFixProvider)),
+                                    diagnostic);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    #endregion // CodeFixProvider
+}

--- a/Reihitsu.Analyzer.Package/README.MD
+++ b/Reihitsu.Analyzer.Package/README.MD
@@ -108,6 +108,7 @@ dotnet add package Reihitsu.Analyzer
 | [RH0386](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0386.md)| Region directives must use consistent indentation with containing code.| ✔| ✔|
 | [RH0387](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0387.md)| Types should be organized with regions.| ✔| ❌|
 | [RH0388](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0388.md)| Region descriptions should not end with implementation.| ✔| ❌|
+| [RH0389](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0389.md)| Indentation must use 4 spaces per scope level.| ✔| ✔|
 || **Documentation**|||
 | [RH0401](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0401.md)| The \<inheritdoc/> Tag should be used if possible.| ✔| ✔|
 | [RH0402](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0402.md)| Elements must be documented.| ✔| ❌|

--- a/Reihitsu.Analyzer.Test/Formatting/RH0389IndentationMustUseFourSpacesPerScopeLevelAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH0389IndentationMustUseFourSpacesPerScopeLevelAnalyzerTests.cs
@@ -1,0 +1,267 @@
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Analyzer.Rules.Formatting;
+using Reihitsu.Analyzer.Test.Base;
+
+namespace Reihitsu.Analyzer.Test.Formatting;
+
+/// <summary>
+/// Test methods for <see cref="RH0389IndentationMustUseFourSpacesPerScopeLevelAnalyzer"/> and <see cref="RH0389IndentationMustUseFourSpacesPerScopeLevelCodeFixProvider"/>
+/// </summary>
+[TestClass]
+public class RH0389IndentationMustUseFourSpacesPerScopeLevelAnalyzerTests : AnalyzerTestsBase<RH0389IndentationMustUseFourSpacesPerScopeLevelAnalyzer, RH0389IndentationMustUseFourSpacesPerScopeLevelCodeFixProvider>
+{
+    /// <summary>
+    /// Verifies that clean indentation does not produce diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenIndentationIsConsistent()
+    {
+        const string testData = """
+                                internal class Example
+                                {
+                                    #region Members
+
+                                    /// <summary>
+                                    /// Gets a value.
+                                    /// </summary>
+                                    internal bool Value
+                                    {
+                                        get
+                                        {
+                                            // Comment
+                                            return true;
+                                        }
+                                    }
+
+                                    #endregion // Members
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that lines within multi-line strings are ignored
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForMultiLineStrings()
+    {
+        const string testData = """
+                                internal class Example
+                                {
+                                    internal void Method()
+                                    {
+                                        var text = @"first
+                                  second";
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that member indentation is detected and fixed
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyMemberIndentationIsDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class Example
+                                {
+                                  {|#0:internal|} bool Value
+                                    {
+                                        get;
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class Example
+                                 {
+                                     internal bool Value
+                                     {
+                                         get;
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData,
+                     fixedData,
+                     Diagnostics(RH0389IndentationMustUseFourSpacesPerScopeLevelAnalyzer.DiagnosticId, AnalyzerResources.RH0389MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that nested statement indentation is detected and fixed
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNestedStatementIndentationIsDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class Example
+                                {
+                                    internal bool Method()
+                                    {
+                                         {|#0:return|} false;
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class Example
+                                 {
+                                     internal bool Method()
+                                     {
+                                         return false;
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData,
+                     fixedData,
+                     Diagnostics(RH0389IndentationMustUseFourSpacesPerScopeLevelAnalyzer.DiagnosticId, AnalyzerResources.RH0389MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that accessor indentation is detected and fixed
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyAccessorIndentationIsDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class Example
+                                {
+                                    internal bool Value
+                                    {
+                                      {|#0:get|};
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class Example
+                                 {
+                                     internal bool Value
+                                     {
+                                         get;
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData,
+                     fixedData,
+                     Diagnostics(RH0389IndentationMustUseFourSpacesPerScopeLevelAnalyzer.DiagnosticId, AnalyzerResources.RH0389MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that region indentation is detected and fixed
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyRegionIndentationIsDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class Example
+                                {
+                                  {|#0:#region Members|}
+
+                                    internal bool Value => true;
+
+                                    #endregion // Members
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class Example
+                                 {
+                                     #region Members
+
+                                     internal bool Value => true;
+
+                                     #endregion // Members
+                                 }
+                                 """;
+
+        await Verify(testData,
+                     fixedData,
+                     Diagnostics(RH0389IndentationMustUseFourSpacesPerScopeLevelAnalyzer.DiagnosticId, AnalyzerResources.RH0389MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that comment indentation is detected and fixed
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCommentIndentationIsDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class Example
+                                {
+                                    internal void Method()
+                                    {
+                                      {|#0:// Comment|}
+                                        return;
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class Example
+                                 {
+                                     internal void Method()
+                                     {
+                                         // Comment
+                                         return;
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData,
+                     fixedData,
+                     Diagnostics(RH0389IndentationMustUseFourSpacesPerScopeLevelAnalyzer.DiagnosticId, AnalyzerResources.RH0389MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that multiple indentation issues are detected and fixed together
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyMultipleIndentationIssuesAreDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class Example
+                                {
+                                  {|#0:#region Members|}
+
+                                  {|#1:internal|} bool Method()
+                                  {|#2:{|}
+                                     {|#3:// Comment|}
+                                     {|#4:return|} false;
+                                  {|#5:}|}
+
+                                    #endregion // Members
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class Example
+                                 {
+                                     #region Members
+
+                                     internal bool Method()
+                                     {
+                                         // Comment
+                                         return false;
+                                     }
+
+                                     #endregion // Members
+                                 }
+                                 """;
+
+        await Verify(testData,
+                     fixedData,
+                     Diagnostics(RH0389IndentationMustUseFourSpacesPerScopeLevelAnalyzer.DiagnosticId, AnalyzerResources.RH0389MessageFormat, 6));
+    }
+}

--- a/Reihitsu.Analyzer/AnalyzerResources.cs
+++ b/Reihitsu.Analyzer/AnalyzerResources.cs
@@ -985,6 +985,16 @@ internal static class AnalyzerResources
     internal static string RH0388Title => GetString(nameof(RH0388Title));
 
     /// <summary>
+    /// Gets the localized string for RH0389MessageFormat
+    /// </summary>
+    internal static string RH0389MessageFormat => GetString(nameof(RH0389MessageFormat));
+
+    /// <summary>
+    /// Gets the localized string for RH0389Title
+    /// </summary>
+    internal static string RH0389Title => GetString(nameof(RH0389Title));
+
+    /// <summary>
     /// Gets the localized string for RH0334MessageFormat
     /// </summary>
     internal static string RH0334MessageFormat => GetString(nameof(RH0334MessageFormat));

--- a/Reihitsu.Analyzer/AnalyzerResources.resx
+++ b/Reihitsu.Analyzer/AnalyzerResources.resx
@@ -993,6 +993,12 @@
   <data name="RH0388Title" xml:space="preserve">
     <value>Region descriptions should not end with implementation</value>
   </data>
+  <data name="RH0389MessageFormat" xml:space="preserve">
+    <value>Indentation must use 4 spaces per scope level.</value>
+  </data>
+  <data name="RH0389Title" xml:space="preserve">
+    <value>Indentation must use 4 spaces per scope level</value>
+  </data>
   <data name="RH0601Title" xml:space="preserve">
     <value>Constants must appear before fields</value>
   </data>

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0389IndentationMustUseFourSpacesPerScopeLevelAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0389IndentationMustUseFourSpacesPerScopeLevelAnalyzer.cs
@@ -1,0 +1,483 @@
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+
+using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Core;
+using Reihitsu.Analyzer.Enumerations;
+
+namespace Reihitsu.Analyzer.Rules.Formatting;
+
+/// <summary>
+/// RH0389: Indentation must use 4 spaces per scope level
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class RH0389IndentationMustUseFourSpacesPerScopeLevelAnalyzer : DiagnosticAnalyzerBase<RH0389IndentationMustUseFourSpacesPerScopeLevelAnalyzer>
+{
+    #region Constants
+
+    /// <summary>
+    /// Diagnostic ID
+    /// </summary>
+    public const string DiagnosticId = "RH0389";
+
+    /// <summary>
+    /// Indent size
+    /// </summary>
+    private const int IndentSize = 4;
+
+    #endregion // Constants
+
+    #region Constructor
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public RH0389IndentationMustUseFourSpacesPerScopeLevelAnalyzer()
+        : base(DiagnosticId, DiagnosticCategory.Formatting, nameof(AnalyzerResources.RH0389Title), nameof(AnalyzerResources.RH0389MessageFormat))
+    {
+    }
+
+    #endregion // Constructor
+
+    #region Methods
+
+    /// <summary>
+    /// Aligns comments to the indentation of the token they precede
+    /// </summary>
+    /// <param name="root">Syntax root</param>
+    /// <param name="expectedIndentationByLine">Expected indentation by line</param>
+    private static void AlignCommentIndentation(SyntaxNode root, Dictionary<int, (int Indentation, Location Location)> expectedIndentationByLine)
+    {
+        foreach (var token in root.DescendantTokens())
+        {
+            var tokenLine = GetLine(token);
+
+            if (expectedIndentationByLine.TryGetValue(tokenLine, out var expectation) == false)
+            {
+                continue;
+            }
+
+            var alignColumn = expectation.Indentation;
+
+            if (token.IsKind(SyntaxKind.CloseBraceToken))
+            {
+                alignColumn += IndentSize;
+            }
+
+            foreach (var trivia in token.LeadingTrivia)
+            {
+                if (IsComment(trivia) == false)
+                {
+                    continue;
+                }
+
+                var commentLine = trivia.GetLocation().GetLineSpan().StartLinePosition.Line;
+
+                if (commentLine != tokenLine)
+                {
+                    expectedIndentationByLine[commentLine] = (alignColumn, trivia.GetLocation());
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Builds the expected indentation by line
+    /// </summary>
+    /// <param name="root">Syntax root</param>
+    /// <returns>Expected indentation by line</returns>
+    private static Dictionary<int, (int Indentation, Location Location)> BuildExpectedIndentationMap(SyntaxNode root)
+    {
+        var expectedIndentationByLine = new Dictionary<int, (int Indentation, Location Location)>();
+
+        ComputeBlockIndentation(root, 0, expectedIndentationByLine);
+        AlignCommentIndentation(root, expectedIndentationByLine);
+
+        return expectedIndentationByLine;
+    }
+
+    /// <summary>
+    /// Computes block indentation recursively
+    /// </summary>
+    /// <param name="node">Current node</param>
+    /// <param name="indentLevel">Current indent level</param>
+    /// <param name="expectedIndentationByLine">Expected indentation by line</param>
+    private static void ComputeBlockIndentation(SyntaxNode node, int indentLevel, Dictionary<int, (int Indentation, Location Location)> expectedIndentationByLine)
+    {
+        if (node is BlockSyntax { Parent: AnonymousFunctionExpressionSyntax })
+        {
+            return;
+        }
+
+        var braceRange = GetIndentingBraceRange(node);
+        var isSwitchSection = node is SwitchSectionSyntax;
+
+        foreach (var child in node.ChildNodesAndTokens())
+        {
+            var childIndent = GetChildIndentLevel(child, indentLevel, braceRange, isSwitchSection);
+
+            if (child.IsToken)
+            {
+                var token = child.AsToken();
+
+                SetDirectiveIndentation(token, indentLevel, braceRange, expectedIndentationByLine);
+                SetTokenIndentation(token, childIndent, expectedIndentationByLine);
+
+                continue;
+            }
+
+            ComputeBlockIndentation(child.AsNode(), childIndent, expectedIndentationByLine);
+        }
+    }
+
+    /// <summary>
+    /// Gets the child indentation level
+    /// </summary>
+    /// <param name="child">Child node or token</param>
+    /// <param name="indentLevel">Current indent level</param>
+    /// <param name="braceRange">Brace range</param>
+    /// <param name="isSwitchSection"><see langword="true"/> if the parent is a switch section</param>
+    /// <returns>The child indentation level</returns>
+    private static int GetChildIndentLevel(SyntaxNodeOrToken child, int indentLevel, (int OpenEnd, int CloseStart)? braceRange, bool isSwitchSection)
+    {
+        var childIndent = indentLevel;
+
+        if (IsInsideBraceRange(child.SpanStart, braceRange))
+        {
+            childIndent = indentLevel + 1;
+        }
+
+        if (isSwitchSection
+            && child.IsNode
+            && child.AsNode() is StatementSyntax)
+        {
+            childIndent = indentLevel + 1;
+        }
+
+        return childIndent;
+    }
+
+    /// <summary>
+    /// Gets the 0-based line number of a token
+    /// </summary>
+    /// <param name="token">Token</param>
+    /// <returns>Line number</returns>
+    private static int GetLine(SyntaxToken token)
+    {
+        return token.GetLocation().GetLineSpan().StartLinePosition.Line;
+    }
+
+    /// <summary>
+    /// Gets the brace range of indenting constructs
+    /// </summary>
+    /// <param name="node">Node</param>
+    /// <returns>Brace range</returns>
+    private static (int OpenEnd, int CloseStart)? GetIndentingBraceRange(SyntaxNode node)
+    {
+        SyntaxToken openBrace;
+        SyntaxToken closeBrace;
+
+        switch (node)
+        {
+            case NamespaceDeclarationSyntax namespaceDeclaration:
+                {
+                    openBrace = namespaceDeclaration.OpenBraceToken;
+                    closeBrace = namespaceDeclaration.CloseBraceToken;
+                }
+                break;
+
+            case BaseTypeDeclarationSyntax typeDeclaration:
+                {
+                    openBrace = typeDeclaration.OpenBraceToken;
+                    closeBrace = typeDeclaration.CloseBraceToken;
+                }
+                break;
+
+            case BlockSyntax block:
+                {
+                    openBrace = block.OpenBraceToken;
+                    closeBrace = block.CloseBraceToken;
+                }
+                break;
+
+            case SwitchStatementSyntax switchStatement:
+                {
+                    openBrace = switchStatement.OpenBraceToken;
+                    closeBrace = switchStatement.CloseBraceToken;
+                }
+                break;
+
+            case AccessorListSyntax accessorList:
+                {
+                    openBrace = accessorList.OpenBraceToken;
+                    closeBrace = accessorList.CloseBraceToken;
+                }
+                break;
+
+            default:
+                {
+                    return null;
+                }
+        }
+
+        if (openBrace.IsMissing || closeBrace.IsMissing)
+        {
+            return null;
+        }
+
+        return (openBrace.Span.End, closeBrace.SpanStart);
+    }
+
+    /// <summary>
+    /// Determines whether a trivia is a comment
+    /// </summary>
+    /// <param name="trivia">Trivia</param>
+    /// <returns><see langword="true"/> if the trivia is a comment</returns>
+    private static bool IsComment(SyntaxTrivia trivia)
+    {
+        return trivia.IsKind(SyntaxKind.SingleLineCommentTrivia)
+               || trivia.IsKind(SyntaxKind.MultiLineCommentTrivia)
+               || trivia.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia)
+               || trivia.IsKind(SyntaxKind.MultiLineDocumentationCommentTrivia);
+    }
+
+    /// <summary>
+    /// Determines whether the position is within the specified brace range
+    /// </summary>
+    /// <param name="position">Position</param>
+    /// <param name="braceRange">Brace range</param>
+    /// <returns><see langword="true"/> if the position is inside the brace range</returns>
+    private static bool IsInsideBraceRange(int position, (int OpenEnd, int CloseStart)? braceRange)
+    {
+        if (braceRange == null)
+        {
+            return false;
+        }
+
+        var (openEnd, closeStart) = braceRange.Value;
+
+        return position >= openEnd && position < closeStart;
+    }
+
+    /// <summary>
+    /// Determines whether the specified token is the first token on its line
+    /// </summary>
+    /// <param name="token">Token</param>
+    /// <returns><see langword="true"/> if the token starts a line</returns>
+    private static bool IsFirstOnLine(SyntaxToken token)
+    {
+        if (token.IsKind(SyntaxKind.None))
+        {
+            return false;
+        }
+
+        var previousToken = token.GetPreviousToken();
+
+        if (previousToken == default || previousToken.IsKind(SyntaxKind.None))
+        {
+            return true;
+        }
+
+        foreach (var trivia in token.LeadingTrivia)
+        {
+            if (trivia.IsKind(SyntaxKind.EndOfLineTrivia))
+            {
+                return true;
+            }
+        }
+
+        foreach (var trivia in previousToken.TrailingTrivia)
+        {
+            if (trivia.IsKind(SyntaxKind.EndOfLineTrivia))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether the specified trivia is a region directive
+    /// </summary>
+    /// <param name="trivia">Trivia</param>
+    /// <returns><see langword="true"/> if the trivia is a region directive</returns>
+    private static bool IsRegionDirective(SyntaxTrivia trivia)
+    {
+        return trivia.IsKind(SyntaxKind.RegionDirectiveTrivia)
+               || trivia.IsKind(SyntaxKind.EndRegionDirectiveTrivia);
+    }
+
+    /// <summary>
+    /// Determines whether a first-on-line token should participate in scope indentation analysis
+    /// </summary>
+    /// <param name="token">Token</param>
+    /// <returns><see langword="true"/> if the token begins a scope-relevant line</returns>
+    private static bool ShouldAnalyzeToken(SyntaxToken token)
+    {
+        if (token.IsKind(SyntaxKind.OpenBraceToken) || token.IsKind(SyntaxKind.CloseBraceToken))
+        {
+            return token.Parent != null && GetIndentingBraceRange(token.Parent) != null;
+        }
+
+        if (token.Parent == null || token.Parent.GetFirstToken() != token)
+        {
+            return false;
+        }
+
+        return token.Parent is BaseNamespaceDeclarationSyntax
+               || token.Parent is MemberDeclarationSyntax
+               || token.Parent is EnumMemberDeclarationSyntax
+               || token.Parent is StatementSyntax
+               || token.Parent is AccessorDeclarationSyntax
+               || token.Parent is ElseClauseSyntax
+               || token.Parent is CatchClauseSyntax
+               || token.Parent is FinallyClauseSyntax
+               || token.Parent is SwitchLabelSyntax;
+    }
+
+    /// <summary>
+    /// Sets the indentation for region directives
+    /// </summary>
+    /// <param name="token">Token</param>
+    /// <param name="indentLevel">Current indent level</param>
+    /// <param name="braceRange">Brace range</param>
+    /// <param name="expectedIndentationByLine">Expected indentation by line</param>
+    private static void SetDirectiveIndentation(SyntaxToken token, int indentLevel, (int OpenEnd, int CloseStart)? braceRange, Dictionary<int, (int Indentation, Location Location)> expectedIndentationByLine)
+    {
+        foreach (var trivia in token.LeadingTrivia)
+        {
+            if (IsRegionDirective(trivia) == false)
+            {
+                continue;
+            }
+
+            var directiveIndentLevel = IsInsideBraceRange(trivia.SpanStart, braceRange)
+                                           ? indentLevel + 1
+                                           : indentLevel;
+            var directiveLine = trivia.GetLocation().GetLineSpan().StartLinePosition.Line;
+
+            expectedIndentationByLine[directiveLine] = (directiveIndentLevel * IndentSize, trivia.GetLocation());
+        }
+    }
+
+    /// <summary>
+    /// Sets the indentation for first-on-line tokens
+    /// </summary>
+    /// <param name="token">Token</param>
+    /// <param name="indentLevel">Indent level</param>
+    /// <param name="expectedIndentationByLine">Expected indentation by line</param>
+    private static void SetTokenIndentation(SyntaxToken token, int indentLevel, Dictionary<int, (int Indentation, Location Location)> expectedIndentationByLine)
+    {
+        if (IsFirstOnLine(token)
+            && ShouldAnalyzeToken(token))
+        {
+            expectedIndentationByLine[GetLine(token)] = (indentLevel * IndentSize, token.GetLocation());
+        }
+    }
+
+    /// <summary>
+    /// Tries to read the indentation at the start of a line
+    /// </summary>
+    /// <param name="lineText">Line text</param>
+    /// <param name="indentation">Indentation width</param>
+    /// <param name="firstSignificantIndex">Index of the first non-whitespace character</param>
+    /// <returns><see langword="true"/> if the line uses only spaces for indentation</returns>
+    private static bool TryGetActualIndentation(string lineText, out int indentation, out int firstSignificantIndex)
+    {
+        indentation = 0;
+        firstSignificantIndex = 0;
+
+        while (firstSignificantIndex < lineText.Length)
+        {
+            var currentCharacter = lineText[firstSignificantIndex];
+
+            if (currentCharacter == '\uFEFF')
+            {
+                firstSignificantIndex++;
+
+                continue;
+            }
+
+            if (currentCharacter == ' ')
+            {
+                indentation++;
+                firstSignificantIndex++;
+
+                continue;
+            }
+
+            if (currentCharacter == '\t')
+            {
+                return false;
+            }
+
+            if (char.IsWhiteSpace(currentCharacter))
+            {
+                indentation++;
+                firstSignificantIndex++;
+
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Analyzes the syntax tree
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnSyntaxTree(SyntaxTreeAnalysisContext context)
+    {
+        var root = context.Tree.GetRoot(context.CancellationToken);
+        var sourceText = context.Tree.GetText(context.CancellationToken);
+        var stringLineIndices = FormattingTextAnalysisUtilities.GetStringLineIndices(root, sourceText);
+        var expectedIndentationByLine = BuildExpectedIndentationMap(root);
+
+        foreach (var pair in expectedIndentationByLine)
+        {
+            if (stringLineIndices.Contains(pair.Key))
+            {
+                continue;
+            }
+
+            var line = sourceText.Lines[pair.Key];
+            var lineText = FormattingTextAnalysisUtilities.GetLineText(sourceText, line);
+
+            if (string.IsNullOrWhiteSpace(lineText))
+            {
+                continue;
+            }
+
+            if (TryGetActualIndentation(lineText, out var actualIndentation, out var firstSignificantIndex) == false
+                || actualIndentation == pair.Value.Indentation)
+            {
+                continue;
+            }
+
+            context.ReportDiagnostic(CreateDiagnostic(pair.Value.Location));
+        }
+    }
+
+    #endregion // Methods
+
+    #region DiagnosticAnalyzer
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        base.Initialize(context);
+
+        context.RegisterSyntaxTreeAction(OnSyntaxTree);
+    }
+
+    #endregion // DiagnosticAnalyzer
+}

--- a/Reihitsu.sln
+++ b/Reihitsu.sln
@@ -169,6 +169,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		documentation\rules\RH0386.md = documentation\rules\RH0386.md
 		documentation\rules\RH0387.md = documentation\rules\RH0387.md
 		documentation\rules\RH0388.md = documentation\rules\RH0388.md
+		documentation\rules\RH0389.md = documentation\rules\RH0389.md
 		documentation\rules\RH0401.md = documentation\rules\RH0401.md
 		documentation\rules\RH0402.md = documentation\rules\RH0402.md
 		documentation\rules\RH0403.md = documentation\rules\RH0403.md

--- a/documentation/rules/RH0389.md
+++ b/documentation/rules/RH0389.md
@@ -1,0 +1,46 @@
+# RH0389 — Indentation must use 4 spaces per scope level
+
+| Property | Value |
+|----------|-------|
+| **ID** | RH0389 |
+| **Category** | Formatting |
+| **Severity** | Warning |
+| **Code Fix** | ✓ |
+
+## Description
+
+This rule requires each scope level to add exactly 4 spaces of indentation.
+
+## Why is this a problem?
+
+Inconsistent indentation makes nested code harder to scan and understand. When members, blocks, regions, or comments drift away from their expected scope level, the visual structure of the file becomes unclear.
+
+## How to fix it
+
+Indent each nested scope by 4 additional spaces. Keep comments and region directives aligned with the code they belong to, or apply the provided code fix to normalize the indentation.
+
+## Examples
+
+### Violation
+
+```cs
+public class Example
+{
+  public bool Foo()
+  {
+     return false;
+  }
+}
+```
+
+### Correction
+
+```cs
+public class Example
+{
+    public bool Foo()
+    {
+        return false;
+    }
+}
+```


### PR DESCRIPTION
Introduces RH0389 analyzer and code fix to require 4 spaces per scope level. Includes implementation, tests, resource strings, and documentation. Updates README and solution file. Also improves project.yml language/tool/mode documentation (unrelated to analyzer).