### PR TITLE
Implement RH0323: blank line after local declarations

### DIFF
--- a/Reihitsu.Analyzer.CodeFixes/CodeFixResources.cs
+++ b/Reihitsu.Analyzer.CodeFixes/CodeFixResources.cs
@@ -339,6 +339,11 @@ internal static class CodeFixResources
     internal static string RH0322Title => GetString(nameof(RH0322Title));
 
     /// <summary>
+    /// Gets the localized string for RH0323Title
+    /// </summary>
+    internal static string RH0323Title => GetString(nameof(RH0323Title));
+
+    /// <summary>
     /// Gets the localized string for RH0324Title
     /// </summary>
     internal static string RH0324Title => GetString(nameof(RH0324Title));

--- a/Reihitsu.Analyzer.CodeFixes/CodeFixResources.resx
+++ b/Reihitsu.Analyzer.CodeFixes/CodeFixResources.resx
@@ -306,6 +306,9 @@
   <data name="RH0322Title" xml:space="preserve">
     <value>Insert blank line before comment</value>
   </data>
+  <data name="RH0323Title" xml:space="preserve">
+    <value>Insert blank line after declaration</value>
+  </data>
   <data name="RH0302Title" xml:space="preserve">
     <value>Fix the indention of the initializer</value>
   </data>

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0323LocalDeclarationsShouldBeFollowedByABlankLineCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0323LocalDeclarationsShouldBeFollowedByABlankLineCodeFixProvider.cs
@@ -1,0 +1,28 @@
+using System.Composition;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+using Reihitsu.Analyzer.Base;
+
+namespace Reihitsu.Analyzer.Rules.Formatting;
+
+/// <summary>
+/// Providing fixes for <see cref="RH0323LocalDeclarationsShouldBeFollowedByABlankLineAnalyzer"/>
+/// </summary>
+[Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(RH0323LocalDeclarationsShouldBeFollowedByABlankLineCodeFixProvider))]
+public class RH0323LocalDeclarationsShouldBeFollowedByABlankLineCodeFixProvider : StatementShouldBePrecededByABlankLineCodeFixProviderBase
+{
+    #region Constructor
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public RH0323LocalDeclarationsShouldBeFollowedByABlankLineCodeFixProvider()
+        : base(RH0323LocalDeclarationsShouldBeFollowedByABlankLineAnalyzer.DiagnosticId, CodeFixResources.RH0323Title)
+    {
+    }
+
+    #endregion // Constructor
+}

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0330RawStringLiteralsShouldBeFormattedCorrectlyCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0330RawStringLiteralsShouldBeFormattedCorrectlyCodeFixProvider.cs
@@ -103,6 +103,7 @@ public class RH0330RawStringLiteralsShouldBeFormattedCorrectlyCodeFixProvider : 
             else
             {
                 var spacesToRemove = Math.Min(-delta, GetLeadingSpaceCount(line));
+
                 result.Append(line.Substring(spacesToRemove));
             }
         }

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0390UsingDirectivesShouldBeOrganizedIntoGroupsCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0390UsingDirectivesShouldBeOrganizedIntoGroupsCodeFixProvider.cs
@@ -143,6 +143,7 @@ public class RH0390UsingDirectivesShouldBeOrganizedIntoGroupsCodeFixProvider : C
                                       {
                                           SyntaxFactory.EndOfLine(Environment.NewLine)
                                       };
+
             blankLineTriviaList.AddRange(indentation);
             result.Add(current.WithLeadingTrivia(SyntaxFactory.TriviaList(blankLineTriviaList)));
         }

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0391AssignmentsMustHaveProperLineBreaksCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0391AssignmentsMustHaveProperLineBreaksCodeFixProvider.cs
@@ -252,6 +252,7 @@ public class RH0391AssignmentsMustHaveProperLineBreaksCodeFixProvider : CodeFixP
                         {
                             SyntaxFactory.Space
                         };
+
         newTrivia.AddRange(trivia);
 
         return SyntaxFactory.TriviaList(newTrivia);

--- a/Reihitsu.Analyzer.Package/README.MD
+++ b/Reihitsu.Analyzer.Package/README.MD
@@ -91,7 +91,7 @@ dotnet add package Reihitsu.Analyzer
 | [RH0320](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0320.md)| The lock-Statement should be preceded by a blank line.| ✔| ✔| ✔|
 | [RH0321](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0321.md)| The yield-Statement should be preceded by a blank line.| ✔| ✔| ✔|
 | [RH0322](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0322.md)| Single line comments should be preceded by a blank line.| ✔| ✔| ✔|
-| [RH0323](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0323.md)| Assignments and statements should be separated by a blank line.| ❌| ❌| ❌|
+| [RH0323](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0323.md)| Local declarations should be followed by a blank line.| ✔| ✔| ✔|
 | [RH0324](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0324.md)| Method chains should be aligned.| ✔| ✔| ✔|
 | [RH0325](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0325.md)| Expression style methods should not be used.| ✔| ✔| ✔|
 | [RH0326](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0326.md)| Expression style constructors should not be used.| ✔| ❌| ✔|

--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH0323LocalDeclarationsShouldBeFollowedByABlankLineFormatterTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH0323LocalDeclarationsShouldBeFollowedByABlankLineFormatterTests.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Analyzer.Rules.Formatting;
+using Reihitsu.Analyzer.Test.Base;
+using Reihitsu.Formatter;
+using Reihitsu.Formatter.Pipeline;
+
+namespace Reihitsu.Analyzer.Test.Formatter.Formatting;
+
+/// <summary>
+/// Formatter validation tests for <see cref="RH0323LocalDeclarationsShouldBeFollowedByABlankLineAnalyzer"/>
+/// </summary>
+[TestClass]
+public class RH0323LocalDeclarationsShouldBeFollowedByABlankLineFormatterTests : FormatterTestsBase<RH0323LocalDeclarationsShouldBeFollowedByABlankLineAnalyzer>
+{
+    #region Members
+
+    /// <summary>
+    /// Verifies that the formatter inserts a blank line between a local declaration with initializer and a following expression statement
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFormatterInsertsBlankLineAfterLocalDeclarationBeforeExpressionStatement()
+    {
+        const string input = """
+                             internal class Example
+                             {
+                                 internal void Method()
+                                 {
+                                     var value = GetValue();
+                                     Consume(value);
+                                 }
+
+                                 private string GetValue()
+                                 {
+                                     return string.Empty;
+                                 }
+
+                                 private void Consume(string value)
+                                 {
+                                 }
+                             }
+                             """;
+        const string fixedData = """
+                                 internal class Example
+                                 {
+                                     internal void Method()
+                                     {
+                                         var value = GetValue();
+
+                                         Consume(value);
+                                     }
+
+                                     private string GetValue()
+                                     {
+                                         return string.Empty;
+                                     }
+
+                                     private void Consume(string value)
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await VerifyFormatterFix(input,
+                                 fixedData,
+                                 ExpectedDiagnostic(RH0323LocalDeclarationsShouldBeFollowedByABlankLineAnalyzer.DiagnosticId, 6, 9, 6, 16, AnalyzerResources.RH0323MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that the formatter inserts a blank line between a local declaration without initializer and a following expression statement
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFormatterInsertsBlankLineAfterLocalDeclarationWithoutInitializerBeforeExpressionStatement()
+    {
+        const string input = """
+                             internal class Example
+                             {
+                                 internal void Method()
+                                 {
+                                     string text;
+                                     Consume();
+                                 }
+
+                                 private void Consume()
+                                 {
+                                 }
+                             }
+                             """;
+        const string fixedData = """
+                                 internal class Example
+                                 {
+                                     internal void Method()
+                                     {
+                                         string text;
+
+                                         Consume();
+                                     }
+
+                                     private void Consume()
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await VerifyFormatterFix(input,
+                                 fixedData,
+                                 ExpectedDiagnostic(RH0323LocalDeclarationsShouldBeFollowedByABlankLineAnalyzer.DiagnosticId, 6, 9, 6, 16, AnalyzerResources.RH0323MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that the formatter leaves an expression statement before a declaration untouched
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFormatterLeavesExpressionStatementBeforeLocalDeclarationUntouched()
+    {
+        const string input = """
+                             internal class Example
+                             {
+                                 internal void Method()
+                                 {
+                                     Consume();
+                                     var next = GetValue();
+                                 }
+
+                                 private string GetValue()
+                                 {
+                                     return string.Empty;
+                                 }
+
+                                 private void Consume()
+                                 {
+                                 }
+                             }
+                             """;
+
+        await VerifyFormatterLeavesCodeUnchanged(input);
+    }
+
+    /// <summary>
+    /// Verifies that the formatter leaves mixed declaration blocks and consecutive expression statements untouched
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFormatterDoesNotSplitMixedDeclarationBlocksOrConsecutiveExpressionStatements()
+    {
+        const string input = """
+                             internal class Example
+                             {
+                                 internal void Method()
+                                 {
+                                     string text;
+                                     var value = GetValue();
+
+                                     Consume(value);
+                                     Consume(value);
+                                 }
+
+                                 private string GetValue()
+                                 {
+                                     return string.Empty;
+                                 }
+
+                                 private void Consume(string value)
+                                 {
+                                 }
+                             }
+                             """;
+
+        await VerifyFormatterLeavesCodeUnchanged(input);
+    }
+
+    /// <summary>
+    /// Verifies the formatter leaves already compliant code unchanged
+    /// </summary>
+    /// <param name="source">Source code</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    private static async Task VerifyFormatterLeavesCodeUnchanged(string source)
+    {
+        await Verify(source);
+
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var context = new FormattingContext(Environment.NewLine);
+        var formatted = FormattingPipeline.Execute(await tree.GetRootAsync(), context, CancellationToken.None).ToFullString();
+
+        Assert.AreEqual(source, formatted, "Formatter output should keep compliant code unchanged.");
+
+        await Verify(formatted);
+    }
+
+    #endregion // Members
+}

--- a/Reihitsu.Analyzer.Test/Formatting/RH0323LocalDeclarationsShouldBeFollowedByABlankLineAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH0323LocalDeclarationsShouldBeFollowedByABlankLineAnalyzerTests.cs
@@ -1,0 +1,345 @@
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Analyzer.Rules.Formatting;
+using Reihitsu.Analyzer.Test.Base;
+
+namespace Reihitsu.Analyzer.Test.Formatting;
+
+/// <summary>
+/// Test methods for <see cref="RH0323LocalDeclarationsShouldBeFollowedByABlankLineAnalyzer"/> and <see cref="RH0323LocalDeclarationsShouldBeFollowedByABlankLineCodeFixProvider"/>
+/// </summary>
+[TestClass]
+public class RH0323LocalDeclarationsShouldBeFollowedByABlankLineAnalyzerTests : AnalyzerTestsBase<RH0323LocalDeclarationsShouldBeFollowedByABlankLineAnalyzer, RH0323LocalDeclarationsShouldBeFollowedByABlankLineCodeFixProvider>
+{
+    #region Members
+
+    /// <summary>
+    /// Verifies diagnostics are reported when a local declaration with initializer is directly followed by an expression statement
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticWhenLocalDeclarationIsFollowedByExpressionStatementWithoutBlankLine()
+    {
+        const string testCode = """
+                                internal class RH0323
+                                {
+                                    public void Execute()
+                                    {
+                                        var value = GetValue();
+                                        {|#0:Consume|}(value);
+                                    }
+
+                                    private string GetValue()
+                                    {
+                                        return string.Empty;
+                                    }
+
+                                    private void Consume(string value)
+                                    {
+                                    }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 internal class RH0323
+                                 {
+                                     public void Execute()
+                                     {
+                                         var value = GetValue();
+
+                                         Consume(value);
+                                     }
+
+                                     private string GetValue()
+                                     {
+                                         return string.Empty;
+                                     }
+
+                                     private void Consume(string value)
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH0323LocalDeclarationsShouldBeFollowedByABlankLineAnalyzer.DiagnosticId, AnalyzerResources.RH0323MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies diagnostics are reported when a local declaration without initializer is directly followed by an expression statement
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticWhenLocalDeclarationWithoutInitializerIsFollowedByExpressionStatementWithoutBlankLine()
+    {
+        const string testCode = """
+                                internal class RH0323
+                                {
+                                    public void Execute()
+                                    {
+                                        string text;
+                                        {|#0:Consume|}();
+                                    }
+
+                                    private void Consume()
+                                    {
+                                    }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 internal class RH0323
+                                 {
+                                     public void Execute()
+                                     {
+                                         string text;
+
+                                         Consume();
+                                     }
+
+                                     private void Consume()
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH0323LocalDeclarationsShouldBeFollowedByABlankLineAnalyzer.DiagnosticId, AnalyzerResources.RH0323MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies no diagnostics are reported when an expression statement is followed by a local declaration
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticWhenExpressionStatementIsFollowedByLocalDeclarationWithoutBlankLine()
+    {
+        const string testCode = """
+                                internal class RH0323
+                                {
+                                    public void Execute()
+                                    {
+                                        Consume();
+                                        var next = GetValue();
+                                    }
+
+                                    private string GetValue()
+                                    {
+                                        return string.Empty;
+                                    }
+
+                                    private void Consume()
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
+    /// <summary>
+    /// Verifies no diagnostics are reported for consecutive local declarations with initializer
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticForConsecutiveLocalDeclarationsWithInitializer()
+    {
+        const string testCode = """
+                                internal class RH0323
+                                {
+                                    public void Execute()
+                                    {
+                                        var first = GetValue();
+                                        var second = GetValue();
+
+                                        Consume(first + second);
+                                    }
+
+                                    private string GetValue()
+                                    {
+                                        return string.Empty;
+                                    }
+
+                                    private void Consume(string value)
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
+    /// <summary>
+    /// Verifies no diagnostics are reported for consecutive local declarations without initializer
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticForConsecutiveLocalDeclarationsWithoutInitializer()
+    {
+        const string testCode = """
+                                internal class RH0323
+                                {
+                                    public void Execute()
+                                    {
+                                        string first;
+                                        string second;
+
+                                        Consume();
+                                    }
+
+                                    private void Consume()
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
+    /// <summary>
+    /// Verifies no diagnostics are reported inside a mixed local declaration block
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticForMixedLocalDeclarationBlockWithAndWithoutInitializer()
+    {
+        const string testCode = """
+                                internal class RH0323
+                                {
+                                    public void Execute()
+                                    {
+                                        string text;
+                                        var value = GetValue();
+
+                                        Consume(value);
+                                    }
+
+                                    private string GetValue()
+                                    {
+                                        return string.Empty;
+                                    }
+
+                                    private void Consume(string value)
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
+    /// <summary>
+    /// Verifies no diagnostics are reported for consecutive expression statements
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticForConsecutiveExpressionStatements()
+    {
+        const string testCode = """
+                                internal class RH0323
+                                {
+                                    public void Execute()
+                                    {
+                                        Consume();
+                                        Consume();
+                                    }
+
+                                    private void Consume()
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
+    /// <summary>
+    /// Verifies no diagnostics are reported when a local declaration and expression statement are already separated by a blank line
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticWhenLocalDeclarationAndExpressionStatementAreAlreadySeparatedByBlankLine()
+    {
+        const string testCode = """
+                                internal class RH0323
+                                {
+                                    public void Execute()
+                                    {
+                                        var value = GetValue();
+
+                                        Consume(value);
+                                    }
+
+                                    private string GetValue()
+                                    {
+                                        return string.Empty;
+                                    }
+
+                                    private void Consume(string value)
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
+    /// <summary>
+    /// Verifies no diagnostics are reported when a local declaration is followed by a control flow statement
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticForLocalDeclarationAdjacentToControlFlowStatement()
+    {
+        const string testCode = """
+                                internal class RH0323
+                                {
+                                    public string Execute()
+                                    {
+                                        var value = GetValue();
+                                        return value;
+                                    }
+
+                                    private string GetValue()
+                                    {
+                                        return string.Empty;
+                                    }
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
+    /// <summary>
+    /// Verifies no diagnostics are reported when a plain assignment is followed by an expression statement
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticForAssignmentStatementAdjacentToExpressionStatement()
+    {
+        const string testCode = """
+                                internal class RH0323
+                                {
+                                    public void Execute()
+                                    {
+                                        var value = string.Empty;
+                                        value = GetValue();
+                                        Consume(value);
+                                    }
+
+                                    private string GetValue()
+                                    {
+                                        return string.Empty;
+                                    }
+
+                                    private void Consume(string value)
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
+    #endregion // Members
+}

--- a/Reihitsu.Analyzer/AnalyzerResources.cs
+++ b/Reihitsu.Analyzer/AnalyzerResources.cs
@@ -775,6 +775,16 @@ internal static class AnalyzerResources
     internal static string RH0322Title => GetString(nameof(RH0322Title));
 
     /// <summary>
+    /// Gets the localized string for RH0323MessageFormat
+    /// </summary>
+    internal static string RH0323MessageFormat => GetString(nameof(RH0323MessageFormat));
+
+    /// <summary>
+    /// Gets the localized string for RH0323Title
+    /// </summary>
+    internal static string RH0323Title => GetString(nameof(RH0323Title));
+
+    /// <summary>
     /// Gets the localized string for RH0325MessageFormat
     /// </summary>
     internal static string RH0325MessageFormat => GetString(nameof(RH0325MessageFormat));

--- a/Reihitsu.Analyzer/AnalyzerResources.resx
+++ b/Reihitsu.Analyzer/AnalyzerResources.resx
@@ -567,6 +567,12 @@
   <data name="RH0322Title" xml:space="preserve">
     <value>Single-line comments should be preceded by a blank line.</value>
   </data>
+  <data name="RH0323MessageFormat" xml:space="preserve">
+    <value>Local declarations should be followed by a blank line.</value>
+  </data>
+  <data name="RH0323Title" xml:space="preserve">
+    <value>Local declarations should be followed by a blank line.</value>
+  </data>
   <data name="RH0324MessageFormat" xml:space="preserve">
     <value>Method chains should be aligned.</value>
   </data>

--- a/Reihitsu.Analyzer/Core/UsingDirectiveOrderingUtilities.cs
+++ b/Reihitsu.Analyzer/Core/UsingDirectiveOrderingUtilities.cs
@@ -202,6 +202,7 @@ internal static class UsingDirectiveOrderingUtilities
         {
             var usingDirective = orderedUsings[usingIndex];
             var usingDirectiveGroup = GetUsingDirectiveGroup(usingDirective);
+
             groupCounts.TryGetValue(usingDirectiveGroup, out var groupIndex);
             var groupLeadingTrivia = leadingTriviaByGroup[usingDirectiveGroup];
             var leadingTrivia = groupIndex < groupLeadingTrivia.Count

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0323LocalDeclarationsShouldBeFollowedByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0323LocalDeclarationsShouldBeFollowedByABlankLineAnalyzer.cs
@@ -1,0 +1,92 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Enumerations;
+
+namespace Reihitsu.Analyzer.Rules.Formatting;
+
+/// <summary>
+/// RH0323: Local declarations should be followed by a blank line
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class RH0323LocalDeclarationsShouldBeFollowedByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<ExpressionStatementSyntax, RH0323LocalDeclarationsShouldBeFollowedByABlankLineAnalyzer>
+{
+    #region Constants
+
+    /// <summary>
+    /// Diagnostic ID
+    /// </summary>
+    public const string DiagnosticId = "RH0323";
+
+    #endregion // Constants
+
+    #region Constructor
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public RH0323LocalDeclarationsShouldBeFollowedByABlankLineAnalyzer()
+        : base(DiagnosticId, DiagnosticCategory.Formatting, nameof(AnalyzerResources.RH0323Title), nameof(AnalyzerResources.RH0323MessageFormat), SyntaxKind.ExpressionStatement)
+    {
+    }
+
+    #endregion // Constructor
+
+    #region Methods
+
+    /// <summary>
+    /// Gets the previous statement in the same statement list
+    /// </summary>
+    /// <param name="statement">Current statement</param>
+    /// <returns>The previous statement, if available</returns>
+    private static StatementSyntax? GetPreviousStatement(ExpressionStatementSyntax statement)
+    {
+        return statement.Parent switch
+        {
+            BlockSyntax block => GetPreviousStatement(block.Statements, statement),
+            SwitchSectionSyntax switchSection => GetPreviousStatement(switchSection.Statements, statement),
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    /// Gets the previous statement from the provided statement list
+    /// </summary>
+    /// <param name="statements">Statement list</param>
+    /// <param name="currentStatement">Current statement</param>
+    /// <returns>The previous statement, if available</returns>
+    private static StatementSyntax? GetPreviousStatement(SyntaxList<StatementSyntax> statements, StatementSyntax currentStatement)
+    {
+        var statementIndex = statements.IndexOf(currentStatement);
+
+        return statementIndex > 0 ? statements[statementIndex - 1] : null;
+    }
+
+    #endregion // Methods
+
+    #region StatementShouldBePrecededByABlankLineAnalyzerBase
+
+    /// <inheritdoc />
+    protected override Location GetLocation(ExpressionStatementSyntax statement)
+    {
+        return statement.GetFirstToken().GetLocation();
+    }
+
+    /// <inheritdoc />
+    protected override SyntaxToken GetPreviousToken(ExpressionStatementSyntax statement)
+    {
+        return statement.GetFirstToken().GetPreviousToken();
+    }
+
+    /// <inheritdoc />
+    protected override bool IsRelevant(ExpressionStatementSyntax statement)
+    {
+        return GetPreviousStatement(statement) is LocalDeclarationStatementSyntax
+               && statement.Expression is AssignmentExpressionSyntax == false;
+    }
+
+    #endregion // StatementShouldBePrecededByABlankLineAnalyzerBase
+}

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0323LocalDeclarationsShouldBeFollowedByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0323LocalDeclarationsShouldBeFollowedByABlankLineAnalyzer.cs
@@ -45,11 +45,11 @@ public class RH0323LocalDeclarationsShouldBeFollowedByABlankLineAnalyzer : State
     private static StatementSyntax? GetPreviousStatement(ExpressionStatementSyntax statement)
     {
         return statement.Parent switch
-        {
-            BlockSyntax block => GetPreviousStatement(block.Statements, statement),
-            SwitchSectionSyntax switchSection => GetPreviousStatement(switchSection.Statements, statement),
-            _ => null,
-        };
+               {
+                   BlockSyntax block => GetPreviousStatement(block.Statements, statement),
+                   SwitchSectionSyntax switchSection => GetPreviousStatement(switchSection.Statements, statement),
+                   _ => null
+               };
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0363OpeningBraceMustNotBeFollowedByBlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0363OpeningBraceMustNotBeFollowedByBlankLineAnalyzer.cs
@@ -61,6 +61,7 @@ public class RH0363OpeningBraceMustNotBeFollowedByBlankLineAnalyzer : Diagnostic
                 && FormattingTextAnalysisUtilities.IsBlankLine(sourceText, lineIndex + 1))
             {
                 var blankLine = sourceText.Lines[lineIndex + 1];
+
                 context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, TextSpan.FromBounds(blankLine.Start, blankLine.EndIncludingLineBreak))));
             }
         }

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0364ElementDocumentationHeadersMustNotBeFollowedByBlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0364ElementDocumentationHeadersMustNotBeFollowedByBlankLineAnalyzer.cs
@@ -80,6 +80,7 @@ public class RH0364ElementDocumentationHeadersMustNotBeFollowedByBlankLineAnalyz
                 && FormattingTextAnalysisUtilities.IsBlankLine(sourceText, nextLineIndex))
             {
                 var blankLine = sourceText.Lines[nextLineIndex];
+
                 context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, TextSpan.FromBounds(blankLine.Start, blankLine.EndIncludingLineBreak))));
             }
 

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0365CodeMustNotContainMultipleBlankLinesInARowAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0365CodeMustNotContainMultipleBlankLinesInARowAnalyzer.cs
@@ -59,6 +59,7 @@ public class RH0365CodeMustNotContainMultipleBlankLinesInARowAnalyzer : Diagnost
                 && FormattingTextAnalysisUtilities.IsBlankLine(sourceText, lineIndex - 1))
             {
                 var blankLine = sourceText.Lines[lineIndex];
+
                 context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, TextSpan.FromBounds(blankLine.Start, blankLine.EndIncludingLineBreak))));
             }
         }

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0366ClosingBraceMustNotBePrecededByBlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0366ClosingBraceMustNotBePrecededByBlankLineAnalyzer.cs
@@ -61,6 +61,7 @@ public class RH0366ClosingBraceMustNotBePrecededByBlankLineAnalyzer : Diagnostic
                 && FormattingTextAnalysisUtilities.IsBlankLine(sourceText, lineIndex - 1))
             {
                 var blankLine = sourceText.Lines[lineIndex - 1];
+
                 context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, TextSpan.FromBounds(blankLine.Start, blankLine.EndIncludingLineBreak))));
             }
         }

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0367OpeningBraceMustNotBePrecededByBlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0367OpeningBraceMustNotBePrecededByBlankLineAnalyzer.cs
@@ -60,6 +60,7 @@ public class RH0367OpeningBraceMustNotBePrecededByBlankLineAnalyzer : Diagnostic
                 && FormattingTextAnalysisUtilities.IsBlankLine(sourceText, lineIndex - 1))
             {
                 var blankLine = sourceText.Lines[lineIndex - 1];
+
                 context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, TextSpan.FromBounds(blankLine.Start, blankLine.EndIncludingLineBreak))));
             }
         }

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0368ChainedStatementBlocksMustNotBePrecededByBlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0368ChainedStatementBlocksMustNotBePrecededByBlankLineAnalyzer.cs
@@ -62,6 +62,7 @@ public class RH0368ChainedStatementBlocksMustNotBePrecededByBlankLineAnalyzer : 
                 && FormattingTextAnalysisUtilities.IsBlankLine(sourceText, lineIndex - 1))
             {
                 var blankLine = sourceText.Lines[lineIndex - 1];
+
                 context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, TextSpan.FromBounds(blankLine.Start, blankLine.EndIncludingLineBreak))));
             }
         }

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0369WhileDoFooterMustNotBePrecededByBlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0369WhileDoFooterMustNotBePrecededByBlankLineAnalyzer.cs
@@ -60,6 +60,7 @@ public class RH0369WhileDoFooterMustNotBePrecededByBlankLineAnalyzer : Diagnosti
         }
 
         var blankLine = sourceText.Lines[whileLineIndex - 1];
+
         context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Node.SyntaxTree, TextSpan.FromBounds(blankLine.Start, blankLine.EndIncludingLineBreak))));
     }
 

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0374UseBracesConsistentlyAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0374UseBracesConsistentlyAnalyzer.cs
@@ -62,6 +62,7 @@ public class RH0374UseBracesConsistentlyAnalyzer : DiagnosticAnalyzerBase<RH0374
             if (ifHasBraces != elseHasBraces)
             {
                 var target = elseHasBraces ? statement.Statement : statement.Else.Statement;
+
                 context.ReportDiagnostic(CreateDiagnostic(target.GetLocation()));
             }
         }

--- a/Reihitsu.Cli.Test/Integration/FormatCommandHandlerIntegrationTests.cs
+++ b/Reihitsu.Cli.Test/Integration/FormatCommandHandlerIntegrationTests.cs
@@ -346,6 +346,7 @@ public class FormatCommandHandlerIntegrationTests
     {
         // Arrange
         using var tempDir = new TemporaryDirectoryFixture();
+
         tempDir.CreateFile("Test.cs", ValidInputTestData);
 
         var handler = CreateHandler([tempDir.Path], checkOnly: true);
@@ -366,6 +367,7 @@ public class FormatCommandHandlerIntegrationTests
     {
         // Arrange
         using var tempDir = new TemporaryDirectoryFixture();
+
         tempDir.CreateFile("Test.cs", ValidInputResultData);
 
         var handler = CreateHandler([tempDir.Path]);
@@ -386,6 +388,7 @@ public class FormatCommandHandlerIntegrationTests
     {
         // Arrange
         using var tempDir = new TemporaryDirectoryFixture();
+
         tempDir.CreateFile("Test.cs", ValidInputTestData);
 
         var handler = CreateHandler([tempDir.Path], false, true, false, out var console);
@@ -408,6 +411,7 @@ public class FormatCommandHandlerIntegrationTests
     {
         // Arrange
         using var tempDir = new TemporaryDirectoryFixture();
+
         tempDir.CreateFile("Test.cs", ValidInputTestData);
         tempDir.CreateFile("Resource.Designer.cs", GeneratedFileTestData);
         tempDir.CreateFile("Broken.cs", SyntaxErrorTestData);

--- a/Reihitsu.Formatter.Test/Regression/FullPipeline/ArgumentFormattingFullPipelineTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/FullPipeline/ArgumentFormattingFullPipelineTests.cs
@@ -268,6 +268,7 @@ public class ArgumentFormattingFullPipelineTests : FormatterTestsBase
                                     }
                                 }
                                 """;
+
         AssertRuleResult(input, expected);
     }
 

--- a/Reihitsu.Formatter.Test/Regression/Structural/SwitchCaseBracesTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Structural/SwitchCaseBracesTests.cs
@@ -180,6 +180,7 @@ public class SwitchCaseBracesTests : FormatterTestsBase
                                             case 1:
                                                 {
                                                     var a = 1;
+ 
                                                     Console.Write(a);
 
                                                     return a;
@@ -187,6 +188,7 @@ public class SwitchCaseBracesTests : FormatterTestsBase
                                             case 2:
                                                 {
                                                     var b = 2;
+ 
                                                     Console.Write(b);
 
                                                     return b;

--- a/Reihitsu.Formatter.Test/Unit/Indentation/Contributors/AnonymousObjectContributorTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/Indentation/Contributors/AnonymousObjectContributorTests.cs
@@ -63,6 +63,7 @@ public class AnonymousObjectContributorTests
         if (LayoutComputer.IsFirstOnLine(anon.OpenBraceToken))
         {
             var openLine = LayoutComputer.GetLine(anon.OpenBraceToken);
+
             Assert.IsTrue(model.TryGetLayout(openLine, out var openLayout));
             Assert.AreEqual(newColumn, openLayout.Column, "Open brace should align to new keyword");
         }
@@ -70,6 +71,7 @@ public class AnonymousObjectContributorTests
         if (LayoutComputer.IsFirstOnLine(anon.CloseBraceToken))
         {
             var closeLine = LayoutComputer.GetLine(anon.CloseBraceToken);
+
             Assert.IsTrue(model.TryGetLayout(closeLine, out var closeLayout));
             Assert.AreEqual(newColumn, closeLayout.Column, "Close brace should align to new keyword");
         }
@@ -119,6 +121,7 @@ public class AnonymousObjectContributorTests
             if (LayoutComputer.IsFirstOnLine(firstToken))
             {
                 var line = LayoutComputer.GetLine(firstToken);
+
                 Assert.IsTrue(model.TryGetLayout(line, out var layout));
                 Assert.AreEqual(expectedMemberColumn, layout.Column, $"Member on line {line} should be indented +4 from new keyword");
             }
@@ -195,6 +198,7 @@ public class AnonymousObjectContributorTests
         if (LayoutComputer.IsFirstOnLine(anon.OpenBraceToken))
         {
             var openLine = LayoutComputer.GetLine(anon.OpenBraceToken);
+
             Assert.IsTrue(model.TryGetLayout(openLine, out var openLayout));
             Assert.AreEqual(newColumn, openLayout.Column);
         }
@@ -202,6 +206,7 @@ public class AnonymousObjectContributorTests
         if (LayoutComputer.IsFirstOnLine(anon.CloseBraceToken))
         {
             var closeLine = LayoutComputer.GetLine(anon.CloseBraceToken);
+
             Assert.IsTrue(model.TryGetLayout(closeLine, out var closeLayout));
             Assert.AreEqual(newColumn, closeLayout.Column);
         }

--- a/Reihitsu.Formatter.Test/Unit/Indentation/Contributors/ArgumentAlignmentContributorTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/Indentation/Contributors/ArgumentAlignmentContributorTests.cs
@@ -65,6 +65,7 @@ public class ArgumentAlignmentContributorTests
             if (LayoutComputer.IsFirstOnLine(firstToken))
             {
                 var line = LayoutComputer.GetLine(firstToken);
+
                 Assert.IsTrue(model.TryGetLayout(line, out var layout), $"Expected layout for line {line}");
                 Assert.AreEqual(openParenColumn, layout.Column, $"Argument on line {line} should align to column after open paren");
             }
@@ -144,6 +145,7 @@ public class ArgumentAlignmentContributorTests
             if (LayoutComputer.IsFirstOnLine(firstToken))
             {
                 var line = LayoutComputer.GetLine(firstToken);
+
                 Assert.IsTrue(model.TryGetLayout(line, out var layout), $"Expected layout for parameter on line {line}");
                 Assert.AreEqual(openParenColumn, layout.Column);
             }
@@ -187,6 +189,7 @@ public class ArgumentAlignmentContributorTests
         if (LayoutComputer.IsFirstOnLine(secondArg))
         {
             var line = LayoutComputer.GetLine(secondArg);
+
             Assert.IsTrue(model.TryGetLayout(line, out var layout));
             Assert.AreEqual(openBracketColumn, layout.Column);
         }
@@ -260,6 +263,7 @@ public class ArgumentAlignmentContributorTests
         if (LayoutComputer.IsFirstOnLine(secondArg))
         {
             var line = LayoutComputer.GetLine(secondArg);
+
             Assert.IsTrue(model.TryGetLayout(line, out var layout));
             Assert.AreEqual(openParenColumn, layout.Column);
         }

--- a/Reihitsu.Formatter.Test/Unit/Indentation/Contributors/BaseTypeListContributorTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/Indentation/Contributors/BaseTypeListContributorTests.cs
@@ -61,6 +61,7 @@ public class BaseTypeListContributorTests
             if (LayoutComputer.IsFirstOnLine(firstToken))
             {
                 var line = LayoutComputer.GetLine(firstToken);
+
                 Assert.IsTrue(model.TryGetLayout(line, out var layout), $"Expected layout for type {typeIndex} on line {line}");
                 Assert.AreEqual(firstBaseColumn, layout.Column, $"Base type {typeIndex} should align to first base type column");
             }

--- a/Reihitsu.Formatter.Test/Unit/Indentation/Contributors/BinaryExpressionContributorTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/Indentation/Contributors/BinaryExpressionContributorTests.cs
@@ -63,6 +63,7 @@ public class BinaryExpressionContributorTests
             if (LayoutComputer.IsFirstOnLine(binary.OperatorToken))
             {
                 var line = LayoutComputer.GetLine(binary.OperatorToken);
+
                 Assert.IsTrue(model.TryGetLayout(line, out _), $"Expected layout for operator on line {line}");
             }
         }
@@ -173,6 +174,7 @@ public class BinaryExpressionContributorTests
         if (LayoutComputer.IsFirstOnLine(isPattern.IsKeyword))
         {
             var line = LayoutComputer.GetLine(isPattern.IsKeyword);
+
             Assert.IsTrue(model.TryGetLayout(line, out var layout));
             Assert.AreEqual(expressionColumn, layout.Column, "is keyword should align to expression column");
         }

--- a/Reihitsu.Formatter.Test/Unit/Indentation/Contributors/CollectionExpressionContributorTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/Indentation/Contributors/CollectionExpressionContributorTests.cs
@@ -69,6 +69,7 @@ public class CollectionExpressionContributorTests
             if (LayoutComputer.IsFirstOnLine(firstToken))
             {
                 var line = LayoutComputer.GetLine(firstToken);
+
                 Assert.IsTrue(model.TryGetLayout(line, out var layout));
                 Assert.AreEqual(expectedElementColumn, layout.Column, $"Element on line {line} should be indented +4 from bracket");
             }
@@ -114,6 +115,7 @@ public class CollectionExpressionContributorTests
         if (LayoutComputer.IsFirstOnLine(collection.CloseBracketToken))
         {
             var closeLine = LayoutComputer.GetLine(collection.CloseBracketToken);
+
             Assert.IsTrue(model.TryGetLayout(closeLine, out var layout));
             Assert.AreEqual(bracketColumn, layout.Column, "Close bracket should align to open bracket");
         }

--- a/Reihitsu.Formatter.Test/Unit/Indentation/Contributors/CommentIndentationContributorTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/Indentation/Contributors/CommentIndentationContributorTests.cs
@@ -53,6 +53,7 @@ public class CommentIndentationContributorTests
         var varDecl = root.DescendantNodes().OfType<LocalDeclarationStatementSyntax>().First();
         var varToken = varDecl.GetFirstToken();
         var varLine = LayoutComputer.GetLine(varToken);
+
         model.Set(varLine, new TokenLayout(8, "Block"));
 
         var contributor = new CommentIndentationContributor();
@@ -62,6 +63,7 @@ public class CommentIndentationContributorTests
 
         // Assert — the comment on the line before var should have the same column
         var commentLine = varLine - 1;
+
         Assert.IsTrue(model.TryGetLayout(commentLine, out var commentLayout), "Expected layout for comment line");
         Assert.AreEqual(8, commentLayout.Column, "Comment should align to the following token's column");
     }
@@ -127,6 +129,7 @@ public class CommentIndentationContributorTests
         var varDecl = root.DescendantNodes().OfType<LocalDeclarationStatementSyntax>().First();
         var varToken = varDecl.GetFirstToken();
         var varLine = LayoutComputer.GetLine(varToken);
+
         model.Set(varLine, new TokenLayout(8, "Block"));
 
         var contributor = new CommentIndentationContributor();
@@ -168,6 +171,7 @@ public class CommentIndentationContributorTests
         var varDecl = root.DescendantNodes().OfType<LocalDeclarationStatementSyntax>().First();
         var varToken = varDecl.GetFirstToken();
         var varLine = LayoutComputer.GetLine(varToken);
+
         model.Set(varLine, new TokenLayout(8, "Block"));
 
         var contributor = new CommentIndentationContributor();
@@ -217,6 +221,7 @@ public class CommentIndentationContributorTests
         var elseBlock = root.DescendantNodes().OfType<BlockSyntax>().Last();
         var closeBrace = elseBlock.CloseBraceToken;
         var closeBraceLine = LayoutComputer.GetLine(closeBrace);
+
         model.Set(closeBraceLine, new TokenLayout(8, "Block"));
 
         var contributor = new CommentIndentationContributor();

--- a/Reihitsu.Formatter.Test/Unit/Indentation/Contributors/ConditionalExpressionContributorTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/Indentation/Contributors/ConditionalExpressionContributorTests.cs
@@ -62,6 +62,7 @@ public class ConditionalExpressionContributorTests
         if (LayoutComputer.IsFirstOnLine(conditional.QuestionToken))
         {
             var questionLine = LayoutComputer.GetLine(conditional.QuestionToken);
+
             Assert.IsTrue(model.TryGetLayout(questionLine, out var questionLayout));
             Assert.AreEqual(expectedOperatorColumn, questionLayout.Column, "? should align to condition + indent");
         }
@@ -69,6 +70,7 @@ public class ConditionalExpressionContributorTests
         if (LayoutComputer.IsFirstOnLine(conditional.ColonToken))
         {
             var colonLine = LayoutComputer.GetLine(conditional.ColonToken);
+
             Assert.IsTrue(model.TryGetLayout(colonLine, out var colonLayout));
             Assert.AreEqual(expectedOperatorColumn, colonLayout.Column, ": should align to condition + indent");
         }

--- a/Reihitsu.Formatter.Test/Unit/Indentation/Contributors/ConstructorInitializerContributorTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/Indentation/Contributors/ConstructorInitializerContributorTests.cs
@@ -54,6 +54,7 @@ public class ConstructorInitializerContributorTests
         var constructorFirstToken = constructor.GetFirstToken();
         var constructorLine = LayoutComputer.GetLine(constructorFirstToken);
         var constructorColumn = LayoutComputer.GetColumn(constructorFirstToken);
+
         model.Set(constructorLine, new TokenLayout(constructorColumn, "Block"));
 
         var contributor = new ConstructorInitializerContributor();
@@ -66,6 +67,7 @@ public class ConstructorInitializerContributorTests
         if (LayoutComputer.IsFirstOnLine(initializer.ColonToken))
         {
             var colonLine = LayoutComputer.GetLine(initializer.ColonToken);
+
             Assert.IsTrue(model.TryGetLayout(colonLine, out var colonLayout));
             Assert.AreEqual(expectedColonColumn, colonLayout.Column, "Colon should be indented +4 from constructor");
         }
@@ -101,6 +103,7 @@ public class ConstructorInitializerContributorTests
         var constructorFirstToken = constructor.GetFirstToken();
         var constructorLine = LayoutComputer.GetLine(constructorFirstToken);
         var constructorColumn = LayoutComputer.GetColumn(constructorFirstToken);
+
         model.Set(constructorLine, new TokenLayout(constructorColumn, "Block"));
 
         var contributor = new ConstructorInitializerContributor();
@@ -113,6 +116,7 @@ public class ConstructorInitializerContributorTests
         if (LayoutComputer.IsFirstOnLine(initializer.ColonToken))
         {
             var colonLine = LayoutComputer.GetLine(initializer.ColonToken);
+
             Assert.IsTrue(model.TryGetLayout(colonLine, out var colonLayout));
             Assert.AreEqual(expectedColonColumn, colonLayout.Column);
         }

--- a/Reihitsu.Formatter.Test/Unit/Indentation/Contributors/GenericConstraintContributorTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/Indentation/Contributors/GenericConstraintContributorTests.cs
@@ -51,6 +51,7 @@ public class GenericConstraintContributorTests
         var parentFirstToken = classDecl.GetFirstToken();
         var parentLine = LayoutComputer.GetLine(parentFirstToken);
         var parentColumn = LayoutComputer.GetColumn(parentFirstToken);
+
         model.Set(parentLine, new TokenLayout(parentColumn, "Block"));
 
         var contributor = new GenericConstraintContributor();
@@ -63,6 +64,7 @@ public class GenericConstraintContributorTests
         if (LayoutComputer.IsFirstOnLine(constraint.WhereKeyword))
         {
             var whereLine = LayoutComputer.GetLine(constraint.WhereKeyword);
+
             Assert.IsTrue(model.TryGetLayout(whereLine, out var whereLayout));
             Assert.AreEqual(expectedWhereColumn, whereLayout.Column, "where keyword should be indented +4 from parent");
         }
@@ -98,6 +100,7 @@ public class GenericConstraintContributorTests
         var methodFirstToken = methodDecl.GetFirstToken();
         var methodLine = LayoutComputer.GetLine(methodFirstToken);
         var methodColumn = LayoutComputer.GetColumn(methodFirstToken);
+
         model.Set(methodLine, new TokenLayout(methodColumn, "Block"));
 
         var contributor = new GenericConstraintContributor();
@@ -110,6 +113,7 @@ public class GenericConstraintContributorTests
         if (LayoutComputer.IsFirstOnLine(constraint.WhereKeyword))
         {
             var whereLine = LayoutComputer.GetLine(constraint.WhereKeyword);
+
             Assert.IsTrue(model.TryGetLayout(whereLine, out var whereLayout));
             Assert.AreEqual(expectedWhereColumn, whereLayout.Column);
         }

--- a/Reihitsu.Formatter.Test/Unit/Indentation/Contributors/LambdaAlignmentContributorTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/Indentation/Contributors/LambdaAlignmentContributorTests.cs
@@ -56,6 +56,7 @@ public class LambdaAlignmentContributorTests
         var block = lambda.Block;
         var openBraceLine = LayoutComputer.GetLine(block.OpenBraceToken);
         var closeBraceLine = LayoutComputer.GetLine(block.CloseBraceToken);
+
         model.Set(openBraceLine, new TokenLayout(8, "Block"));
         model.Set(closeBraceLine, new TokenLayout(8, "Block"));
 
@@ -63,6 +64,7 @@ public class LambdaAlignmentContributorTests
         foreach (var statement in block.Statements)
         {
             var statementLine = LayoutComputer.GetLine(statement.GetFirstToken());
+
             model.Set(statementLine, new TokenLayout(12, "Block"));
         }
 
@@ -109,12 +111,14 @@ public class LambdaAlignmentContributorTests
         var block = lambda.Block;
         var openBraceLine = LayoutComputer.GetLine(block.OpenBraceToken);
         var closeBraceLine = LayoutComputer.GetLine(block.CloseBraceToken);
+
         model.Set(openBraceLine, new TokenLayout(8, "Block"));
         model.Set(closeBraceLine, new TokenLayout(8, "Block"));
 
         foreach (var statement in block.Statements)
         {
             var statementLine = LayoutComputer.GetLine(statement.GetFirstToken());
+
             model.Set(statementLine, new TokenLayout(12, "Block"));
         }
 

--- a/Reihitsu.Formatter.Test/Unit/Indentation/Contributors/ObjectInitializerContributorTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/Indentation/Contributors/ObjectInitializerContributorTests.cs
@@ -63,6 +63,7 @@ public class ObjectInitializerContributorTests
         if (LayoutComputer.IsFirstOnLine(creation.Initializer.OpenBraceToken))
         {
             var openLine = LayoutComputer.GetLine(creation.Initializer.OpenBraceToken);
+
             Assert.IsTrue(model.TryGetLayout(openLine, out var openLayout));
             Assert.AreEqual(newColumn, openLayout.Column, "Open brace should align to new keyword");
         }
@@ -70,6 +71,7 @@ public class ObjectInitializerContributorTests
         if (LayoutComputer.IsFirstOnLine(creation.Initializer.CloseBraceToken))
         {
             var closeLine = LayoutComputer.GetLine(creation.Initializer.CloseBraceToken);
+
             Assert.IsTrue(model.TryGetLayout(closeLine, out var closeLayout));
             Assert.AreEqual(newColumn, closeLayout.Column, "Close brace should align to new keyword");
         }
@@ -119,6 +121,7 @@ public class ObjectInitializerContributorTests
             if (LayoutComputer.IsFirstOnLine(firstToken))
             {
                 var line = LayoutComputer.GetLine(firstToken);
+
                 Assert.IsTrue(model.TryGetLayout(line, out var layout));
                 Assert.AreEqual(expectedMemberColumn, layout.Column, $"Member on line {line} should be indented +4 from new keyword");
             }
@@ -164,6 +167,7 @@ public class ObjectInitializerContributorTests
         if (LayoutComputer.IsFirstOnLine(creation.Initializer.OpenBraceToken))
         {
             var openLine = LayoutComputer.GetLine(creation.Initializer.OpenBraceToken);
+
             Assert.IsTrue(model.TryGetLayout(openLine, out var openLayout));
             Assert.AreEqual(newColumn, openLayout.Column);
         }

--- a/Reihitsu.Formatter.Test/Unit/Indentation/Contributors/SwitchExpressionContributorTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/Indentation/Contributors/SwitchExpressionContributorTests.cs
@@ -64,6 +64,7 @@ public class SwitchExpressionContributorTests
         if (LayoutComputer.IsFirstOnLine(switchExpr.OpenBraceToken))
         {
             var openLine = LayoutComputer.GetLine(switchExpr.OpenBraceToken);
+
             Assert.IsTrue(model.TryGetLayout(openLine, out var openLayout));
             Assert.AreEqual(switchColumn, openLayout.Column, "Open brace should align to governing expression");
         }
@@ -71,6 +72,7 @@ public class SwitchExpressionContributorTests
         if (LayoutComputer.IsFirstOnLine(switchExpr.CloseBraceToken))
         {
             var closeLine = LayoutComputer.GetLine(switchExpr.CloseBraceToken);
+
             Assert.IsTrue(model.TryGetLayout(closeLine, out var closeLayout));
             Assert.AreEqual(switchColumn, closeLayout.Column, "Close brace should align to governing expression");
         }
@@ -121,6 +123,7 @@ public class SwitchExpressionContributorTests
             if (LayoutComputer.IsFirstOnLine(firstToken))
             {
                 var line = LayoutComputer.GetLine(firstToken);
+
                 Assert.IsTrue(model.TryGetLayout(line, out var layout));
                 Assert.AreEqual(expectedArmColumn, layout.Column, $"Arm on line {line} should be indented +4 from governing expression");
             }
@@ -197,6 +200,7 @@ public class SwitchExpressionContributorTests
         if (LayoutComputer.IsFirstOnLine(switchExpr.OpenBraceToken))
         {
             var openLine = LayoutComputer.GetLine(switchExpr.OpenBraceToken);
+
             Assert.IsTrue(model.TryGetLayout(openLine, out var openLayout));
             Assert.AreEqual(switchColumn, openLayout.Column);
         }

--- a/Reihitsu.Formatter.Test/Unit/Indentation/LayoutModelTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/Indentation/LayoutModelTests.cs
@@ -86,6 +86,7 @@ public class LayoutModelTests
 
         var lineNumber = classToken.GetLocation().GetLineSpan().StartLinePosition.Line;
         var layout = new TokenLayout(0, "root");
+
         model.Set(lineNumber, layout);
 
         // Act
@@ -125,6 +126,7 @@ public class LayoutModelTests
     {
         // Arrange
         var model = new LayoutModel();
+
         model.Set(0, new TokenLayout(0, "init"));
         model.Set(1, new TokenLayout(4, "init"));
         model.Set(2, new TokenLayout(4, "init"));
@@ -155,6 +157,7 @@ public class LayoutModelTests
     {
         // Arrange
         var model = new LayoutModel();
+
         model.Set(0, new TokenLayout(2, "init"));
 
         // Act — shift left by 10, which would make column negative
@@ -175,6 +178,7 @@ public class LayoutModelTests
     {
         // Arrange
         var model = new LayoutModel();
+
         model.Set(0, new TokenLayout(4, "original"));
 
         // Act
@@ -196,6 +200,7 @@ public class LayoutModelTests
     {
         // Arrange
         var model = new LayoutModel();
+
         model.Set(5, new TokenLayout(4, "first"));
 
         // Act

--- a/Reihitsu.Formatter/Pipeline/BlankLines/BlankLineRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/BlankLines/BlankLineRewriter.cs
@@ -77,6 +77,10 @@ internal sealed class BlankLineRewriter : CSharpSyntaxRewriter
             case YieldStatementSyntax:
                 return previous is YieldStatementSyntax == false;
 
+            case ExpressionStatementSyntax expressionStatement:
+                return previous is LocalDeclarationStatementSyntax
+                       && expressionStatement.Expression is AssignmentExpressionSyntax == false;
+
             default:
                 return false;
         }
@@ -576,6 +580,7 @@ internal sealed class BlankLineRewriter : CSharpSyntaxRewriter
                     var eol = SyntaxFactory.EndOfLine(_context.EndOfLine);
                     var newLeading = firstToken.LeadingTrivia.Insert(0, eol);
                     var newToken = firstToken.WithLeadingTrivia(newLeading);
+
                     newSections[sectionIndex] = section.ReplaceToken(firstToken, newToken);
                     modified = true;
                 }

--- a/Reihitsu.Formatter/Pipeline/Indentation/LayoutComputer.cs
+++ b/Reihitsu.Formatter/Pipeline/Indentation/LayoutComputer.cs
@@ -44,6 +44,7 @@ internal static class LayoutComputer
 
         // Pass 3: Comment alignment — align comments to the code they precede
         var commentContributor = new CommentIndentationContributor();
+
         commentContributor.Contribute(root, rootScope, model, context);
 
         return model;
@@ -96,6 +97,7 @@ internal static class LayoutComputer
             if (child.IsToken)
             {
                 var token = child.AsToken();
+
                 SetDirectiveIndentation(token, indentLevel, braceRange, model, baseColumn);
                 SetTokenIndentation(token, childIndent, model, baseColumn);
             }
@@ -166,6 +168,7 @@ internal static class LayoutComputer
                                       : indentLevel;
 
             var directiveLine = directiveTrivia.GetLocation().GetLineSpan().StartLinePosition.Line;
+
             model.Set(directiveLine, new TokenLayout(directiveIndent * FormattingContext.IndentSize + baseColumn, "Directive"));
         }
     }
@@ -196,6 +199,7 @@ internal static class LayoutComputer
         }
 
         var line = token.GetLocation().GetLineSpan().StartLinePosition.Line;
+
         model.Set(line, new TokenLayout(childIndent * FormattingContext.IndentSize + baseColumn, "Block"));
     }
 

--- a/documentation/rules/RH0323.md
+++ b/documentation/rules/RH0323.md
@@ -1,23 +1,23 @@
-# RH0323 — Assignments and statements should be separated by a blank line
+# RH0323 — Local declarations should be followed by a blank line
 
 | Property     | Value        |
 |--------------|--------------|
 | **ID**       | RH0323       |
 | **Category** | Formatting   |
 | **Severity** | Warning      |
-| **Code Fix** | ✗            |
+| **Code Fix** | ✓            |
 
 ## Description
 
-This rule checks that assignments and other statements are separated by a blank line when transitioning between them. **Note:** This rule is planned but not yet implemented. It is reserved for future use.
+This rule checks that local declarations are followed by a blank line when the next statement is a normal expression statement such as a method call.
 
 ## Why is this a problem?
 
-When assignment statements and control flow or method call statements are intermixed without blank lines, the code becomes harder to scan. Separating these with blank lines makes the logical structure of the code more apparent.
+When local declarations are placed directly next to the expression statements that use or follow them, the code becomes harder to scan. Separating declaration blocks from the next action makes the logical structure of the method easier to follow.
 
 ## How to fix it
 
-Add a blank line between assignment statements and non-assignment statements to visually separate them.
+Add a blank line after the local declaration block before the following expression statement.
 
 ## Examples
 
@@ -25,18 +25,13 @@ Add a blank line between assignment statements and non-assignment statements to 
 
 ```cs
 var x = 1;
-var y = 2;
-Console.WriteLine(x + y);
-var z = 3;
+Console.WriteLine(x);
 ```
 
 ### Correction
 
 ```cs
 var x = 1;
-var y = 2;
 
-Console.WriteLine(x + y);
-
-var z = 3;
+Console.WriteLine(x);
 ```


### PR DESCRIPTION
Adds analyzer, code fix, and tests for RH0323, enforcing a blank line after local declarations when followed by an expression statement (excluding assignments). Updates resources, documentation, and formatter logic. Marks RH0323 as implemented in the README. No unrelated rule changes.