### PR TITLE
RH0322: Full support, analyzer fixes, and formatter tests

### DIFF
--- a/Reihitsu.Analyzer.Package/README.MD
+++ b/Reihitsu.Analyzer.Package/README.MD
@@ -90,7 +90,7 @@ dotnet add package Reihitsu.Analyzer
 | [RH0319](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0319.md)| The fixed-Statement should be preceded by a blank line.| ✔| ✔| ✔|
 | [RH0320](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0320.md)| The lock-Statement should be preceded by a blank line.| ✔| ✔| ✔|
 | [RH0321](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0321.md)| The yield-Statement should be preceded by a blank line.| ✔| ✔| ✔|
-| [RH0322](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0322.md)| Single line comments should be preceded by a blank line.| ❌| ❌| ❌|
+| [RH0322](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0322.md)| Single line comments should be preceded by a blank line.| ✔| ✔| ✔|
 | [RH0323](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0323.md)| Assignments and statements should be separated by a blank line.| ❌| ❌| ❌|
 | [RH0324](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0324.md)| Method chains should be aligned.| ✔| ✔| ✔|
 | [RH0325](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0325.md)| Expression style methods should not be used.| ✔| ✔| ✔|

--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH0322SingleLineCommentsShouldBePrecededByABlankLineFormatterTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH0322SingleLineCommentsShouldBePrecededByABlankLineFormatterTests.cs
@@ -1,5 +1,7 @@
 using System.Threading.Tasks;
 
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Reihitsu.Analyzer.Rules.Formatting;
 using Reihitsu.Analyzer.Test.Base;
 

--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH0322SingleLineCommentsShouldBePrecededByABlankLineFormatterTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH0322SingleLineCommentsShouldBePrecededByABlankLineFormatterTests.cs
@@ -1,0 +1,63 @@
+using System.Threading.Tasks;
+
+using Reihitsu.Analyzer.Rules.Formatting;
+using Reihitsu.Analyzer.Test.Base;
+
+namespace Reihitsu.Analyzer.Test.Formatter.Formatting;
+
+/// <summary>
+/// Formatter validation tests for <see cref="RH0322SingleLineCommentsShouldBePrecededByABlankLineAnalyzer"/>
+/// </summary>
+[TestClass]
+public class RH0322SingleLineCommentsShouldBePrecededByABlankLineFormatterTests : FormatterTestsBase<RH0322SingleLineCommentsShouldBePrecededByABlankLineAnalyzer>
+{
+    #region Members
+
+    /// <summary>
+    /// Verifies that the formatter inserts a blank line before the first comment in a comment block
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFormatterFixesCommentBlockViolation()
+    {
+        const string input = """
+                             internal class Example
+                             {
+                                 internal void Method()
+                                 {
+                                     var value = 1;
+                                     // First comment
+                                     // Follow-up comment
+                                     Consume(value);
+                                 }
+
+                                 private void Consume(int value)
+                                 {
+                                 }
+                             }
+                             """;
+        const string fixedData = """
+                                 internal class Example
+                                 {
+                                     internal void Method()
+                                     {
+                                         var value = 1;
+
+                                         // First comment
+                                         // Follow-up comment
+                                         Consume(value);
+                                     }
+
+                                     private void Consume(int value)
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await VerifyFormatterFix(input,
+                                 fixedData,
+                                 ExpectedDiagnostic(RH0322SingleLineCommentsShouldBePrecededByABlankLineAnalyzer.DiagnosticId, 6, 9, 6, 25, AnalyzerResources.RH0322MessageFormat));
+    }
+
+    #endregion // Members
+}

--- a/Reihitsu.Analyzer.Test/Formatting/RH0322SingleLineCommentsShouldBePrecededByABlankLineAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH0322SingleLineCommentsShouldBePrecededByABlankLineAnalyzerTests.cs
@@ -59,6 +59,51 @@ public class RH0322SingleLineCommentsShouldBePrecededByABlankLineAnalyzerTests :
     }
 
     /// <summary>
+    /// Verifies diagnostics are reported only for the first comment in a comment block
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticForCommentBlockWithoutPrecedingBlankLine()
+    {
+        const string testCode = """
+                                internal class RH0322
+                                {
+                                    public void Execute()
+                                    {
+                                        var value = 0;
+                                        {|#0:// Explain the value|}
+                                        // Continue the explanation
+                                        Consume(value);
+                                    }
+
+                                    private void Consume(int value)
+                                    {
+                                    }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 internal class RH0322
+                                 {
+                                     public void Execute()
+                                     {
+                                         var value = 0;
+
+                                         // Explain the value
+                                         // Continue the explanation
+                                         Consume(value);
+                                     }
+
+                                     private void Consume(int value)
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH0322SingleLineCommentsShouldBePrecededByABlankLineAnalyzer.DiagnosticId, AnalyzerResources.RH0322MessageFormat));
+    }
+
+    /// <summary>
     /// Verifies no diagnostics are reported when a single-line comment already has a preceding blank line
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
@@ -99,6 +144,53 @@ public class RH0322SingleLineCommentsShouldBePrecededByABlankLineAnalyzerTests :
                                     {
                                         // First comment in block
                                         Consume(0);
+                                    }
+
+                                    private void Consume(int value)
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
+    /// <summary>
+    /// Verifies no diagnostics are reported for the first comment in a file
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticForFirstCommentInFile()
+    {
+        const string testCode = """
+                                // File header comment
+                                internal class RH0322
+                                {
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
+    /// <summary>
+    /// Verifies no diagnostics are reported when a comment starts a switch section
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticForFirstCommentInSwitchSection()
+    {
+        const string testCode = """
+                                internal class RH0322
+                                {
+                                    public void Execute(int value)
+                                    {
+                                        switch (value)
+                                        {
+                                            case 0:
+                                                // First comment in switch section
+                                                Consume(value);
+                                                break;
+                                        }
                                     }
 
                                     private void Consume(int value)

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0322SingleLineCommentsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0322SingleLineCommentsShouldBePrecededByABlankLineAnalyzer.cs
@@ -38,6 +38,23 @@ public class RH0322SingleLineCommentsShouldBePrecededByABlankLineAnalyzer : Diag
     #region Methods
 
     /// <summary>
+    /// Determines whether the comment starts a block or switch section
+    /// </summary>
+    /// <param name="commentTrivia">The comment trivia</param>
+    /// <returns><see langword="true"/> if the comment starts a block or switch section</returns>
+    private static bool IsFirstCommentInBlock(SyntaxTrivia commentTrivia)
+    {
+        var previousToken = commentTrivia.Token.GetPreviousToken();
+
+        return previousToken.RawKind == 0
+               || previousToken.IsKind(SyntaxKind.OpenBraceToken)
+               || (previousToken.IsKind(SyntaxKind.ColonToken)
+                   && previousToken.Parent?.Kind() is SyntaxKind.CaseSwitchLabel
+                                                   or SyntaxKind.CasePatternSwitchLabel
+                                                   or SyntaxKind.DefaultSwitchLabel);
+    }
+
+    /// <summary>
     /// Analyzes single-line comments for missing separating blank lines
     /// </summary>
     /// <param name="context">Context</param>
@@ -88,7 +105,7 @@ public class RH0322SingleLineCommentsShouldBePrecededByABlankLineAnalyzer : Diag
             var previousLineText = FormattingTextAnalysisUtilities.GetLineText(sourceText, sourceText.Lines[previousNonBlankLineIndex]).TrimStart();
 
             if (previousLineText.StartsWith("//", StringComparison.Ordinal)
-                || previousLineText.EndsWith("{", StringComparison.Ordinal))
+                || IsFirstCommentInBlock(trivia))
             {
                 continue;
             }


### PR DESCRIPTION
README updated to mark RH0322 as fully supported. Analyzer logic improved to skip diagnostics for first comments in blocks and switch sections. Added new analyzer and formatter tests to verify correct handling of comment blocks and edge cases.