### PR TITLE
Add RH0391: enforce assignment line break consistency

### DIFF
--- a/Reihitsu.Analyzer.CodeFixes/CodeFixResources.cs
+++ b/Reihitsu.Analyzer.CodeFixes/CodeFixResources.cs
@@ -419,6 +419,11 @@ internal static class CodeFixResources
     internal static string RH0389Title => GetString(nameof(RH0389Title));
 
     /// <summary>
+    /// Gets the localized string for RH0391Title
+    /// </summary>
+    internal static string RH0391Title => GetString(nameof(RH0391Title));
+
+    /// <summary>
     /// Gets the localized string for RH0334Title
     /// </summary>
     internal static string RH0334Title => GetString(nameof(RH0334Title));

--- a/Reihitsu.Analyzer.CodeFixes/CodeFixResources.resx
+++ b/Reihitsu.Analyzer.CodeFixes/CodeFixResources.resx
@@ -516,6 +516,9 @@
   <data name="RH0389Title" xml:space="preserve">
     <value>Normalize indentation</value>
   </data>
+  <data name="RH0391Title" xml:space="preserve">
+    <value>Normalize assignment line breaks</value>
+  </data>
   <data name="RH0601Title" xml:space="preserve">
     <value>Move constant field</value>
   </data>

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0391AssignmentsMustHaveProperLineBreaksCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0391AssignmentsMustHaveProperLineBreaksCodeFixProvider.cs
@@ -1,0 +1,316 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Reihitsu.Analyzer.Rules.Formatting;
+
+/// <summary>
+/// Code fix provider for <see cref="RH0391AssignmentsMustHaveProperLineBreaksAnalyzer"/>
+/// </summary>
+[Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(RH0391AssignmentsMustHaveProperLineBreaksCodeFixProvider))]
+public class RH0391AssignmentsMustHaveProperLineBreaksCodeFixProvider : CodeFixProvider
+{
+    #region Methods
+
+    /// <summary>
+    /// Applies the code fix
+    /// </summary>
+    /// <param name="document">Document</param>
+    /// <param name="diagnosticSpan">Diagnostic span</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The updated document</returns>
+    private static async Task<Document> ApplyCodeFixAsync(Document document, TextSpan diagnosticSpan, CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+        if (root == null)
+        {
+            return document;
+        }
+
+        var diagnosticNode = root.FindNode(diagnosticSpan, getInnermostNodeForTie: true);
+        var assignmentNode = GetFormattingNode(diagnosticNode);
+        var updatedNode = assignmentNode == null ? null : FixAssignmentNode(assignmentNode);
+
+        return assignmentNode == null || updatedNode == null
+                   ? document
+                   : document.WithSyntaxRoot(root.ReplaceNode(assignmentNode, updatedNode));
+    }
+
+    /// <summary>
+    /// Gets the narrowest formatting node that can still fix the assignment
+    /// </summary>
+    /// <param name="diagnosticNode">Diagnostic node</param>
+    /// <returns>Formatting node</returns>
+    private static SyntaxNode GetFormattingNode(SyntaxNode diagnosticNode)
+    {
+        var formattingNode = (diagnosticNode.FirstAncestorOrSelf<AssignmentExpressionSyntax>()
+                                  ?? (SyntaxNode)diagnosticNode.FirstAncestorOrSelf<VariableDeclaratorSyntax>())
+                                 ?? diagnosticNode.FirstAncestorOrSelf<PropertyDeclarationSyntax>();
+
+        return formattingNode;
+    }
+
+    /// <summary>
+    /// Fixes the reported assignment node without formatting the surrounding scope
+    /// </summary>
+    /// <param name="assignmentNode">Assignment node</param>
+    /// <returns>Updated assignment node</returns>
+    private static SyntaxNode FixAssignmentNode(SyntaxNode assignmentNode)
+    {
+        return assignmentNode switch
+               {
+                   AssignmentExpressionSyntax assignmentExpression => FixAssignmentExpression(assignmentExpression),
+                   VariableDeclaratorSyntax variableDeclarator => FixVariableDeclarator(variableDeclarator),
+                   PropertyDeclarationSyntax propertyDeclaration => FixPropertyDeclaration(propertyDeclaration),
+                   _ => assignmentNode,
+               };
+    }
+
+    /// <summary>
+    /// Fixes a simple assignment expression
+    /// </summary>
+    /// <param name="node">Assignment expression</param>
+    /// <returns>Updated assignment expression</returns>
+    private static AssignmentExpressionSyntax FixAssignmentExpression(AssignmentExpressionSyntax node)
+    {
+        node = CollapseOperatorToTargetLine(node, node.Left.GetLastToken(), node.OperatorToken);
+
+        return CollapseValueToEqualsLine(node, node.OperatorToken, node.Right.GetFirstToken());
+    }
+
+    /// <summary>
+    /// Fixes a variable or field declarator initializer
+    /// </summary>
+    /// <param name="node">Variable declarator</param>
+    /// <returns>Updated variable declarator</returns>
+    private static VariableDeclaratorSyntax FixVariableDeclarator(VariableDeclaratorSyntax node)
+    {
+        if (node.Initializer == null)
+        {
+            return node;
+        }
+
+        node = CollapseOperatorToTargetLine(node, node.Identifier, node.Initializer.EqualsToken);
+
+        if (node.Initializer == null)
+        {
+            return node;
+        }
+
+        return CollapseValueToEqualsLine(node, node.Initializer.EqualsToken, node.Initializer.Value.GetFirstToken());
+    }
+
+    /// <summary>
+    /// Fixes a property initializer
+    /// </summary>
+    /// <param name="node">Property declaration</param>
+    /// <returns>Updated property declaration</returns>
+    private static PropertyDeclarationSyntax FixPropertyDeclaration(PropertyDeclarationSyntax node)
+    {
+        if (node.Initializer == null || node.AccessorList == null)
+        {
+            return node;
+        }
+
+        var targetToken = node.AccessorList.CloseBraceToken;
+        node = CollapseOperatorToTargetLine(node, targetToken, node.Initializer.EqualsToken);
+
+        if (node.Initializer == null)
+        {
+            return node;
+        }
+
+        return CollapseValueToEqualsLine(node, node.Initializer.EqualsToken, node.Initializer.Value.GetFirstToken());
+    }
+
+    /// <summary>
+    /// Moves the equals operator onto the same line as the assignment target
+    /// </summary>
+    /// <typeparam name="TNode">Node type</typeparam>
+    /// <param name="node">Node to update</param>
+    /// <param name="targetToken">Assignment target token</param>
+    /// <param name="operatorToken">Equals token</param>
+    /// <returns>Updated node</returns>
+    private static TNode CollapseOperatorToTargetLine<TNode>(TNode node, SyntaxToken targetToken, SyntaxToken operatorToken)
+        where TNode : SyntaxNode
+    {
+        if (ContainsEndOfLine(targetToken.TrailingTrivia) == false
+            && ContainsEndOfLine(operatorToken.LeadingTrivia) == false)
+        {
+            return node;
+        }
+
+        var newTargetToken = targetToken.WithTrailingTrivia(RemoveTrailingWhitespaceAndLineBreaks(targetToken.TrailingTrivia));
+        var newOperatorToken = operatorToken.WithLeadingTrivia(EnsureSingleLeadingSpace(RemoveLeadingWhitespaceAndLineBreaks(operatorToken.LeadingTrivia)));
+
+        return node.ReplaceTokens([targetToken, operatorToken],
+                                  (original, _) =>
+                                  {
+                                      if (original == targetToken)
+                                      {
+                                          return newTargetToken;
+                                      }
+
+                                      return newOperatorToken;
+                                  });
+    }
+
+    /// <summary>
+    /// Moves the value start onto the same line as the equals operator
+    /// </summary>
+    /// <typeparam name="TNode">Node type</typeparam>
+    /// <param name="node">Node to update</param>
+    /// <param name="operatorToken">Equals token</param>
+    /// <param name="valueFirstToken">First token of the value</param>
+    /// <returns>Updated node</returns>
+    private static TNode CollapseValueToEqualsLine<TNode>(TNode node, SyntaxToken operatorToken, SyntaxToken valueFirstToken)
+        where TNode : SyntaxNode
+    {
+        if (ContainsEndOfLine(operatorToken.TrailingTrivia) == false
+            && ContainsEndOfLine(valueFirstToken.LeadingTrivia) == false)
+        {
+            return node;
+        }
+
+        var newOperatorToken = operatorToken.WithTrailingTrivia(EnsureSingleTrailingSpace(RemoveTrailingWhitespaceAndLineBreaks(operatorToken.TrailingTrivia)));
+        var newValueFirstToken = valueFirstToken.WithLeadingTrivia(RemoveLeadingWhitespaceAndLineBreaks(valueFirstToken.LeadingTrivia));
+
+        return node.ReplaceTokens([operatorToken, valueFirstToken],
+                                  (original, _) =>
+                                  {
+                                      if (original == operatorToken)
+                                      {
+                                          return newOperatorToken;
+                                      }
+
+                                      return newValueFirstToken;
+                                  });
+    }
+
+    /// <summary>
+    /// Removes leading whitespace and line breaks from trivia
+    /// </summary>
+    /// <param name="trivia">Trivia list</param>
+    /// <returns>Trimmed trivia list</returns>
+    private static SyntaxTriviaList RemoveLeadingWhitespaceAndLineBreaks(SyntaxTriviaList trivia)
+    {
+        var trimmedTrivia = trivia.ToList();
+
+        while (trimmedTrivia.Count > 0
+               && (trimmedTrivia[0].IsKind(SyntaxKind.WhitespaceTrivia) || trimmedTrivia[0].IsKind(SyntaxKind.EndOfLineTrivia)))
+        {
+            trimmedTrivia.RemoveAt(0);
+        }
+
+        return SyntaxFactory.TriviaList(trimmedTrivia);
+    }
+
+    /// <summary>
+    /// Removes trailing whitespace and line breaks from trivia
+    /// </summary>
+    /// <param name="trivia">Trivia list</param>
+    /// <returns>Trimmed trivia list</returns>
+    private static SyntaxTriviaList RemoveTrailingWhitespaceAndLineBreaks(SyntaxTriviaList trivia)
+    {
+        var trimmedTrivia = trivia.ToList();
+
+        while (trimmedTrivia.Count > 0)
+        {
+            var lastTrivia = trimmedTrivia[trimmedTrivia.Count - 1];
+
+            if (lastTrivia.IsKind(SyntaxKind.WhitespaceTrivia) == false
+                && lastTrivia.IsKind(SyntaxKind.EndOfLineTrivia) == false)
+            {
+                break;
+            }
+
+            trimmedTrivia.RemoveAt(trimmedTrivia.Count - 1);
+        }
+
+        return SyntaxFactory.TriviaList(trimmedTrivia);
+    }
+
+    /// <summary>
+    /// Ensures the trivia starts with a single space
+    /// </summary>
+    /// <param name="trivia">Trivia list</param>
+    /// <returns>Trivia list with a single leading space</returns>
+    private static SyntaxTriviaList EnsureSingleLeadingSpace(SyntaxTriviaList trivia)
+    {
+        var newTrivia = new List<SyntaxTrivia>
+                        {
+                            SyntaxFactory.Space
+                        };
+        newTrivia.AddRange(trivia);
+
+        return SyntaxFactory.TriviaList(newTrivia);
+    }
+
+    /// <summary>
+    /// Ensures the trivia ends with a single space
+    /// </summary>
+    /// <param name="trivia">Trivia list</param>
+    /// <returns>Trivia list with a single trailing space</returns>
+    private static SyntaxTriviaList EnsureSingleTrailingSpace(SyntaxTriviaList trivia)
+    {
+        return SyntaxFactory.TriviaList(trivia.Add(SyntaxFactory.Space));
+    }
+
+    /// <summary>
+    /// Determines whether the trivia contains a line break
+    /// </summary>
+    /// <param name="trivia">Trivia list</param>
+    /// <returns><see langword="true"/> if a line break exists; otherwise, <see langword="false"/></returns>
+    private static bool ContainsEndOfLine(SyntaxTriviaList trivia)
+    {
+        foreach (var currentTrivia in trivia)
+        {
+            if (currentTrivia.IsKind(SyntaxKind.EndOfLineTrivia))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    #endregion // Methods
+
+    #region CodeFixProvider
+
+    /// <inheritdoc/>
+    public sealed override ImmutableArray<string> FixableDiagnosticIds => [RH0391AssignmentsMustHaveProperLineBreaksAnalyzer.DiagnosticId];
+
+    /// <inheritdoc/>
+    public sealed override FixAllProvider GetFixAllProvider()
+    {
+        return WellKnownFixAllProviders.BatchFixer;
+    }
+
+    /// <inheritdoc/>
+    public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            context.RegisterCodeFix(CodeAction.Create(CodeFixResources.RH0391Title,
+                                                      token => ApplyCodeFixAsync(context.Document, diagnostic.Location.SourceSpan, token),
+                                                      nameof(RH0391AssignmentsMustHaveProperLineBreaksCodeFixProvider)),
+                                    diagnostic);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    #endregion // CodeFixProvider
+}

--- a/Reihitsu.Analyzer.Package/README.MD
+++ b/Reihitsu.Analyzer.Package/README.MD
@@ -110,6 +110,7 @@ dotnet add package Reihitsu.Analyzer
 | [RH0388](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0388.md)| Region descriptions should not end with implementation.| ✔| ❌|
 | [RH0389](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0389.md)| Indentation must use 4 spaces per scope level.| ✔| ✔|
 | [RH0390](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0390.md)| Using directives should be grouped by kind and namespace with blank lines between groups.| ✔| ✔|
+| [RH0391](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0391.md)| Assignments must keep the target, `=`, and value start on the same line.| ✔| ✔|
 || **Documentation**|||
 | [RH0401](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0401.md)| The \<inheritdoc/> Tag should be used if possible.| ✔| ✔|
 | [RH0402](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0402.md)| Elements must be documented.| ✔| ❌|

--- a/Reihitsu.Analyzer.Test/Formatting/RH0391AssignmentsMustHaveProperLineBreaksAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH0391AssignmentsMustHaveProperLineBreaksAnalyzerTests.cs
@@ -1,0 +1,632 @@
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Analyzer.Rules.Formatting;
+using Reihitsu.Analyzer.Test.Base;
+
+namespace Reihitsu.Analyzer.Test.Formatting;
+
+/// <summary>
+/// Test methods for <see cref="RH0391AssignmentsMustHaveProperLineBreaksAnalyzer"/>
+/// </summary>
+[TestClass]
+public class RH0391AssignmentsMustHaveProperLineBreaksAnalyzerTests : AnalyzerTestsBase<RH0391AssignmentsMustHaveProperLineBreaksAnalyzer, RH0391AssignmentsMustHaveProperLineBreaksCodeFixProvider>
+{
+    /// <summary>
+    /// Verifying diagnostics for variable declaration with equals on new line
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticsForVariableDeclarationWithEqualsOnNewLine()
+    {
+        const string testData = """
+                                namespace TestNamespace
+                                {
+                                    class TestClass
+                                    {
+                                        public void TestMethod()
+                                        {
+                                            var {|#0:value
+                                                = "test"|};
+                                        }
+                                    }
+                                }
+                                """;
+
+        const string fixedData = """
+                                 namespace TestNamespace
+                                 {
+                                     class TestClass
+                                     {
+                                         public void TestMethod()
+                                         {
+                                             var value = "test";
+                                         }
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH0391AssignmentsMustHaveProperLineBreaksAnalyzer.DiagnosticId, AnalyzerResources.RH0391MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying diagnostics for variable declaration with value on new line
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticsForVariableDeclarationWithValueOnNewLine()
+    {
+        const string testData = """
+                                namespace TestNamespace
+                                {
+                                    class TestClass
+                                    {
+                                        public void TestMethod()
+                                        {
+                                            var {|#0:value =
+                                                "test"|};
+                                        }
+                                    }
+                                }
+                                """;
+
+        const string fixedData = """
+                                 namespace TestNamespace
+                                 {
+                                     class TestClass
+                                     {
+                                         public void TestMethod()
+                                         {
+                                             var value = "test";
+                                         }
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH0391AssignmentsMustHaveProperLineBreaksAnalyzer.DiagnosticId, AnalyzerResources.RH0391MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying diagnostics for field declaration with equals on new line
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticsForFieldDeclarationWithEqualsOnNewLine()
+    {
+        const string testData = """
+                                namespace TestNamespace
+                                {
+                                    class TestClass
+                                    {
+                                        private string {|#0:_field
+                                            = "test"|};
+                                    }
+                                }
+                                """;
+
+        const string fixedData = """
+                                 namespace TestNamespace
+                                 {
+                                     class TestClass
+                                     {
+                                         private string _field = "test";
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH0391AssignmentsMustHaveProperLineBreaksAnalyzer.DiagnosticId, AnalyzerResources.RH0391MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying diagnostics for property declaration with equals on new line
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticsForPropertyDeclarationWithEqualsOnNewLine()
+    {
+        const string testData = """
+                                namespace TestNamespace
+                                {
+                                    class TestClass
+                                    {
+                                        {|#0:public string Property { get; set; }
+                                            = "test";|}
+                                    }
+                                }
+                                """;
+
+        const string fixedData = """
+                                 namespace TestNamespace
+                                 {
+                                     class TestClass
+                                     {
+                                         public string Property { get; set; } = "test";
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH0391AssignmentsMustHaveProperLineBreaksAnalyzer.DiagnosticId, AnalyzerResources.RH0391MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying diagnostics for assignment expression with equals on new line
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticsForAssignmentExpressionWithEqualsOnNewLine()
+    {
+        const string testData = """
+                                namespace TestNamespace
+                                {
+                                    class TestClass
+                                    {
+                                        public void TestMethod()
+                                        {
+                                            string value;
+                                            {|#0:value
+                                                = "test"|};
+                                        }
+                                    }
+                                }
+                                """;
+
+        const string fixedData = """
+                                 namespace TestNamespace
+                                 {
+                                     class TestClass
+                                     {
+                                         public void TestMethod()
+                                         {
+                                             string value;
+                                             value = "test";
+                                         }
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH0391AssignmentsMustHaveProperLineBreaksAnalyzer.DiagnosticId, AnalyzerResources.RH0391MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying code fix only formats the reported assignment expression
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task CodeFixOnlyFormatsReportedAssignmentExpression()
+    {
+        const string testData = """
+                                namespace TestNamespace
+                                {
+                                    class TestClass
+                                    {
+                                        public void TestMethod()
+                                        {
+                                            string value;
+                                            Log( 1,2 );
+                                            {|#0:value
+                                                = "test"|};
+                                            Log( 3,4 );
+                                        }
+
+                                        private static void Log(int left, int right)
+                                        {
+                                        }
+                                    }
+                                }
+                                """;
+
+        const string fixedData = """
+                                 namespace TestNamespace
+                                 {
+                                     class TestClass
+                                     {
+                                         public void TestMethod()
+                                         {
+                                             string value;
+                                             Log( 1,2 );
+                                             value = "test";
+                                             Log( 3,4 );
+                                         }
+
+                                         private static void Log(int left, int right)
+                                         {
+                                         }
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH0391AssignmentsMustHaveProperLineBreaksAnalyzer.DiagnosticId, AnalyzerResources.RH0391MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying diagnostics for member initializer with value on new line
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticsForMemberInitializerWithValueOnNewLine()
+    {
+        const string testData = """
+                                namespace TestNamespace
+                                {
+                                    class TestClass
+                                    {
+                                        public void TestMethod()
+                                        {
+                                            var value = new Data
+                                            {
+                                                {|#0:Name =
+                                                    "test"|}
+                                            };
+                                        }
+                                    }
+
+                                    class Data
+                                    {
+                                        public string Name { get; set; }
+                                    }
+                                }
+                                """;
+
+        const string fixedData = """
+                                 namespace TestNamespace
+                                 {
+                                     class TestClass
+                                     {
+                                         public void TestMethod()
+                                         {
+                                             var value = new Data
+                                             {
+                                                 Name = "test"
+                                             };
+                                         }
+                                     }
+
+                                     class Data
+                                     {
+                                         public string Name { get; set; }
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH0391AssignmentsMustHaveProperLineBreaksAnalyzer.DiagnosticId, AnalyzerResources.RH0391MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying diagnostics for index assignment with equals on new line
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticsForIndexAssignmentWithEqualsOnNewLine()
+    {
+        const string testData = """
+                                namespace TestNamespace
+                                {
+                                    class TestClass
+                                    {
+                                        public void TestMethod()
+                                        {
+                                            var values = new int[1];
+                                            {|#0:values[0]
+                                                = 42|};
+                                        }
+                                    }
+                                }
+                                """;
+
+        const string fixedData = """
+                                 namespace TestNamespace
+                                 {
+                                     class TestClass
+                                     {
+                                         public void TestMethod()
+                                         {
+                                             var values = new int[1];
+                                             values[0] = 42;
+                                         }
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH0391AssignmentsMustHaveProperLineBreaksAnalyzer.DiagnosticId, AnalyzerResources.RH0391MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying no diagnostics for correctly formatted variable declaration
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForCorrectlyFormattedVariableDeclaration()
+    {
+        const string testData = """
+                                namespace TestNamespace
+                                {
+                                    class TestClass
+                                    {
+                                        public void TestMethod()
+                                        {
+                                            var value = "test";
+                                        }
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifying no diagnostics for multiline value starting on same line as equals
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForMultilineValueStartingOnEqualsLine()
+    {
+        const string testData = """
+                                namespace TestNamespace
+                                {
+                                    class TestClass
+                                    {
+                                        public void TestMethod()
+                                        {
+                                            var value = "multiline " +
+                                                        "value";
+                                        }
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifying diagnostics for raw multiline string whose opening quotes start on the next line
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticsForRawMultilineStringWhenQuotesStartOnNextLine()
+    {
+        const string testData = """"
+                                namespace TestNamespace
+                                {
+                                    class TestClass
+                                    {
+                                        public void TestMethod()
+                                        {
+                                            var {|#0:value =
+                                                """
+                                                This is a
+                                                multiline string
+                                                """|};
+                                        }
+                                    }
+                                }
+                                """";
+
+        const string fixedData = """"
+                                 namespace TestNamespace
+                                 {
+                                     class TestClass
+                                     {
+                                         public void TestMethod()
+                                         {
+                                             var value = """
+                                                 This is a
+                                                 multiline string
+                                                 """;
+                                         }
+                                     }
+                                 }
+                                 """";
+
+        await Verify(testData, fixedData, Diagnostics(RH0391AssignmentsMustHaveProperLineBreaksAnalyzer.DiagnosticId, AnalyzerResources.RH0391MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying diagnostics for interpolated raw multiline string whose opening quotes start on the next line
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticsForInterpolatedRawMultilineStringWhenQuotesStartOnNextLine()
+    {
+        const string testData = """"
+                                namespace TestNamespace
+                                {
+                                    class TestClass
+                                    {
+                                        public void TestMethod(string name)
+                                        {
+                                            var {|#0:value =
+                                                $"""
+                                                Hello {name}
+                                                """|};
+                                        }
+                                    }
+                                }
+                                """";
+
+        const string fixedData = """"
+                                 namespace TestNamespace
+                                 {
+                                     class TestClass
+                                     {
+                                         public void TestMethod(string name)
+                                         {
+                                             var value = $"""
+                                                 Hello {name}
+                                                 """;
+                                         }
+                                     }
+                                 }
+                                 """";
+
+        await Verify(testData, fixedData, Diagnostics(RH0391AssignmentsMustHaveProperLineBreaksAnalyzer.DiagnosticId, AnalyzerResources.RH0391MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying no diagnostics for raw multiline string whose opening quotes already start on the equals line
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForRawMultilineStringStartingOnEqualsLine()
+    {
+        const string testData = """"
+                                namespace TestNamespace
+                                {
+                                    class TestClass
+                                    {
+                                        public void TestMethod()
+                                        {
+                                            var value = """
+                                                This is a
+                                                multiline string
+                                                """;
+                                        }
+                                    }
+                                }
+                                """";
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifying no diagnostics for correctly formatted field declaration
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForCorrectlyFormattedFieldDeclaration()
+    {
+        const string testData = """
+                                namespace TestNamespace
+                                {
+                                    class TestClass
+                                    {
+                                        private string _field = "test";
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifying no diagnostics for correctly formatted property declaration
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForCorrectlyFormattedPropertyDeclaration()
+    {
+        const string testData = """
+                                namespace TestNamespace
+                                {
+                                    class TestClass
+                                    {
+                                        public string Property { get; set; } = "test";
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifying no diagnostics for correctly formatted assignment expression
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForCorrectlyFormattedAssignmentExpression()
+    {
+        const string testData = """
+                                namespace TestNamespace
+                                {
+                                    class TestClass
+                                    {
+                                        public void TestMethod()
+                                        {
+                                            string value;
+                                            value = "test";
+                                        }
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifying no diagnostics for correctly formatted member initializer
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForCorrectlyFormattedMemberInitializer()
+    {
+        const string testData = """
+                                namespace TestNamespace
+                                {
+                                    class TestClass
+                                    {
+                                        public void TestMethod()
+                                        {
+                                            var value = new Data
+                                            {
+                                                Name = "test"
+                                            };
+                                        }
+                                    }
+
+                                    class Data
+                                    {
+                                        public string Name { get; set; }
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifying no diagnostics for correctly formatted index assignment
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForCorrectlyFormattedIndexAssignment()
+    {
+        const string testData = """
+                                namespace TestNamespace
+                                {
+                                    class TestClass
+                                    {
+                                        public void TestMethod()
+                                        {
+                                            var values = new int[1];
+                                            values[0] = 42;
+                                        }
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifying no diagnostics for assignment without initializer
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForVariableDeclarationWithoutInitializer()
+    {
+        const string testData = """
+                                namespace TestNamespace
+                                {
+                                    class TestClass
+                                    {
+                                        public void TestMethod()
+                                        {
+                                            string value;
+                                        }
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+}

--- a/Reihitsu.Analyzer/AnalyzerResources.cs
+++ b/Reihitsu.Analyzer/AnalyzerResources.cs
@@ -1005,6 +1005,16 @@ internal static class AnalyzerResources
     internal static string RH0390Title => GetString(nameof(RH0390Title));
 
     /// <summary>
+    /// Gets the localized string for RH0391MessageFormat
+    /// </summary>
+    internal static string RH0391MessageFormat => GetString(nameof(RH0391MessageFormat));
+
+    /// <summary>
+    /// Gets the localized string for RH0391Title
+    /// </summary>
+    internal static string RH0391Title => GetString(nameof(RH0391Title));
+
+    /// <summary>
     /// Gets the localized string for RH0334MessageFormat
     /// </summary>
     internal static string RH0334MessageFormat => GetString(nameof(RH0334MessageFormat));

--- a/Reihitsu.Analyzer/AnalyzerResources.resx
+++ b/Reihitsu.Analyzer/AnalyzerResources.resx
@@ -1089,6 +1089,12 @@
   <data name="RH0390MessageFormat" xml:space="preserve">
     <value>Using directives should be organized into groups separated by blank lines.</value>
   </data>
+  <data name="RH0391Title" xml:space="preserve">
+    <value>Assignments must have proper line breaks</value>
+  </data>
+  <data name="RH0391MessageFormat" xml:space="preserve">
+    <value>Assignment target and equals operator must be on the same line, and the equals operator and the start of the value must be on the same line.</value>
+  </data>
    <data name="RH0401MessageFormat" xml:space="preserve">
     <value>The \&lt;inheritdoc/&gt; Tag should be used if possible.</value>
   </data>

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0391AssignmentsMustHaveProperLineBreaksAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0391AssignmentsMustHaveProperLineBreaksAnalyzer.cs
@@ -1,0 +1,135 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Enumerations;
+
+namespace Reihitsu.Analyzer.Rules.Formatting;
+
+/// <summary>
+/// RH0391: Assignments must have proper line breaks
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class RH0391AssignmentsMustHaveProperLineBreaksAnalyzer : DiagnosticAnalyzerBase<RH0391AssignmentsMustHaveProperLineBreaksAnalyzer>
+{
+    #region Constants
+
+    /// <summary>
+    /// Diagnostic ID
+    /// </summary>
+    public const string DiagnosticId = "RH0391";
+
+    #endregion // Constants
+
+    #region Constructor
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public RH0391AssignmentsMustHaveProperLineBreaksAnalyzer()
+        : base(DiagnosticId, DiagnosticCategory.Formatting, nameof(AnalyzerResources.RH0391Title), nameof(AnalyzerResources.RH0391MessageFormat))
+    {
+    }
+
+    #endregion // Constructor
+
+    #region Methods
+
+    /// <summary>
+    /// Analyzing all <see cref="SyntaxKind.SimpleAssignmentExpression"/> occurrences
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnSimpleAssignmentExpression(SyntaxNodeAnalysisContext context)
+    {
+        var assignment = (AssignmentExpressionSyntax)context.Node;
+
+        if (assignment.Parent is EqualsValueClauseSyntax)
+        {
+            return;
+        }
+
+        CheckAssignment(context, assignment.Left, assignment.OperatorToken, assignment.Right, assignment.GetLocation());
+    }
+
+    /// <summary>
+    /// Analyzing all <see cref="SyntaxKind.VariableDeclaration"/> occurrences
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnVariableDeclaration(SyntaxNodeAnalysisContext context)
+    {
+        var declaration = (VariableDeclarationSyntax)context.Node;
+
+        foreach (var variable in declaration.Variables)
+        {
+            if (variable.Initializer != null)
+            {
+                var identifier = variable.Identifier;
+
+                CheckAssignment(context, identifier, variable.Initializer.EqualsToken, variable.Initializer.Value, variable.GetLocation());
+            }
+        }
+    }
+
+    /// <summary>
+    /// Analyzing all <see cref="SyntaxKind.PropertyDeclaration"/> occurrences
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnPropertyDeclaration(SyntaxNodeAnalysisContext context)
+    {
+        var property = (PropertyDeclarationSyntax)context.Node;
+
+        if (property.Initializer != null)
+        {
+            var identifier = property.Identifier;
+
+            CheckAssignment(context, identifier, property.Initializer.EqualsToken, property.Initializer.Value, property.GetLocation());
+        }
+    }
+
+    /// <summary>
+    /// Checks if an assignment has proper line breaks
+    /// </summary>
+    /// <param name="context">Analysis context</param>
+    /// <param name="target">The assignment target (left-hand side) - can be a token or node</param>
+    /// <param name="equalsToken">The equals token</param>
+    /// <param name="value">The value expression (right-hand side)</param>
+    /// <param name="location">Location for diagnostic reporting</param>
+    private void CheckAssignment(SyntaxNodeAnalysisContext context, SyntaxNodeOrToken target, SyntaxToken equalsToken, ExpressionSyntax value, Location location)
+    {
+        var targetEndLine = target.GetLocation()?.GetLineSpan().EndLinePosition.Line;
+        var equalsLine = equalsToken.GetLocation().GetLineSpan().StartLinePosition.Line;
+        var valueStartLine = value.GetLocation().GetLineSpan().StartLinePosition.Line;
+
+        // Rule 1: The assignment target and equals operator must be on the same line
+        if (targetEndLine != equalsLine)
+        {
+            context.ReportDiagnostic(CreateDiagnostic(location));
+
+            return;
+        }
+
+        // Rule 2: The equals operator and the start of the value must be on the same line
+        if (equalsLine != valueStartLine)
+        {
+            context.ReportDiagnostic(CreateDiagnostic(location));
+        }
+    }
+
+    #endregion // Methods
+
+    #region DiagnosticAnalyzer
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        base.Initialize(context);
+
+        context.RegisterSyntaxNodeAction(OnSimpleAssignmentExpression, SyntaxKind.SimpleAssignmentExpression);
+        context.RegisterSyntaxNodeAction(OnVariableDeclaration, SyntaxKind.VariableDeclaration);
+        context.RegisterSyntaxNodeAction(OnPropertyDeclaration, SyntaxKind.PropertyDeclaration);
+    }
+
+    #endregion // DiagnosticAnalyzer
+}

--- a/Reihitsu.Formatter.Test/Unit/LineBreaks/LineBreakRewriterTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/LineBreaks/LineBreakRewriterTests.cs
@@ -610,6 +610,325 @@ public class LineBreakRewriterTests
     }
 
     /// <summary>
+    /// Verifies that a variable declaration whose value starts on a new line after the equals sign
+    /// is collapsed so the value begins on the same line as the equals sign
+    /// </summary>
+    [TestMethod]
+    public void CollapsesVariableValueToEqualsLine()
+    {
+        // Arrange — value on line after =
+        const string input = """
+                             class Foo
+                             {
+                                 void Bar()
+                                 {
+                                     var value =
+                                         "test";
+                                 }
+                             }
+                             """;
+
+        // Act
+        var result = ExecuteLineBreakPhase(input);
+
+        // Assert — value must start on same line as =
+        Assert.Contains("var value = \"test\";", result, "Value must start on the same line as the equals operator.");
+    }
+
+    /// <summary>
+    /// Verifies that a variable declaration whose equals sign is on a new line after the variable name
+    /// is collapsed so the equals sign is on the same line as the name
+    /// </summary>
+    [TestMethod]
+    public void CollapsesVariableEqualsToTargetLine()
+    {
+        // Arrange — = on line after variable name
+        const string input = """
+                             class Foo
+                             {
+                                 void Bar()
+                                 {
+                                     var value
+                                         = "test";
+                                 }
+                             }
+                             """;
+
+        // Act
+        var result = ExecuteLineBreakPhase(input);
+
+        // Assert — = must be on the same line as the variable name
+        Assert.Contains("var value = \"test\";", result, "Equals sign must be on the same line as the variable name.");
+    }
+
+    /// <summary>
+    /// Verifies that a variable declaration where both the equals sign and the value
+    /// are on separate lines is fully collapsed to a single assignment line
+    /// </summary>
+    [TestMethod]
+    public void CollapsesVariableEqualsAndValueToTargetLine()
+    {
+        // Arrange — = and value both on separate lines
+        const string input = """
+                             class Foo
+                             {
+                                 void Bar()
+                                 {
+                                     int x
+                                         =
+                                         42;
+                                 }
+                             }
+                             """;
+
+        // Act
+        var result = ExecuteLineBreakPhase(input);
+
+        // Assert — all three must end up on one line
+        Assert.Contains("int x = 42;", result, "Variable name, equals sign, and value must all be on the same line.");
+    }
+
+    /// <summary>
+    /// Verifies that an assignment expression whose right-hand side starts on a new line
+    /// after the equals sign is collapsed to the same line
+    /// </summary>
+    [TestMethod]
+    public void CollapsesAssignmentValueToEqualsLine()
+    {
+        // Arrange — right-hand side on line after =
+        const string input = """
+                             class Foo
+                             {
+                                 void Bar()
+                                 {
+                                     string result =
+                                         CalculateValue();
+                                 }
+
+                                 string CalculateValue() { return "x"; }
+                             }
+                             """;
+
+        // Act
+        var result = ExecuteLineBreakPhase(input);
+
+        // Assert — right-hand side must start on the same line as =
+        Assert.Contains("string result = CalculateValue();", result, "Right-hand side must start on the same line as the equals operator.");
+    }
+
+    /// <summary>
+    /// Verifies that an assignment expression whose equals sign is on a new line
+    /// after the property target is collapsed so the equals sign is on the target line
+    /// </summary>
+    [TestMethod]
+    public void CollapsesPropertyAssignmentEqualsToTargetLine()
+    {
+        // Arrange — = on line after property name
+        const string input = """
+                             class Foo
+                             {
+                                 private string Value { get; set; }
+
+                                 void Bar()
+                                 {
+                                     Value
+                                         = "test";
+                                 }
+                             }
+                             """;
+
+        // Act
+        var result = ExecuteLineBreakPhase(input);
+
+        // Assert — = must be on the same line as the property target
+        Assert.Contains("Value = \"test\";", result, "Equals sign must be on the same line as the assignment target.");
+    }
+
+    /// <summary>
+    /// Verifies that a field declaration whose value starts on a new line after the equals sign
+    /// is collapsed so the value begins on the same line as the equals sign
+    /// </summary>
+    [TestMethod]
+    public void CollapsesFieldValueToEqualsLine()
+    {
+        // Arrange — field with value on line after =
+        const string input = """
+                             class Foo
+                             {
+                                 private string _name =
+                                     "default";
+                             }
+                             """;
+
+        // Act
+        var result = ExecuteLineBreakPhase(input);
+
+        // Assert — value must start on the same line as =
+        Assert.Contains("_name = \"default\";", result, "Field value must start on the same line as the equals operator.");
+    }
+
+    /// <summary>
+    /// Verifies that a member initialization whose value starts on a new line
+    /// after the equals sign is collapsed to the same line
+    /// </summary>
+    [TestMethod]
+    public void CollapsesMemberInitializationValueToEqualsLine()
+    {
+        // Arrange — member init with value on new line
+        const string input = """
+                             class Foo
+                             {
+                                 void Bar()
+                                 {
+                                     var obj = new Foo
+                                     {
+                                         Name =
+                                             "test"
+                                     };
+                                 }
+
+                                 public string Name { get; set; }
+                             }
+                             """;
+
+        // Act
+        var result = ExecuteLineBreakPhase(input);
+
+        // Assert — member init value must start on the same line as =
+        Assert.Contains("Name = \"test\"", result, "Member initialization value must start on the same line as the equals operator.");
+    }
+
+    /// <summary>
+    /// Verifies that an index assignment whose equals sign is on a new line
+    /// after the index target is collapsed so the equals sign is on the target line
+    /// </summary>
+    [TestMethod]
+    public void CollapsesIndexAssignmentEqualsToTargetLine()
+    {
+        // Arrange — = on line after index target
+        const string input = """
+                             class Foo
+                             {
+                                 void Bar()
+                                 {
+                                     var values = new int[1];
+                                     values[0]
+                                         = 42;
+                                 }
+                             }
+                             """;
+
+        // Act
+        var result = ExecuteLineBreakPhase(input);
+
+        // Assert — = must be on the same line as the index target
+        Assert.Contains("values[0] = 42;", result, "Equals sign must be on the same line as the index assignment target.");
+    }
+
+    /// <summary>
+    /// Verifies that an already-correct single-line assignment is not modified
+    /// </summary>
+    [TestMethod]
+    public void PreservesCorrectSingleLineAssignment()
+    {
+        // Arrange — already-correct assignment
+        const string input = """
+                             class Foo
+                             {
+                                 void Bar()
+                                 {
+                                     var value = "test";
+                                     int x = 42;
+                                 }
+                             }
+                             """;
+
+        // Act
+        var result = ExecuteLineBreakPhase(input);
+
+        // Assert — nothing should change
+        Assert.AreEqual(input, result, "Correct single-line assignments must not be modified.");
+    }
+
+    /// <summary>
+    /// Verifies that an assignment whose value starts on the equals line but continues
+    /// on subsequent lines is preserved without modification
+    /// </summary>
+    [TestMethod]
+    public void PreservesMultilineValueStartingOnEqualsLine()
+    {
+        // Arrange — value starts on = line and continues below (allowed form)
+        const string input = """
+                             class Foo
+                             {
+                                 void Bar()
+                                 {
+                                     var result = SomeMethod("arg1",
+                                                             "arg2");
+                                 }
+
+                                 string SomeMethod(string a, string b) { return a + b; }
+                             }
+                             """;
+
+        // Act
+        var result = ExecuteLineBreakPhase(input);
+
+        // Assert — value already starts on = line; should not be altered
+        Assert.Contains("var result = SomeMethod(\"arg1\",", result, "Value that starts on the equals line must not be moved.");
+    }
+
+    /// <summary>
+    /// Verifies that a raw multiline string whose opening quotes start on the line after the equals sign
+    /// is collapsed so the opening quotes begin on the same line as the equals sign
+    /// </summary>
+    [TestMethod]
+    public void CollapsesRawMultilineStringAssignmentToEqualsLine()
+    {
+        // Arrange — raw multiline string opening quotes on line after =
+        const string input = "class Foo\n{\n    void Bar()\n    {\n        var text =\n            \"\"\"\n            Hello\n            \"\"\";\n    }\n}\n";
+
+        // Act
+        var result = ExecuteLineBreakPhase(input, "\n");
+
+        // Assert — raw multiline string must start on the equals line
+        Assert.Contains("var text = \"\"\"\n", result, "Raw multiline string opening quotes must be moved to the equals line.");
+    }
+
+    /// <summary>
+    /// Verifies that an interpolated raw multiline string whose opening quotes start on the line after the equals sign
+    /// is collapsed so the opening quotes begin on the same line as the equals sign
+    /// </summary>
+    [TestMethod]
+    public void CollapsesInterpolatedRawMultilineStringAssignmentToEqualsLine()
+    {
+        // Arrange — interpolated raw multiline string opening quotes on line after =
+        const string input = "class Foo\n{\n    void Bar(string name)\n    {\n        var text =\n            $\"\"\"\n            Hello {name}\n            \"\"\";\n    }\n}\n";
+
+        // Act
+        var result = ExecuteLineBreakPhase(input, "\n");
+
+        // Assert — interpolated raw multiline string must start on the equals line
+        Assert.Contains("var text = $\"\"\"\n", result, "Interpolated raw multiline string opening quotes must be moved to the equals line.");
+    }
+
+    /// <summary>
+    /// Verifies that a raw multiline string whose opening quotes already begin on the equals line is preserved
+    /// </summary>
+    [TestMethod]
+    public void PreservesRawMultilineStringStartingOnEqualsLine()
+    {
+        // Arrange — raw multiline string opening quotes already on = line
+        const string input = "class Foo\n{\n    void Bar()\n    {\n        var text = \"\"\"\n            Hello\n            \"\"\";\n    }\n}\n";
+
+        // Act
+        var result = ExecuteLineBreakPhase(input, "\n");
+
+        // Assert — already-correct raw multiline string must not be modified
+        Assert.AreEqual(input, result, "Raw multiline string opening quotes already on the equals line must be preserved.");
+    }
+
+    /// <summary>
     /// Executes the <see cref="LineBreakPhase"/> on the given C# source text
     /// </summary>
     /// <param name="input">The C# source text to format</param>

--- a/Reihitsu.Formatter.Test/Unit/Pipeline/FormattingPipelineTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/Pipeline/FormattingPipelineTests.cs
@@ -76,12 +76,11 @@ public class FormattingPipelineTests
     public void ExecuteCancellationRequestedThrowsOperationCanceled()
     {
         // Arrange
-        var input =
-        """
-        class Foo
-        {
-        }
-        """;
+        var input = """
+                    class Foo
+                    {
+                    }
+                    """;
 
         var tree = CSharpSyntaxTree.ParseText(input, cancellationToken: TestContext.CancellationTokenSource.Token);
         var context = new FormattingContext(Environment.NewLine);

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/LineBreakRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/LineBreakRewriter.cs
@@ -1639,16 +1639,26 @@ internal sealed class LineBreakRewriter : CSharpSyntaxRewriter
                 node = node.WithCloseBraceToken(PrependEndOfLine(node.CloseBraceToken));
             }
         }
-        else
+        else if (node != null)
         {
             node = EnsureBraceOnOwnLine(node, node.OpenBraceToken, (n, t) => n.WithOpenBraceToken(t), node.CloseBraceToken, (n, t) => n.WithCloseBraceToken(t));
         }
 
-        node = EnsureFirstContentOnNewLine(node, node.OpenBraceToken);
-        node = EnsureCloseBraceContinuation(node, node.CloseBraceToken);
+        if (node != null)
+        {
+            node = EnsureFirstContentOnNewLine(node, node.OpenBraceToken);
+        }
+
+        if (node != null)
+        {
+            node = EnsureCloseBraceContinuation(node, node.CloseBraceToken);
+        }
 
         // Clean trailing whitespace before close brace when it was moved to a new line
-        node = CleanupTrailingWhitespaceBeforeCloseBrace(node);
+        if (node != null)
+        {
+            node = CleanupTrailingWhitespaceBeforeCloseBrace(node);
+        }
 
         return node;
     }
@@ -1705,6 +1715,81 @@ internal sealed class LineBreakRewriter : CSharpSyntaxRewriter
             }
         }
 
+        // Rules for simple assignment (=): enforce same-line placement of operator and value.
+        if (node.IsKind(SyntaxKind.SimpleAssignmentExpression))
+        {
+            // Rule 1: The equals operator must be on the same line as the assignment target.
+            var operatorToken = node.OperatorToken;
+
+            if (HasLeadingEndOfLine(operatorToken))
+            {
+                var newOperatorToken = RemoveLeadingEndOfLineAndWhitespace(operatorToken);
+
+                if (newOperatorToken.LeadingTrivia.Any(SyntaxKind.WhitespaceTrivia) == false)
+                {
+                    newOperatorToken = newOperatorToken.WithLeadingTrivia(newOperatorToken.LeadingTrivia.Add(SyntaxFactory.Space));
+                }
+
+                var previousToken = operatorToken.GetPreviousToken();
+
+                if (previousToken != default
+                    && previousToken.IsKind(SyntaxKind.None) == false
+                    && HasTrailingEndOfLine(previousToken))
+                {
+                    var newPreviousToken = previousToken.WithTrailingTrivia(RemoveTrailingEndOfLineTrivia(previousToken.TrailingTrivia));
+
+                    node = node.ReplaceTokens([previousToken, operatorToken],
+                                              (original, _) =>
+                                              {
+                                                  if (original == previousToken)
+                                                  {
+                                                      return newPreviousToken;
+                                                  }
+
+                                                  return newOperatorToken;
+                                              });
+                }
+                else
+                {
+                    node = node.WithOperatorToken(newOperatorToken);
+                }
+            }
+
+            // Rule 2: The right-hand side must start on the same line as the equals operator.
+            // Collection expressions and collection initializers are already handled above.
+            if (node.Right is not CollectionExpressionSyntax
+                && node.Right is not InitializerExpressionSyntax
+                && HasTrailingEndOfLine(node.OperatorToken))
+            {
+                var rightFirstToken = node.Right.GetFirstToken();
+
+                if (rightFirstToken != default
+                    && HasLeadingEndOfLine(rightFirstToken))
+                {
+                    var currentOperatorToken = node.OperatorToken;
+                    var newOperatorTrivia = RemoveTrailingEndOfLineTrivia(currentOperatorToken.TrailingTrivia);
+
+                    if (newOperatorTrivia.Any(SyntaxKind.WhitespaceTrivia) == false)
+                    {
+                        newOperatorTrivia = newOperatorTrivia.Add(SyntaxFactory.Space);
+                    }
+
+                    var newRightFirstToken = RemoveLeadingEndOfLineAndWhitespace(rightFirstToken);
+
+                    node = node.ReplaceTokens([currentOperatorToken, rightFirstToken],
+                                              (original, _) =>
+                                              {
+                                                  if (original == currentOperatorToken)
+                                                  {
+                                                      return currentOperatorToken.WithTrailingTrivia(newOperatorTrivia);
+                                                  }
+
+                                                  return newRightFirstToken;
+                                              });
+                }
+            }
+        }
+
         return node;
     }
 
@@ -1747,6 +1832,97 @@ internal sealed class LineBreakRewriter : CSharpSyntaxRewriter
 
                                               return newOpenBracket;
                                           });
+            }
+        }
+
+        // Rule 2: The value must start on the same line as the equals operator.
+        // Collection expressions are already handled above.
+        if (node.Value is not CollectionExpressionSyntax
+            && HasTrailingEndOfLine(node.EqualsToken))
+        {
+            var equalsToken = node.EqualsToken;
+            var valueFirstToken = node.Value.GetFirstToken();
+
+            if (valueFirstToken != default
+                && HasLeadingEndOfLine(valueFirstToken))
+            {
+                var newEqualsTrivia = RemoveTrailingEndOfLineTrivia(equalsToken.TrailingTrivia);
+
+                if (newEqualsTrivia.Any(SyntaxKind.WhitespaceTrivia) == false)
+                {
+                    newEqualsTrivia = newEqualsTrivia.Add(SyntaxFactory.Space);
+                }
+
+                var newValueFirstToken = RemoveLeadingEndOfLineAndWhitespace(valueFirstToken);
+
+                node = node.ReplaceTokens([equalsToken, valueFirstToken],
+                                          (original, _) =>
+                                          {
+                                              if (original == equalsToken)
+                                              {
+                                                  return equalsToken.WithTrailingTrivia(newEqualsTrivia);
+                                              }
+
+                                              return newValueFirstToken;
+                                          });
+            }
+        }
+
+        return node;
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxNode VisitVariableDeclarator(VariableDeclaratorSyntax node)
+    {
+        _cancellationToken.ThrowIfCancellationRequested();
+
+        node = (VariableDeclaratorSyntax)base.VisitVariableDeclarator(node);
+
+        if (node == null)
+        {
+            return null;
+        }
+
+        if (node.Initializer == null)
+        {
+            return node;
+        }
+
+        // Rule 1: The equals token must be on the same line as the variable/field name.
+        // Rule 2 (value on same line as =) is handled in VisitEqualsValueClause.
+        var equalsToken = node.Initializer.EqualsToken;
+
+        if (HasLeadingEndOfLine(equalsToken))
+        {
+            var newEqualsToken = RemoveLeadingEndOfLineAndWhitespace(equalsToken);
+
+            if (newEqualsToken.LeadingTrivia.Any(SyntaxKind.WhitespaceTrivia) == false)
+            {
+                newEqualsToken = newEqualsToken.WithLeadingTrivia(newEqualsToken.LeadingTrivia.Add(SyntaxFactory.Space));
+            }
+
+            var previousToken = equalsToken.GetPreviousToken();
+
+            if (previousToken != default
+                && previousToken.IsKind(SyntaxKind.None) == false
+                && HasTrailingEndOfLine(previousToken))
+            {
+                var newPreviousToken = previousToken.WithTrailingTrivia(RemoveTrailingEndOfLineTrivia(previousToken.TrailingTrivia));
+
+                node = node.ReplaceTokens([previousToken, equalsToken],
+                                          (original, _) =>
+                                          {
+                                              if (original == previousToken)
+                                              {
+                                                  return newPreviousToken;
+                                              }
+
+                                              return newEqualsToken;
+                                          });
+            }
+            else
+            {
+                node = node.ReplaceToken(equalsToken, newEqualsToken);
             }
         }
 

--- a/Reihitsu.sln
+++ b/Reihitsu.sln
@@ -171,6 +171,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		documentation\rules\RH0388.md = documentation\rules\RH0388.md
 		documentation\rules\RH0389.md = documentation\rules\RH0389.md
 		documentation\rules\RH0390.md = documentation\rules\RH0390.md
+		documentation\rules\RH0391.md = documentation\rules\RH0391.md
 		documentation\rules\RH0401.md = documentation\rules\RH0401.md
 		documentation\rules\RH0402.md = documentation\rules\RH0402.md
 		documentation\rules\RH0403.md = documentation\rules\RH0403.md

--- a/documentation/rules/RH0391.md
+++ b/documentation/rules/RH0391.md
@@ -1,0 +1,50 @@
+# RH0391 — Assignments must have proper line breaks
+
+| Property | Value |
+|----------|-------|
+| **ID** | RH0391 |
+| **Category** | Formatting |
+| **Severity** | Warning |
+| **Code Fix** | ✔ |
+
+## Description
+
+This rule requires the assignment target and `=` operator to stay on the same line, and it requires the assigned value to begin on that same line as `=`.
+
+## Why is this a problem?
+
+Splitting the target, `=`, and the start of the value across separate lines makes assignments harder to scan. Keeping those parts together makes declarations, assignments, member initializers, and index assignments easier to read consistently.
+
+## How to fix it
+
+Move the `=` operator onto the target line and move the start of the assigned value onto the `=` line. Multiline values are still allowed as long as they begin on the `=` line. Raw multiline string opening quotes must also begin on the `=` line.
+
+## Examples
+
+### Violation
+
+```cs
+var result
+    = 42;
+
+settings.Name =
+    "demo";
+
+values[0]
+    = GetValue();
+```
+
+### Correction
+
+```cs
+var result = 42;
+
+settings.Name = "demo";
+
+values[0] = GetValue();
+
+var text = """
+           Hello
+           World
+           """;
+```


### PR DESCRIPTION
Introduce RH0391 analyzer and code fix to require assignment targets, equals sign, and value start to be on the same line for assignments, variable/field initializers, and property initializers. Update LineBreakRewriter to apply this rule during formatting. Add comprehensive tests and documentation. Update resources, README, and solution to reference the new rule.