### PR TITLE
Add RH0390: group using directives analyzer and code fix

### DIFF
--- a/Reihitsu.Analyzer.CodeFixes/CodeFixResources.cs
+++ b/Reihitsu.Analyzer.CodeFixes/CodeFixResources.cs
@@ -709,6 +709,11 @@ internal static class CodeFixResources
     internal static string RH0614Title => GetString(nameof(RH0614Title));
 
     /// <summary>
+    /// Gets the localized string for RH0390Title
+    /// </summary>
+    internal static string RH0390Title => GetString(nameof(RH0390Title));
+
+    /// <summary>
     /// Gets the localized string for RH0439Title
     /// </summary>
     internal static string RH0439Title => GetString(nameof(RH0439Title));

--- a/Reihitsu.Analyzer.CodeFixes/CodeFixResources.resx
+++ b/Reihitsu.Analyzer.CodeFixes/CodeFixResources.resx
@@ -558,4 +558,7 @@
   <data name="RH0614Title" xml:space="preserve">
     <value>Sort using directives</value>
   </data>
+  <data name="RH0390Title" xml:space="preserve">
+    <value>Organize using directives into groups</value>
+  </data>
 </root>

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0390UsingDirectivesShouldBeOrganizedIntoGroupsCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0390UsingDirectivesShouldBeOrganizedIntoGroupsCodeFixProvider.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Reihitsu.Analyzer.Rules.Formatting;
+
+/// <summary>
+/// Code fix provider for <see cref="RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer"/>
+/// </summary>
+[Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(RH0390UsingDirectivesShouldBeOrganizedIntoGroupsCodeFixProvider))]
+public class RH0390UsingDirectivesShouldBeOrganizedIntoGroupsCodeFixProvider : CodeFixProvider
+{
+    #region Methods
+
+    /// <summary>
+    /// Applies the code fix by reorganizing using directives into groups
+    /// </summary>
+    /// <param name="document">Document</param>
+    /// <param name="scope">Compilation unit or namespace declaration</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The updated document</returns>
+    private static async Task<Document> ApplyCodeFixAsync(Document document, SyntaxNode scope, CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+        if (root == null)
+        {
+            return document;
+        }
+
+        var usings = GetUsings(scope);
+
+        if (usings.Count < 2)
+        {
+            return document;
+        }
+
+        var organizedUsings = OrganizeUsings(usings);
+        var updatedScope = WithUsings(scope, organizedUsings);
+        var updatedRoot = root.ReplaceNode(scope, updatedScope);
+
+        return document.WithSyntaxRoot(updatedRoot);
+    }
+
+    /// <summary>
+    /// Gets the indentation trivia (whitespace only) from the given leading trivia
+    /// </summary>
+    /// <param name="leadingTrivia">Leading trivia to extract indentation from</param>
+    /// <returns>Trivia list containing only the indentation whitespace</returns>
+    private static SyntaxTriviaList GetIndentationTrivia(SyntaxTriviaList leadingTrivia)
+    {
+        var result = new List<SyntaxTrivia>();
+
+        for (var i = leadingTrivia.Count - 1; i >= 0; i--)
+        {
+            if (leadingTrivia[i].IsKind(SyntaxKind.WhitespaceTrivia))
+            {
+                result.Insert(0, leadingTrivia[i]);
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        return SyntaxFactory.TriviaList(result);
+    }
+
+    /// <summary>
+    /// Gets the using directives from the given scope node
+    /// </summary>
+    /// <param name="scope">Compilation unit or namespace declaration</param>
+    /// <returns>Using directives</returns>
+    private static SyntaxList<UsingDirectiveSyntax> GetUsings(SyntaxNode scope)
+    {
+        return scope switch
+               {
+                   CompilationUnitSyntax compilationUnit => compilationUnit.Usings,
+                   BaseNamespaceDeclarationSyntax namespaceDeclaration => namespaceDeclaration.Usings,
+                   _ => default,
+               };
+    }
+
+    /// <summary>
+    /// Applies updated using directives to the given scope node
+    /// </summary>
+    /// <param name="scope">Compilation unit or namespace declaration</param>
+    /// <param name="usingDirectives">New using directives</param>
+    /// <returns>Updated scope node</returns>
+    private static SyntaxNode WithUsings(SyntaxNode scope, SyntaxList<UsingDirectiveSyntax> usingDirectives)
+    {
+        return scope switch
+               {
+                   CompilationUnitSyntax compilationUnit => compilationUnit.WithUsings(usingDirectives),
+                   BaseNamespaceDeclarationSyntax namespaceDeclaration => namespaceDeclaration.WithUsings(usingDirectives),
+                   _ => scope,
+               };
+    }
+
+    /// <summary>
+    /// Reorganizes using directives into groups sorted by using type and root namespace
+    /// </summary>
+    /// <param name="usings">Original using directives</param>
+    /// <returns>Reorganized using directives</returns>
+    private static SyntaxList<UsingDirectiveSyntax> OrganizeUsings(SyntaxList<UsingDirectiveSyntax> usings)
+    {
+        var firstLeadingTrivia = usings.First().GetLeadingTrivia();
+        var canonical = RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer.ComputeCanonicalOrder(usings);
+        var result = new List<UsingDirectiveSyntax>();
+
+        for (var i = 0; i < canonical.Count; i++)
+        {
+            var current = canonical[i];
+
+            if (i == 0)
+            {
+                result.Add(current.WithLeadingTrivia(firstLeadingTrivia));
+
+                continue;
+            }
+
+            var indentation = GetIndentationTrivia(current.GetLeadingTrivia());
+
+            if (RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer.AreInSameGroup(canonical[i - 1], current))
+            {
+                result.Add(current.WithLeadingTrivia(indentation));
+
+                continue;
+            }
+
+            var blankLineTriviaList = new List<SyntaxTrivia>
+                                      {
+                                          SyntaxFactory.EndOfLine(Environment.NewLine)
+                                      };
+            blankLineTriviaList.AddRange(indentation);
+            result.Add(current.WithLeadingTrivia(SyntaxFactory.TriviaList(blankLineTriviaList)));
+        }
+
+        return SyntaxFactory.List(result);
+    }
+
+    #endregion // Methods
+
+    #region CodeFixProvider
+
+    /// <inheritdoc/>
+    public sealed override ImmutableArray<string> FixableDiagnosticIds => [RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer.DiagnosticId];
+
+    /// <inheritdoc/>
+    public sealed override FixAllProvider GetFixAllProvider()
+    {
+        return WellKnownFixAllProviders.BatchFixer;
+    }
+
+    /// <inheritdoc/>
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+        if (root == null)
+        {
+            return;
+        }
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var diagnosticNode = root.FindToken(diagnostic.Location.SourceSpan.Start).Parent;
+            var usingDirective = diagnosticNode?.AncestorsAndSelf().OfType<UsingDirectiveSyntax>().FirstOrDefault();
+            var scope = usingDirective?.Parent;
+
+            if (scope is CompilationUnitSyntax or BaseNamespaceDeclarationSyntax)
+            {
+                context.RegisterCodeFix(CodeAction.Create(CodeFixResources.RH0390Title,
+                                                          token => ApplyCodeFixAsync(context.Document, scope, token),
+                                                          nameof(RH0390UsingDirectivesShouldBeOrganizedIntoGroupsCodeFixProvider)),
+                                        diagnostic);
+            }
+        }
+    }
+
+    #endregion // CodeFixProvider
+}

--- a/Reihitsu.Analyzer.Package/README.MD
+++ b/Reihitsu.Analyzer.Package/README.MD
@@ -109,6 +109,7 @@ dotnet add package Reihitsu.Analyzer
 | [RH0387](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0387.md)| Types should be organized with regions.| ✔| ❌|
 | [RH0388](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0388.md)| Region descriptions should not end with implementation.| ✔| ❌|
 | [RH0389](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0389.md)| Indentation must use 4 spaces per scope level.| ✔| ✔|
+| [RH0390](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0390.md)| Using directives should be grouped by kind and namespace with blank lines between groups.| ✔| ✔|
 || **Documentation**|||
 | [RH0401](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0401.md)| The \<inheritdoc/> Tag should be used if possible.| ✔| ✔|
 | [RH0402](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0402.md)| Elements must be documented.| ✔| ❌|

--- a/Reihitsu.Analyzer.Test/Formatting/RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzerTests.cs
@@ -1,0 +1,616 @@
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Analyzer.Rules.Formatting;
+using Reihitsu.Analyzer.Test.Base;
+
+namespace Reihitsu.Analyzer.Test.Formatting;
+
+/// <summary>
+/// Test methods for <see cref="RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer"/> and <see cref="RH0390UsingDirectivesShouldBeOrganizedIntoGroupsCodeFixProvider"/>
+/// </summary>
+[TestClass]
+public class RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzerTests : AnalyzerTestsBase<RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer, RH0390UsingDirectivesShouldBeOrganizedIntoGroupsCodeFixProvider>
+{
+    /// <summary>
+    /// Verifies that no diagnostic is reported when there is only a single using directive
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task NoDiagnosticForSingleUsing()
+    {
+        const string testCode = """
+                                using System;
+
+                                public class TestClass
+                                {
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
+    /// <summary>
+    /// Verifies that no diagnostic is reported when all usings belong to the same root namespace and no blank line separates them
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task NoDiagnosticForSingleGroupAlreadySorted()
+    {
+        const string testCode = """
+                                using System;
+                                using System.Collections.Generic;
+                                using System.Linq;
+
+                                public class TestClass
+                                {
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
+    /// <summary>
+    /// Verifies that no diagnostic is reported when usings are already organized into groups with correct blank lines
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task NoDiagnosticWhenAlreadyOrganized()
+    {
+        const string testCode = """
+                                using System;
+                                using System.Collections.Generic;
+                                using System.Linq;
+
+                                using Alpha;
+                                using Alpha.Sub;
+
+                                using Bravo;
+
+                                public class TestClass
+                                {
+                                }
+
+                                namespace Alpha
+                                {
+                                    public class Placeholder
+                                    {
+                                    }
+                                }
+
+                                namespace Alpha.Sub
+                                {
+                                    public class Placeholder
+                                    {
+                                    }
+                                }
+
+                                namespace Bravo
+                                {
+                                    public class Placeholder
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
+    /// <summary>
+    /// Verifies that no diagnostic is reported when regular, static, and alias usings are already grouped correctly
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task NoDiagnosticWhenUsingTypesAreAlreadyGrouped()
+    {
+        const string testCode = """
+                                using System;
+
+                                using Alpha;
+                                using Alpha.Sub;
+
+                                using static System.Math;
+
+                                using static Bravo.Helper;
+
+                                using TextAlias = System.String;
+
+                                using BravoAlias = Bravo.Helper;
+
+                                public class TestClass
+                                {
+                                }
+
+                                namespace Alpha
+                                {
+                                    public class Placeholder
+                                    {
+                                    }
+                                }
+
+                                namespace Alpha.Sub
+                                {
+                                    public class Placeholder
+                                    {
+                                    }
+                                }
+
+                                namespace Bravo
+                                {
+                                    public class Helper
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
+    /// <summary>
+    /// Verifies that a diagnostic is reported on the first using when groups are missing blank line separators
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task DiagnosticWhenMissingBlankLineBetweenGroups()
+    {
+        const string testCode = """
+                                using {|#0:System|};
+                                using System.Collections.Generic;
+                                using System.Linq;
+                                using Alpha;
+                                using Alpha.Sub;
+                                using Bravo;
+
+                                public class TestClass
+                                {
+                                }
+
+                                namespace Alpha
+                                {
+                                    public class Placeholder
+                                    {
+                                    }
+                                }
+
+                                namespace Alpha.Sub
+                                {
+                                    public class Placeholder
+                                    {
+                                    }
+                                }
+
+                                namespace Bravo
+                                {
+                                    public class Placeholder
+                                    {
+                                    }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 using System;
+                                 using System.Collections.Generic;
+                                 using System.Linq;
+
+                                 using Alpha;
+                                 using Alpha.Sub;
+
+                                 using Bravo;
+
+                                 public class TestClass
+                                 {
+                                 }
+
+                                 namespace Alpha
+                                 {
+                                     public class Placeholder
+                                     {
+                                     }
+                                 }
+
+                                 namespace Alpha.Sub
+                                 {
+                                     public class Placeholder
+                                     {
+                                     }
+                                 }
+
+                                 namespace Bravo
+                                 {
+                                     public class Placeholder
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer.DiagnosticId, AnalyzerResources.RH0390MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that the code fix also sorts usings alphabetically within each group
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task CodeFixSortsUsingWithinGroups()
+    {
+        const string testCode = """
+                                using {|#0:System.Linq|};
+                                using System;
+                                using System.Collections.Generic;
+                                using Alpha.Sub;
+                                using Alpha;
+
+                                public class TestClass
+                                {
+                                }
+
+                                namespace Alpha
+                                {
+                                    public class Placeholder
+                                    {
+                                    }
+                                }
+
+                                namespace Alpha.Sub
+                                {
+                                    public class Placeholder
+                                    {
+                                    }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 using System;
+                                 using System.Collections.Generic;
+                                 using System.Linq;
+
+                                 using Alpha;
+                                 using Alpha.Sub;
+
+                                 public class TestClass
+                                 {
+                                 }
+
+                                 namespace Alpha
+                                 {
+                                     public class Placeholder
+                                     {
+                                     }
+                                 }
+
+                                 namespace Alpha.Sub
+                                 {
+                                     public class Placeholder
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer.DiagnosticId, AnalyzerResources.RH0390MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that a diagnostic is reported when an extra blank line exists within a group
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task DiagnosticWhenExtraBlankLineWithinGroup()
+    {
+        const string testCode = """
+                                using {|#0:System|};
+
+                                using System.Collections.Generic;
+
+                                public class TestClass
+                                {
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 using System;
+                                 using System.Collections.Generic;
+
+                                 public class TestClass
+                                 {
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer.DiagnosticId, AnalyzerResources.RH0390MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that System group is placed before other groups in the fix
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task CodeFixPlacesSystemGroupFirst()
+    {
+        const string testCode = """
+                                using {|#0:Alpha|};
+                                using System;
+                                using System.Linq;
+
+                                public class TestClass
+                                {
+                                }
+
+                                namespace Alpha
+                                {
+                                    public class Placeholder
+                                    {
+                                    }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 using System;
+                                 using System.Linq;
+
+                                 using Alpha;
+
+                                 public class TestClass
+                                 {
+                                 }
+
+                                 namespace Alpha
+                                 {
+                                     public class Placeholder
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer.DiagnosticId, AnalyzerResources.RH0390MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that static usings are separated from regular usings and grouped by root namespace
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task StaticUsingsAreSeparatedFromRegularUsings()
+    {
+        const string testCode = """
+                                using {|#0:System|};
+                                using static Alpha.Helper;
+                                using Alpha;
+                                using static System.Math;
+
+                                public class TestClass
+                                {
+                                }
+
+                                namespace Alpha
+                                {
+                                    public class Helper
+                                    {
+                                    }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 using System;
+
+                                 using Alpha;
+
+                                 using static System.Math;
+
+                                 using static Alpha.Helper;
+
+                                 public class TestClass
+                                 {
+                                 }
+
+                                 namespace Alpha
+                                 {
+                                     public class Helper
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer.DiagnosticId, AnalyzerResources.RH0390MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that alias usings are grouped by root namespace of their target and kept after other using types
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task AliasUsingsAreGroupedByRootNamespace()
+    {
+        const string testCode = """
+                                using {|#0:System|};
+                                using SysLinq = System.Linq;
+                                using AlphaAlias = Alpha.Something;
+
+                                public class TestClass
+                                {
+                                }
+
+                                namespace Alpha
+                                {
+                                    public class Something
+                                    {
+                                    }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 using System;
+
+                                 using SysLinq = System.Linq;
+
+                                 using AlphaAlias = Alpha.Something;
+
+                                 public class TestClass
+                                 {
+                                 }
+
+                                 namespace Alpha
+                                 {
+                                     public class Something
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer.DiagnosticId, AnalyzerResources.RH0390MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that alias usings are placed after static usings
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task AliasUsingsAreSeparatedFromStaticUsings()
+    {
+        const string testCode = """
+                                using {|#0:System|};
+                                using Alias = Alpha.Helper;
+                                using static System.Math;
+
+                                public class TestClass
+                                {
+                                }
+
+                                namespace Alpha
+                                {
+                                    public class Helper
+                                    {
+                                    }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 using System;
+
+                                 using static System.Math;
+
+                                 using Alias = Alpha.Helper;
+
+                                 public class TestClass
+                                 {
+                                 }
+
+                                 namespace Alpha
+                                 {
+                                     public class Helper
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer.DiagnosticId, AnalyzerResources.RH0390MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that global using directives are organized by root namespace
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task GlobalUsingDirectivesAreOrganized()
+    {
+        const string testCode = """
+                                global using {|#0:System|};
+                                global using System.Linq;
+                                global using Alpha;
+
+                                public class TestClass
+                                {
+                                }
+
+                                namespace Alpha
+                                {
+                                    public class Placeholder
+                                    {
+                                    }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 global using System;
+                                 global using System.Linq;
+
+                                 global using Alpha;
+
+                                 public class TestClass
+                                 {
+                                 }
+
+                                 namespace Alpha
+                                 {
+                                     public class Placeholder
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer.DiagnosticId, AnalyzerResources.RH0390MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that no diagnostic is reported when using directives are zero in a compilation unit
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task NoDiagnosticForNoUsings()
+    {
+        const string testCode = """
+                                public class TestClass
+                                {
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
+    /// <summary>
+    /// Verifies that non-System groups are ordered alphabetically by root namespace
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task NonSystemGroupsAreOrderedAlphabetically()
+    {
+        const string testCode = """
+                                using {|#0:Zebra.Something|};
+                                using Alpha.Something;
+                                using System;
+
+                                public class TestClass
+                                {
+                                }
+
+                                namespace Alpha.Something
+                                {
+                                }
+
+                                namespace Zebra.Something
+                                {
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 using System;
+
+                                 using Alpha.Something;
+
+                                 using Zebra.Something;
+
+                                 public class TestClass
+                                 {
+                                 }
+
+                                 namespace Alpha.Something
+                                 {
+                                 }
+
+                                 namespace Zebra.Something
+                                 {
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer.DiagnosticId, AnalyzerResources.RH0390MessageFormat));
+    }
+}

--- a/Reihitsu.Analyzer/AnalyzerResources.cs
+++ b/Reihitsu.Analyzer/AnalyzerResources.cs
@@ -995,6 +995,16 @@ internal static class AnalyzerResources
     internal static string RH0389Title => GetString(nameof(RH0389Title));
 
     /// <summary>
+    /// Gets the localized string for RH0390MessageFormat
+    /// </summary>
+    internal static string RH0390MessageFormat => GetString(nameof(RH0390MessageFormat));
+
+    /// <summary>
+    /// Gets the localized string for RH0390Title
+    /// </summary>
+    internal static string RH0390Title => GetString(nameof(RH0390Title));
+
+    /// <summary>
     /// Gets the localized string for RH0334MessageFormat
     /// </summary>
     internal static string RH0334MessageFormat => GetString(nameof(RH0334MessageFormat));

--- a/Reihitsu.Analyzer/AnalyzerResources.resx
+++ b/Reihitsu.Analyzer/AnalyzerResources.resx
@@ -1083,6 +1083,12 @@
   <data name="RH0614MessageFormat" xml:space="preserve">
     <value>Using static directives must be ordered alphabetically.</value>
   </data>
+  <data name="RH0390Title" xml:space="preserve">
+    <value>Using directives should be organized into groups</value>
+  </data>
+  <data name="RH0390MessageFormat" xml:space="preserve">
+    <value>Using directives should be organized into groups separated by blank lines.</value>
+  </data>
    <data name="RH0401MessageFormat" xml:space="preserve">
     <value>The \&lt;inheritdoc/&gt; Tag should be used if possible.</value>
   </data>

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0433ElementParametersMustBeDocumentedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0433ElementParametersMustBeDocumentedAnalyzer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0434ElementParameterDocumentationMustMatchElementParametersAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0434ElementParameterDocumentationMustMatchElementParametersAnalyzer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0440GenericTypeParametersMustBeDocumentedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0440GenericTypeParametersMustBeDocumentedAnalyzer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0441GenericTypeParameterDocumentationMustMatchTypeParametersAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0441GenericTypeParameterDocumentationMustMatchTypeParametersAnalyzer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0334KeywordsMustBeSpacedCorrectlyAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0334KeywordsMustBeSpacedCorrectlyAnalyzer.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
+
 using Reihitsu.Analyzer.Base;
 using Reihitsu.Analyzer.Enumerations;
 using Reihitsu.Analyzer.Extensions;

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0335CommasMustBeSpacedCorrectlyAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0335CommasMustBeSpacedCorrectlyAnalyzer.cs
@@ -2,6 +2,7 @@
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+
 using Reihitsu.Analyzer.Base;
 using Reihitsu.Analyzer.Enumerations;
 

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0339OperatorKeywordMustBeFollowedBySpaceAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0339OperatorKeywordMustBeFollowedBySpaceAnalyzer.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
+
 using Reihitsu.Analyzer.Base;
 using Reihitsu.Analyzer.Enumerations;
 

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0343OpeningBracesMustBeSpacedCorrectlyAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0343OpeningBracesMustBeSpacedCorrectlyAnalyzer.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
+
 using Reihitsu.Analyzer.Base;
 using Reihitsu.Analyzer.Core;
 using Reihitsu.Analyzer.Enumerations;

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0344ClosingBracesMustBeSpacedCorrectlyAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0344ClosingBracesMustBeSpacedCorrectlyAnalyzer.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
+
 using Reihitsu.Analyzer.Base;
 using Reihitsu.Analyzer.Core;
 using Reihitsu.Analyzer.Enumerations;

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0350MemberAccessSymbolsMustBeSpacedCorrectlyAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0350MemberAccessSymbolsMustBeSpacedCorrectlyAnalyzer.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
+
 using Reihitsu.Analyzer.Base;
 using Reihitsu.Analyzer.Enumerations;
 

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0355ColonsMustBeSpacedCorrectlyAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0355ColonsMustBeSpacedCorrectlyAnalyzer.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+
 using Reihitsu.Analyzer.Base;
 using Reihitsu.Analyzer.Enumerations;
 

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0359BracesForMultiLineStatementsMustNotShareLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0359BracesForMultiLineStatementsMustNotShareLineAnalyzer.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+
 using Reihitsu.Analyzer.Base;
 using Reihitsu.Analyzer.Enumerations;
 

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0360StatementMustNotBeOnSingleLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0360StatementMustNotBeOnSingleLineAnalyzer.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+
 using Reihitsu.Analyzer.Base;
 using Reihitsu.Analyzer.Enumerations;
 

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0361ElementMustNotBeOnSingleLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0361ElementMustNotBeOnSingleLineAnalyzer.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+
 using Reihitsu.Analyzer.Base;
 using Reihitsu.Analyzer.Enumerations;
 

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0362BracesMustNotBeOmittedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0362BracesMustNotBeOmittedAnalyzer.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+
 using Reihitsu.Analyzer.Base;
 using Reihitsu.Analyzer.Enumerations;
 

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0373BracesMustNotBeOmittedFromMultiLineChildStatementsAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0373BracesMustNotBeOmittedFromMultiLineChildStatementsAnalyzer.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+
 using Reihitsu.Analyzer.Base;
 using Reihitsu.Analyzer.Enumerations;
 

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0374UseBracesConsistentlyAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0374UseBracesConsistentlyAnalyzer.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+
 using Reihitsu.Analyzer.Base;
 using Reihitsu.Analyzer.Enumerations;
 

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0377OpeningParenthesisMustBeOnDeclarationLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0377OpeningParenthesisMustBeOnDeclarationLineAnalyzer.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+
 using Reihitsu.Analyzer.Base;
 using Reihitsu.Analyzer.Enumerations;
 

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0379CommaMustBeOnSameLineAsPreviousParameterAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0379CommaMustBeOnSameLineAsPreviousParameterAnalyzer.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+
 using Reihitsu.Analyzer.Base;
 using Reihitsu.Analyzer.Enumerations;
 

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0380ParameterListMustFollowDeclarationAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0380ParameterListMustFollowDeclarationAnalyzer.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+
 using Reihitsu.Analyzer.Base;
 using Reihitsu.Analyzer.Enumerations;
 

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0381ParametersMustBeOnSameLineOrSeparateLinesAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0381ParametersMustBeOnSameLineOrSeparateLinesAnalyzer.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+
 using Reihitsu.Analyzer.Base;
 using Reihitsu.Analyzer.Enumerations;
 

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer.cs
@@ -1,0 +1,213 @@
+using System.Collections.Generic;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Core;
+using Reihitsu.Analyzer.Enumerations;
+
+namespace Reihitsu.Analyzer.Rules.Formatting;
+
+/// <summary>
+/// RH0390: Using directives should be organized into groups
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer : DiagnosticAnalyzerBase<RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer>
+{
+    #region Constants
+
+    /// <summary>
+    /// Diagnostic ID
+    /// </summary>
+    public const string DiagnosticId = "RH0390";
+
+    #endregion // Constants
+
+    #region Constructor
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer()
+        : base(DiagnosticId, DiagnosticCategory.Formatting, nameof(AnalyzerResources.RH0390Title), nameof(AnalyzerResources.RH0390MessageFormat))
+    {
+    }
+
+    #endregion // Constructor
+
+    #region Methods
+
+    /// <summary>
+    /// Computes the canonical (sorted and grouped) order of the given using directives
+    /// </summary>
+    /// <param name="usings">Using directives</param>
+    /// <returns>Canonically ordered list</returns>
+    internal static List<UsingDirectiveSyntax> ComputeCanonicalOrder(SyntaxList<UsingDirectiveSyntax> usings)
+    {
+        return usings.Select((usingDirective, directiveIndex) => new
+                                                                 {
+                                                                     UsingDirective = usingDirective,
+                                                                     DirectiveIndex = directiveIndex,
+                                                                 })
+                     .OrderBy(obj => GetUsingTypeOrder(obj.UsingDirective))
+                     .ThenBy(obj => GetNamespaceGroupOrderKey(obj.UsingDirective), StringComparer.OrdinalIgnoreCase)
+                     .ThenBy(obj => UsingDirectiveOrderingUtilities.GetSortKey(obj.UsingDirective), StringComparer.OrdinalIgnoreCase)
+                     .ThenBy(obj => obj.DirectiveIndex)
+                     .Select(obj => obj.UsingDirective)
+                     .ToList();
+    }
+
+    /// <summary>
+    /// Determines whether two using directives belong to the same formatting group
+    /// </summary>
+    /// <param name="left">Left using directive</param>
+    /// <param name="right">Right using directive</param>
+    /// <returns><see langword="true"/> if both directives belong to the same group</returns>
+    internal static bool AreInSameGroup(UsingDirectiveSyntax left, UsingDirectiveSyntax right)
+    {
+        return GetUsingTypeOrder(left) == GetUsingTypeOrder(right)
+               && string.Equals(GetRootNamespace(left), GetRootNamespace(right), StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Gets the root namespace (first segment before the first dot) for a using directive
+    /// </summary>
+    /// <param name="usingDirective">Using directive</param>
+    /// <returns>Root namespace segment</returns>
+    internal static string GetRootNamespace(UsingDirectiveSyntax usingDirective)
+    {
+        var name = usingDirective.Name?.ToString() ?? string.Empty;
+        var dotIndex = name.IndexOf('.');
+
+        return dotIndex >= 0 ? name.Substring(0, dotIndex) : name;
+    }
+
+    /// <summary>
+    /// Gets the namespace ordering key for a using directive
+    /// </summary>
+    /// <param name="usingDirective">Using directive</param>
+    /// <returns>The namespace ordering key</returns>
+    internal static string GetNamespaceGroupOrderKey(UsingDirectiveSyntax usingDirective)
+    {
+        var rootNamespace = GetRootNamespace(usingDirective);
+
+        return string.Equals(rootNamespace, "System", StringComparison.OrdinalIgnoreCase)
+                   ? string.Empty
+                   : rootNamespace;
+    }
+
+    /// <summary>
+    /// Gets the using-type ordering slot
+    /// </summary>
+    /// <param name="usingDirective">Using directive</param>
+    /// <returns>The using-type ordering slot</returns>
+    internal static int GetUsingTypeOrder(UsingDirectiveSyntax usingDirective)
+    {
+        return UsingDirectiveOrderingUtilities.GetUsingDirectiveGroup(usingDirective) switch
+               {
+                   UsingDirectiveOrderingGroup.Static => 1,
+                   UsingDirectiveOrderingGroup.Alias => 2,
+                   _ => 0,
+               };
+    }
+
+    /// <summary>
+    /// Determines whether the using directive has a blank line before it (based on its leading trivia)
+    /// </summary>
+    /// <param name="usingDirective">Using directive</param>
+    /// <returns><see langword="true"/> if there is a blank line before the directive</returns>
+    private static bool HasBlankLineBefore(UsingDirectiveSyntax usingDirective)
+    {
+        return usingDirective.GetLeadingTrivia().Any(t => t.IsKind(SyntaxKind.EndOfLineTrivia));
+    }
+
+    /// <summary>
+    /// Determines whether the given using directives are properly organized into groups
+    /// </summary>
+    /// <param name="usings">Using directives</param>
+    /// <returns><see langword="true"/> if the usings are already organized correctly</returns>
+    private static bool IsOrganized(SyntaxList<UsingDirectiveSyntax> usings)
+    {
+        if (usings.Count < 2)
+        {
+            return true;
+        }
+
+        var canonical = ComputeCanonicalOrder(usings);
+
+        for (var i = 0; i < usings.Count; i++)
+        {
+            if (ReferenceEquals(usings[i], canonical[i]) == false)
+            {
+                return false;
+            }
+        }
+
+        for (var i = 1; i < usings.Count; i++)
+        {
+            var sameGroup = AreInSameGroup(usings[i - 1], usings[i]);
+            var hasBlankLine = HasBlankLineBefore(usings[i]);
+
+            if (sameGroup == hasBlankLine)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Gets the using directives from the given scope node
+    /// </summary>
+    /// <param name="scope">Compilation unit or namespace declaration</param>
+    /// <returns>Using directives</returns>
+    private static SyntaxList<UsingDirectiveSyntax> GetUsings(SyntaxNode scope)
+    {
+        return scope switch
+               {
+                   CompilationUnitSyntax compilationUnit => compilationUnit.Usings,
+                   BaseNamespaceDeclarationSyntax namespaceDeclaration => namespaceDeclaration.Usings,
+                   _ => default,
+               };
+    }
+
+    /// <summary>
+    /// Analyzes the using directive scope
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnUsingScope(SyntaxNodeAnalysisContext context)
+    {
+        var usings = GetUsings(context.Node);
+
+        if (usings.Count < 2)
+        {
+            return;
+        }
+
+        if (IsOrganized(usings) == false)
+        {
+            var firstUsing = usings[0];
+            var location = firstUsing.Name?.GetLocation() ?? firstUsing.GetLocation();
+
+            context.ReportDiagnostic(CreateDiagnostic(location));
+        }
+    }
+
+    #endregion // Methods
+
+    #region DiagnosticAnalyzer
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        base.Initialize(context);
+
+        context.RegisterSyntaxNodeAction(OnUsingScope, SyntaxKind.CompilationUnit, SyntaxKind.NamespaceDeclaration, SyntaxKind.FileScopedNamespaceDeclaration);
+    }
+
+    #endregion // DiagnosticAnalyzer
+}

--- a/Reihitsu.sln
+++ b/Reihitsu.sln
@@ -170,6 +170,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		documentation\rules\RH0387.md = documentation\rules\RH0387.md
 		documentation\rules\RH0388.md = documentation\rules\RH0388.md
 		documentation\rules\RH0389.md = documentation\rules\RH0389.md
+		documentation\rules\RH0390.md = documentation\rules\RH0390.md
 		documentation\rules\RH0401.md = documentation\rules\RH0401.md
 		documentation\rules\RH0402.md = documentation\rules\RH0402.md
 		documentation\rules\RH0403.md = documentation\rules\RH0403.md

--- a/documentation/rules/RH0390.md
+++ b/documentation/rules/RH0390.md
@@ -1,0 +1,46 @@
+# RH0390 — Using directives should be organized into groups
+
+| Property | Value |
+|----------|-------|
+| **ID** | RH0390 |
+| **Category** | Formatting |
+| **Severity** | Warning |
+| **Code Fix** | ✓ |
+
+## Description
+
+This rule requires `using` directives to be organized into separate sections for regular usings, `using static` directives, and alias directives. Within each section, directives are grouped by their root namespace (the first segment before the first dot, such as `System`, `Microsoft`, or `Reihitsu`), with each group separated by a single blank line.
+
+## Why is this a problem?
+
+When regular usings, static imports, and aliases are mixed together, the import list becomes harder to scan and maintain. Separating them into predictable sections and grouping related namespaces makes it easier to see what a file depends on and why each import exists.
+
+## How to fix it
+
+Place regular usings first, `using static` directives after them, and alias directives last. Within each section, keep the `System` group first, order the remaining root-namespace groups alphabetically, and separate each group with a single blank line. Apply the provided code fix to reorganize the directives automatically.
+
+## Examples
+
+### Violation
+
+```cs
+using System;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using Microsoft.CodeAnalysis;
+using AnalyzerAlias = Reihitsu.Analyzer;
+using Reihitsu.Formatter;
+```
+
+### Correction
+
+```cs
+using System;
+
+using Microsoft.CodeAnalysis;
+
+using Reihitsu.Formatter;
+
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+using AnalyzerAlias = Reihitsu.Analyzer;
+```


### PR DESCRIPTION
Implements analyzer and code fix for RH0390 to ensure using directives are grouped by root namespace, separated by blank lines, and sorted with System first. Updates resource files, README, and solution. Includes unit tests and rule documentation.