### PR TITLE
Fix using directive ordering trivia preservation

### DIFF
--- a/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0390UsingDirectivesShouldBeOrganizedIntoGroupsCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0390UsingDirectivesShouldBeOrganizedIntoGroupsCodeFixProvider.cs
@@ -1,16 +1,15 @@
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+using Reihitsu.Analyzer.Core;
+using Reihitsu.Formatter;
+using Reihitsu.Formatter.Pipeline.UsingDirectives;
 
 namespace Reihitsu.Analyzer.Rules.Formatting;
 
@@ -32,123 +31,7 @@ public class RH0390UsingDirectivesShouldBeOrganizedIntoGroupsCodeFixProvider : C
     /// <returns>The updated document</returns>
     private static async Task<Document> ApplyCodeFixAsync(Document document, SyntaxNode scope, CancellationToken cancellationToken)
     {
-        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-
-        if (root == null)
-        {
-            return document;
-        }
-
-        var usings = GetUsings(scope);
-
-        if (usings.Count < 2)
-        {
-            return document;
-        }
-
-        var organizedUsings = OrganizeUsings(usings);
-        var updatedScope = WithUsings(scope, organizedUsings);
-        var updatedRoot = root.ReplaceNode(scope, updatedScope);
-
-        return document.WithSyntaxRoot(updatedRoot);
-    }
-
-    /// <summary>
-    /// Gets the indentation trivia (whitespace only) from the given leading trivia
-    /// </summary>
-    /// <param name="leadingTrivia">Leading trivia to extract indentation from</param>
-    /// <returns>Trivia list containing only the indentation whitespace</returns>
-    private static SyntaxTriviaList GetIndentationTrivia(SyntaxTriviaList leadingTrivia)
-    {
-        var result = new List<SyntaxTrivia>();
-
-        for (var i = leadingTrivia.Count - 1; i >= 0; i--)
-        {
-            if (leadingTrivia[i].IsKind(SyntaxKind.WhitespaceTrivia))
-            {
-                result.Insert(0, leadingTrivia[i]);
-            }
-            else
-            {
-                break;
-            }
-        }
-
-        return SyntaxFactory.TriviaList(result);
-    }
-
-    /// <summary>
-    /// Gets the using directives from the given scope node
-    /// </summary>
-    /// <param name="scope">Compilation unit or namespace declaration</param>
-    /// <returns>Using directives</returns>
-    private static SyntaxList<UsingDirectiveSyntax> GetUsings(SyntaxNode scope)
-    {
-        return scope switch
-               {
-                   CompilationUnitSyntax compilationUnit => compilationUnit.Usings,
-                   BaseNamespaceDeclarationSyntax namespaceDeclaration => namespaceDeclaration.Usings,
-                   _ => default,
-               };
-    }
-
-    /// <summary>
-    /// Applies updated using directives to the given scope node
-    /// </summary>
-    /// <param name="scope">Compilation unit or namespace declaration</param>
-    /// <param name="usingDirectives">New using directives</param>
-    /// <returns>Updated scope node</returns>
-    private static SyntaxNode WithUsings(SyntaxNode scope, SyntaxList<UsingDirectiveSyntax> usingDirectives)
-    {
-        return scope switch
-               {
-                   CompilationUnitSyntax compilationUnit => compilationUnit.WithUsings(usingDirectives),
-                   BaseNamespaceDeclarationSyntax namespaceDeclaration => namespaceDeclaration.WithUsings(usingDirectives),
-                   _ => scope,
-               };
-    }
-
-    /// <summary>
-    /// Reorganizes using directives into groups sorted by using type and root namespace
-    /// </summary>
-    /// <param name="usings">Original using directives</param>
-    /// <returns>Reorganized using directives</returns>
-    private static SyntaxList<UsingDirectiveSyntax> OrganizeUsings(SyntaxList<UsingDirectiveSyntax> usings)
-    {
-        var firstLeadingTrivia = usings.First().GetLeadingTrivia();
-        var canonical = RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer.ComputeCanonicalOrder(usings);
-        var result = new List<UsingDirectiveSyntax>();
-
-        for (var i = 0; i < canonical.Count; i++)
-        {
-            var current = canonical[i];
-
-            if (i == 0)
-            {
-                result.Add(current.WithLeadingTrivia(firstLeadingTrivia));
-
-                continue;
-            }
-
-            var indentation = GetIndentationTrivia(current.GetLeadingTrivia());
-
-            if (RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer.AreInSameGroup(canonical[i - 1], current))
-            {
-                result.Add(current.WithLeadingTrivia(indentation));
-
-                continue;
-            }
-
-            var blankLineTriviaList = new List<SyntaxTrivia>
-                                      {
-                                          SyntaxFactory.EndOfLine(Environment.NewLine)
-                                      };
-
-            blankLineTriviaList.AddRange(indentation);
-            result.Add(current.WithLeadingTrivia(SyntaxFactory.TriviaList(blankLineTriviaList)));
-        }
-
-        return SyntaxFactory.List(result);
+        return await ReihitsuFormatter.FormatNodeInDocumentAsync(document, scope, cancellationToken).ConfigureAwait(false);
     }
 
     #endregion // Methods
@@ -176,11 +59,8 @@ public class RH0390UsingDirectivesShouldBeOrganizedIntoGroupsCodeFixProvider : C
 
         foreach (var diagnostic in context.Diagnostics)
         {
-            var diagnosticNode = root.FindToken(diagnostic.Location.SourceSpan.Start).Parent;
-            var usingDirective = diagnosticNode?.AncestorsAndSelf().OfType<UsingDirectiveSyntax>().FirstOrDefault();
-            var scope = usingDirective?.Parent;
-
-            if (scope is CompilationUnitSyntax or BaseNamespaceDeclarationSyntax)
+            if (UsingDirectiveOrderingUtilities.TryGetUsingDirectiveScope(root, diagnostic, out var scope)
+                && UsingDirectiveOrderingSafety.CanSafelyReorder(UsingDirectiveOrderingUtilities.GetUsings(scope)))
             {
                 context.RegisterCodeFix(CodeAction.Create(CodeFixResources.RH0390Title,
                                                           token => ApplyCodeFixAsync(context.Document, scope, token),

--- a/Reihitsu.Analyzer.Test/Base/AnalyzerTestsBase{TAnalyzer,TCodeFix}.cs
+++ b/Reihitsu.Analyzer.Test/Base/AnalyzerTestsBase{TAnalyzer,TCodeFix}.cs
@@ -1,10 +1,16 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Text;
 
 using Reihitsu.Analyzer.Test.Verifiers;
 
@@ -57,6 +63,68 @@ public abstract class AnalyzerTestsBase<TAnalyzer, TCodeFix> : AnalyzerTestsBase
         onConfigure?.Invoke(test);
 
         await test.RunAsync(CancellationToken.None);
+    }
+
+    /// <summary>
+    /// Gets the code actions registered for the provided diagnostic on the given source text
+    /// </summary>
+    /// <param name="source">Source text</param>
+    /// <param name="diagnosticId">Diagnostic ID</param>
+    /// <param name="locationProvider">Callback that selects the diagnostic location from the parsed syntax root</param>
+    /// <param name="preprocessorSymbols">Preprocessor symbols to define for parsing</param>
+    /// <returns>The registered code actions</returns>
+    protected static async Task<List<CodeAction>> GetCodeFixActionsAsync(string source, string diagnosticId, Func<SyntaxNode, Location> locationProvider, params string[] preprocessorSymbols)
+    {
+        using (var workspace = new AdhocWorkspace())
+        {
+            var projectId = ProjectId.CreateNewId();
+            var documentId = DocumentId.CreateNewId(projectId);
+            var versionStamp = VersionStamp.Create();
+            var parseOptions = new Microsoft.CodeAnalysis.CSharp.CSharpParseOptions(preprocessorSymbols: preprocessorSymbols);
+            var solution = workspace.CurrentSolution
+                                    .AddProject(ProjectInfo.Create(projectId,
+                                                                   versionStamp,
+                                                                   "TestProject",
+                                                                   "TestProject",
+                                                                   LanguageNames.CSharp,
+                                                                   parseOptions: parseOptions,
+                                                                   metadataReferences: GetMetadataReferences()))
+                                    .AddDocument(documentId, "Test.cs", SourceText.From(source));
+            var document = solution.GetDocument(documentId)
+                               ?? throw new InvalidOperationException("Failed to create test document.");
+            var root = await document.GetSyntaxRootAsync(CancellationToken.None).ConfigureAwait(false)
+                           ?? throw new InvalidOperationException("Failed to parse test document.");
+            var descriptor = new DiagnosticDescriptor(diagnosticId,
+                                                      "Title",
+                                                      "Message",
+                                                      "Testing",
+                                                      DiagnosticSeverity.Warning,
+                                                      isEnabledByDefault: true);
+            var diagnostic = Microsoft.CodeAnalysis.Diagnostic.Create(descriptor, locationProvider(root));
+            var actions = new List<CodeAction>();
+            var codeFixProvider = new TCodeFix();
+            var context = new CodeFixContext(document,
+                                             diagnostic,
+                                             (action, _) => actions.Add(action),
+                                             CancellationToken.None);
+
+            await codeFixProvider.RegisterCodeFixesAsync(context).ConfigureAwait(false);
+
+            return actions;
+        }
+    }
+
+    /// <summary>
+    /// Gets the metadata references required for the ad-hoc code-fix test project
+    /// </summary>
+    /// <returns>Metadata references</returns>
+    private static IEnumerable<MetadataReference> GetMetadataReferences()
+    {
+        var trustedPlatformAssemblies = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        var referencePaths = trustedPlatformAssemblies?.Split(Path.PathSeparator)
+                                 ?? [];
+
+        return referencePaths.Select(path => MetadataReference.CreateFromFile(path));
     }
 
     #endregion // Methods

--- a/Reihitsu.Analyzer.Test/Formatting/RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzerTests.cs
@@ -1,5 +1,7 @@
-﻿using System.Threading.Tasks;
+using System.Linq;
+using System.Threading.Tasks;
 
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Reihitsu.Analyzer.Rules.Formatting;
@@ -322,6 +324,36 @@ public class RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzerTests : Ana
     }
 
     /// <summary>
+    /// Verifies that the code fix preserves an attached comment when reordering
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task CodeFixPreservesAttachedCommentWhenReordering()
+    {
+        const string testCode = """
+                                using {|#0:System.Linq|};
+                                // Keep with collections
+                                using System.Collections;
+
+                                public class TestClass
+                                {
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 // Keep with collections
+                                 using System.Collections;
+                                 using System.Linq;
+
+                                 public class TestClass
+                                 {
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer.DiagnosticId, AnalyzerResources.RH0390MessageFormat));
+    }
+
+    /// <summary>
     /// Verifies that System group is placed before other groups in the fix
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
@@ -614,6 +646,39 @@ public class RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzerTests : Ana
                                  """;
 
         await Verify(testCode, fixedCode, Diagnostics(RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer.DiagnosticId, AnalyzerResources.RH0390MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that no code fix is offered when a conditional directive would be moved
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task NoCodeFixWhenConditionalDirectiveWouldBeMoved()
+    {
+        const string testCode = """
+                                using System;
+                                #if DEBUG
+                                using Alpha;
+                                #endif
+
+                                public class TestClass
+                                {
+                                }
+                                """;
+
+        var actions = await GetCodeFixActionsAsync(testCode,
+                                                   RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer.DiagnosticId,
+                                                   root =>
+                                                   {
+                                                       var usingDirective = root.DescendantNodes()
+                                                                                .OfType<UsingDirectiveSyntax>()
+                                                                                .First();
+
+                                                       return usingDirective.Name?.GetLocation() ?? usingDirective.GetLocation();
+                                                   },
+                                                   "DEBUG");
+
+        Assert.IsEmpty(actions);
     }
 
     #endregion // Members

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer.cs
@@ -45,7 +45,7 @@ public class RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer : Diagnost
     /// </summary>
     /// <param name="usings">Using directives</param>
     /// <returns>Canonically ordered list</returns>
-    internal static List<UsingDirectiveSyntax> ComputeCanonicalOrder(SyntaxList<UsingDirectiveSyntax> usings)
+    private static List<UsingDirectiveSyntax> ComputeCanonicalOrder(SyntaxList<UsingDirectiveSyntax> usings)
     {
         return usings.Select((usingDirective, directiveIndex) => new
                                                                  {
@@ -66,7 +66,7 @@ public class RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer : Diagnost
     /// <param name="left">Left using directive</param>
     /// <param name="right">Right using directive</param>
     /// <returns><see langword="true"/> if both directives belong to the same group</returns>
-    internal static bool AreInSameGroup(UsingDirectiveSyntax left, UsingDirectiveSyntax right)
+    private static bool AreInSameGroup(UsingDirectiveSyntax left, UsingDirectiveSyntax right)
     {
         return GetUsingTypeOrder(left) == GetUsingTypeOrder(right)
                && string.Equals(GetRootNamespace(left), GetRootNamespace(right), StringComparison.OrdinalIgnoreCase);
@@ -77,7 +77,7 @@ public class RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer : Diagnost
     /// </summary>
     /// <param name="usingDirective">Using directive</param>
     /// <returns>Root namespace segment</returns>
-    internal static string GetRootNamespace(UsingDirectiveSyntax usingDirective)
+    private static string GetRootNamespace(UsingDirectiveSyntax usingDirective)
     {
         var name = usingDirective.Name?.ToString() ?? string.Empty;
         var dotIndex = name.IndexOf('.');
@@ -90,7 +90,7 @@ public class RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer : Diagnost
     /// </summary>
     /// <param name="usingDirective">Using directive</param>
     /// <returns>The namespace ordering key</returns>
-    internal static string GetNamespaceGroupOrderKey(UsingDirectiveSyntax usingDirective)
+    private static string GetNamespaceGroupOrderKey(UsingDirectiveSyntax usingDirective)
     {
         var rootNamespace = GetRootNamespace(usingDirective);
 
@@ -104,7 +104,7 @@ public class RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer : Diagnost
     /// </summary>
     /// <param name="usingDirective">Using directive</param>
     /// <returns>The using-type ordering slot</returns>
-    internal static int GetUsingTypeOrder(UsingDirectiveSyntax usingDirective)
+    private static int GetUsingTypeOrder(UsingDirectiveSyntax usingDirective)
     {
         return UsingDirectiveOrderingUtilities.GetUsingDirectiveGroup(usingDirective) switch
                {
@@ -138,18 +138,18 @@ public class RH0390UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer : Diagnost
 
         var canonical = ComputeCanonicalOrder(usings);
 
-        for (var i = 0; i < usings.Count; i++)
+        for (var index = 0; index < usings.Count; index++)
         {
-            if (ReferenceEquals(usings[i], canonical[i]) == false)
+            if (ReferenceEquals(usings[index], canonical[index]) == false)
             {
                 return false;
             }
         }
 
-        for (var i = 1; i < usings.Count; i++)
+        for (var index = 1; index < usings.Count; index++)
         {
-            var sameGroup = AreInSameGroup(usings[i - 1], usings[i]);
-            var hasBlankLine = HasBlankLineBefore(usings[i]);
+            var sameGroup = AreInSameGroup(usings[index - 1], usings[index]);
+            var hasBlankLine = HasBlankLineBefore(usings[index]);
 
             if (sameGroup == hasBlankLine)
             {

--- a/Reihitsu.Formatter.Test/Helpers/FormatterPhaseTestsBase.cs
+++ b/Reihitsu.Formatter.Test/Helpers/FormatterPhaseTestsBase.cs
@@ -1,0 +1,48 @@
+using System.Threading;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Reihitsu.Formatter.Test.Helpers;
+
+/// <summary>
+/// Base class for formatter phase unit tests that execute a single phase against parsed C# source
+/// </summary>
+public abstract class FormatterPhaseTestsBase
+{
+    #region Properties
+
+    /// <summary>
+    /// Gets or sets the test context for the current test
+    /// </summary>
+    public TestContext TestContext { get; set; }
+
+    #endregion // Properties
+
+    #region Methods
+
+    /// <summary>
+    /// Applies the formatter phase to the given input
+    /// </summary>
+    /// <param name="input">Input source text</param>
+    /// <returns>The phase output</returns>
+    protected string ApplyPhase(string input)
+    {
+        var cancellationToken = TestContext.CancellationTokenSource.Token;
+        var tree = CSharpSyntaxTree.ParseText(input, cancellationToken: cancellationToken);
+        var result = ExecutePhase(tree.GetRoot(cancellationToken), cancellationToken);
+
+        return result.ToFullString();
+    }
+
+    /// <summary>
+    /// Executes the formatter phase for the given syntax root
+    /// </summary>
+    /// <param name="root">Syntax root</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The transformed syntax root</returns>
+    protected abstract SyntaxNode ExecutePhase(SyntaxNode root, CancellationToken cancellationToken);
+
+    #endregion // Methods
+}

--- a/Reihitsu.Formatter.Test/Regression/UsingDirectives/UsingDirectiveOrderingTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/UsingDirectives/UsingDirectiveOrderingTests.cs
@@ -196,5 +196,37 @@ public class UsingDirectiveOrderingTests : FormatterTestsBase
         AssertRuleResult(input, expected);
     }
 
+    /// <summary>
+    /// Verifies that attached comments remain with non-first namespace usings after reordering
+    /// </summary>
+    [TestMethod]
+    public void NamespaceUsingsWithCommentsKeepAttachedTrivia()
+    {
+        // Arrange
+        const string input = """
+                             namespace Example
+                             {
+                                 using Zeta;
+                                 using System.Collections;
+                                 // Keep with Alpha
+                                 using Alpha;
+                             }
+                             """;
+        const string expected = """
+                                namespace Example
+                                {
+                                    using System.Collections;
+
+                                    // Keep with Alpha
+                                    using Alpha;
+
+                                    using Zeta;
+                                }
+                                """;
+
+        // Assert
+        AssertRuleResult(input, expected);
+    }
+
     #endregion // Methods
 }

--- a/Reihitsu.Formatter.Test/Regression/UsingDirectives/UsingDirectiveOrderingTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/UsingDirectives/UsingDirectiveOrderingTests.cs
@@ -1,0 +1,200 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Formatter.Test.Helpers;
+
+namespace Reihitsu.Formatter.Test.Regression.UsingDirectives;
+
+/// <summary>
+/// Unit tests for <see cref="Reihitsu.Formatter.Pipeline.FormattingPipeline"/>
+/// </summary>
+[TestClass]
+public class UsingDirectiveOrderingTests : FormatterTestsBase
+{
+    #region Methods
+
+    /// <summary>
+    /// Verifies that a line comment moves together with its using directive during reordering
+    /// </summary>
+    [TestMethod]
+    public void LineCommentMovesWithUsingDirective()
+    {
+        // Arrange
+        const string input = """
+                             using Alpha.Zeta;
+                             // Keep with Alpha
+                             using Alpha.Alpha;
+
+                             class C
+                             {
+                             }
+                             """;
+        const string expected = """
+                                // Keep with Alpha
+                                using Alpha.Alpha;
+                                using Alpha.Zeta;
+
+                                class C
+                                {
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a using block with a nullable directive on a later directive is not reordered
+    /// </summary>
+    [TestMethod]
+    public void BlockWithNullableDirectiveIsNotReordered()
+    {
+        // Arrange
+        const string input = """
+                             using System;
+
+                             #nullable enable
+                             using System.Linq;
+
+                             class C
+                             {
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a using block with conditional directives is not reordered
+    /// </summary>
+    [TestMethod]
+    public void BlockWithConditionalDirectiveIsNotReordered()
+    {
+        // Arrange
+        const string input = """
+                             using System;
+                             #if DEBUG
+                             using System.Linq;
+                             #endif
+
+                             class C
+                             {
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a using block with a pragma warning directive on a later directive is not reordered
+    /// </summary>
+    [TestMethod]
+    public void BlockWithPragmaWarningDirectiveIsNotReordered()
+    {
+        // Arrange
+        const string input = """
+                             using System;
+
+                             #pragma warning disable CS8019
+                             using System.Linq;
+
+                             class C
+                             {
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that an inline trailing comment moves together with its using directive during reordering
+    /// </summary>
+    [TestMethod]
+    public void InlineTrailingCommentMovesWithUsingDirective()
+    {
+        // Arrange
+        const string input = """
+                             using Alpha.Zeta;
+                             using Alpha.Alpha; // Keep with Alpha
+
+                             class C
+                             {
+                             }
+                             """;
+        const string expected = """
+                                using Alpha.Alpha; // Keep with Alpha
+                                using Alpha.Zeta;
+
+                                class C
+                                {
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a comment attached to an alias directive is preserved during reordering
+    /// </summary>
+    [TestMethod]
+    public void AliasDirectiveCommentMovesWithUsingDirective()
+    {
+        // Arrange
+        const string input = """
+                             using ZAlias = Alpha.Zeta;
+                             // Keep alias attached
+                             using AAlias = Alpha.Alpha;
+
+                             class C
+                             {
+                             }
+                             """;
+        const string expected = """
+                                // Keep alias attached
+                                using AAlias = Alpha.Alpha;
+                                using ZAlias = Alpha.Zeta;
+
+                                class C
+                                {
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a comment attached to a static using is preserved during reordering
+    /// </summary>
+    [TestMethod]
+    public void StaticUsingCommentMovesWithUsingDirective()
+    {
+        // Arrange
+        const string input = """
+                             using static Alpha.Zeta;
+                             // Keep static attached
+                             using static Alpha.Alpha;
+
+                             class C
+                             {
+                             }
+                             """;
+        const string expected = """
+                                // Keep static attached
+                                using static Alpha.Alpha;
+                                using static Alpha.Zeta;
+
+                                class C
+                                {
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Formatter.Test/Unit/Pipeline/UsingDirectiveOrderingRewriterTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/Pipeline/UsingDirectiveOrderingRewriterTests.cs
@@ -1,0 +1,146 @@
+using System.Threading;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Formatter.Pipeline.UsingDirectives;
+using Reihitsu.Formatter.Test.Helpers;
+
+namespace Reihitsu.Formatter.Test.Unit.Pipeline;
+
+/// <summary>
+/// Tests for <see cref="UsingDirectiveOrderingPhase"/> using directive ordering
+/// </summary>
+[TestClass]
+public class UsingDirectiveOrderingRewriterTests : FormatterPhaseTestsBase
+{
+    #region Methods
+
+    /// <summary>
+    /// Verifies that regular usings without trivia are reordered
+    /// </summary>
+    [TestMethod]
+    public void RegularUsingsWithoutTriviaAreReordered()
+    {
+        // Arrange
+        const string input = """
+                             using System.Linq;
+                             using System;
+                             """;
+        var expected = "using System;using System.Linq;" + Environment.NewLine;
+
+        // Assert
+        Assert.AreEqual(expected, ApplyPhase(input));
+    }
+
+    /// <summary>
+    /// Verifies that alias directives without trivia are reordered
+    /// </summary>
+    [TestMethod]
+    public void AliasDirectivesWithoutTriviaAreReordered()
+    {
+        // Arrange
+        const string input = """
+                             using L = System.Linq;
+                             using C = System.Collections;
+                             """;
+        var expected = "using C = System.Collections;using L = System.Linq;" + Environment.NewLine;
+
+        // Assert
+        Assert.AreEqual(expected, ApplyPhase(input));
+    }
+
+    /// <summary>
+    /// Verifies that using static directives without trivia are reordered
+    /// </summary>
+    [TestMethod]
+    public void UsingStaticDirectivesWithoutTriviaAreReordered()
+    {
+        // Arrange
+        const string input = """
+                             using static System.Math;
+                             using static System.Console;
+                             """;
+        var expected = "using static System.Console;using static System.Math;" + Environment.NewLine;
+
+        // Assert
+        Assert.AreEqual(expected, ApplyPhase(input));
+    }
+
+    /// <summary>
+    /// Verifies that conditional directives skip reordering
+    /// </summary>
+    [TestMethod]
+    public void ConditionalDirectiveSkipsReordering()
+    {
+        // Arrange
+        const string input = """
+                             using System;
+                             #if DEBUG
+                             using System.Linq;
+                             #endif
+                             """;
+
+        // Assert
+        Assert.AreEqual(input, ApplyPhase(input));
+    }
+
+    /// <summary>
+    /// Verifies that a nullable directive on a later directive skips reordering
+    /// </summary>
+    [TestMethod]
+    public void NullableDirectiveSkipsReordering()
+    {
+        // Arrange
+        const string input = """
+                             using System;
+                             #nullable enable
+                             using System.Linq;
+                             """;
+
+        // Assert
+        Assert.AreEqual(input, ApplyPhase(input));
+    }
+
+    /// <summary>
+    /// Verifies that a pragma directive on a later directive skips reordering
+    /// </summary>
+    [TestMethod]
+    public void PragmaDirectiveSkipsReordering()
+    {
+        // Arrange
+        const string input = """
+                             using System;
+                             #pragma warning disable CS8019
+                             using System.Linq;
+                             """;
+
+        // Assert
+        Assert.AreEqual(input, ApplyPhase(input));
+    }
+
+    /// <summary>
+    /// Verifies that a single using directive is not processed
+    /// </summary>
+    [TestMethod]
+    public void SingleUsingDirectiveIsNotProcessed()
+    {
+        // Arrange
+        const string input = """
+                             using System;
+                             """;
+
+        // Assert
+        Assert.AreEqual(input, ApplyPhase(input));
+    }
+
+    /// <inheritdoc/>
+    protected override SyntaxNode ExecutePhase(SyntaxNode root, CancellationToken cancellationToken)
+    {
+        var context = new FormattingContext(Environment.NewLine);
+
+        return UsingDirectiveOrderingPhase.Execute(root, context, cancellationToken);
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Formatter.Test/Unit/UsingDirectives/UsingDirectiveOrderingRewriterTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/UsingDirectives/UsingDirectiveOrderingRewriterTests.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Reihitsu.Formatter.Pipeline.UsingDirectives;
 using Reihitsu.Formatter.Test.Helpers;
 
-namespace Reihitsu.Formatter.Test.Unit.Pipeline;
+namespace Reihitsu.Formatter.Test.Unit.UsingDirectives;
 
 /// <summary>
 /// Tests for <see cref="UsingDirectiveOrderingPhase"/> using directive ordering
@@ -117,6 +117,96 @@ public class UsingDirectiveOrderingRewriterTests : FormatterPhaseTestsBase
 
         // Assert
         Assert.AreEqual(input, ApplyPhase(input));
+    }
+
+    /// <summary>
+    /// Verifies that using directives are reordered inside a namespace declaration
+    /// </summary>
+    [TestMethod]
+    public void NamespaceUsingsAreReordered()
+    {
+        // Arrange
+        const string input = """
+                             namespace Example
+                             {
+                                 using System.Linq;
+                                 using System;
+                             }
+                             """;
+        const string expected = """
+                                namespace Example
+                                {
+                                    using System;
+                                    using System.Linq;
+                                }
+                                """;
+
+        // Assert
+        Assert.AreEqual(expected, ApplyPhase(input));
+    }
+
+    /// <summary>
+    /// Verifies that attached comments remain with non-first namespace usings after reordering
+    /// </summary>
+    [TestMethod]
+    public void NamespaceUsingsWithCommentsKeepAttachedTrivia()
+    {
+        // Arrange
+        const string input = """
+                             namespace Example
+                             {
+                                 using Zeta;
+                                 using System.Collections;
+                                 // Keep with Alpha
+                                 using Alpha;
+                             }
+                             """;
+        const string expected = """
+                                namespace Example
+                                {
+                                    using System.Collections;
+
+                                    // Keep with Alpha
+                                    using Alpha;
+
+                                    using Zeta;
+                                }
+                                """;
+
+        // Assert
+        Assert.AreEqual(expected, ApplyPhase(input));
+    }
+
+    /// <summary>
+    /// Verifies that using directives are reordered inside a file-scoped namespace
+    /// </summary>
+    [TestMethod]
+    public void FileScopedNamespaceUsingsAreReordered()
+    {
+        // Arrange
+        const string input = """
+                             namespace Example;
+
+                             using System.Linq;
+                             using System;
+
+                             class C
+                             {
+                             }
+                             """;
+        const string expected = """
+                                namespace Example;
+
+                                using System;
+                                using System.Linq;
+
+                                class C
+                                {
+                                }
+                                """;
+
+        // Assert
+        Assert.AreEqual(expected, ApplyPhase(input));
     }
 
     /// <summary>

--- a/Reihitsu.Formatter/Pipeline/UsingDirectives/UsingDirectiveOrderingPhase.cs
+++ b/Reihitsu.Formatter/Pipeline/UsingDirectives/UsingDirectiveOrderingPhase.cs
@@ -1,5 +1,3 @@
-using System.Threading;
-
 using Microsoft.CodeAnalysis;
 
 namespace Reihitsu.Formatter.Pipeline.UsingDirectives;

--- a/Reihitsu.Formatter/Pipeline/UsingDirectives/UsingDirectiveOrderingRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/UsingDirectives/UsingDirectiveOrderingRewriter.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -164,13 +161,167 @@ internal sealed class UsingDirectiveOrderingRewriter : CSharpSyntaxRewriter
     }
 
     /// <summary>
+    /// Creates the leading trivia for the reordered using directive
+    /// </summary>
+    /// <param name="current">Current using directive</param>
+    /// <param name="firstLeadingTriviaPrefix">Whitespace prefix from the first using directive</param>
+    /// <param name="startsNewGroup"><see langword="true"/> if the using starts a new group</param>
+    /// <param name="isFirst"><see langword="true"/> if the using is the first directive in the block</param>
+    /// <param name="endOfLine">Preferred end-of-line sequence</param>
+    /// <returns>The leading trivia to apply</returns>
+    private static SyntaxTriviaList CreateLeadingTrivia(UsingDirectiveSyntax current,
+                                                        SyntaxTriviaList firstLeadingTriviaPrefix,
+                                                        bool startsNewGroup,
+                                                        bool isFirst,
+                                                        string endOfLine)
+    {
+        var leadingTrivia = current.GetLeadingTrivia();
+        var firstSignificantTriviaIndex = GetFirstSignificantTriviaIndex(leadingTrivia);
+
+        if (firstSignificantTriviaIndex < 0)
+        {
+            if (isFirst)
+            {
+                return firstLeadingTriviaPrefix;
+            }
+
+            var indentation = GetIndentationTrivia(leadingTrivia);
+
+            return startsNewGroup
+                       ? SyntaxFactory.TriviaList(SyntaxFactory.EndOfLine(endOfLine))
+                                      .AddRange(indentation)
+                       : indentation;
+        }
+
+        var significantLeadingTrivia = SyntaxFactory.TriviaList(leadingTrivia.Skip(firstSignificantTriviaIndex));
+
+        if (isFirst)
+        {
+            return firstLeadingTriviaPrefix.AddRange(significantLeadingTrivia);
+        }
+
+        var indentationBeforeSignificantTrivia = GetIndentationTriviaBefore(leadingTrivia, firstSignificantTriviaIndex);
+        var linePrefix = startsNewGroup
+                             ? SyntaxFactory.TriviaList(SyntaxFactory.EndOfLine(endOfLine),
+                                                        SyntaxFactory.EndOfLine(endOfLine))
+                             : SyntaxFactory.TriviaList(SyntaxFactory.EndOfLine(endOfLine));
+
+        return linePrefix.AddRange(indentationBeforeSignificantTrivia)
+                         .AddRange(significantLeadingTrivia);
+    }
+
+    /// <summary>
+    /// Gets the first index containing non-whitespace trivia
+    /// </summary>
+    /// <param name="triviaList">Trivia list</param>
+    /// <returns>The index of the first significant trivia, or -1 when none exists</returns>
+    private static int GetFirstSignificantTriviaIndex(SyntaxTriviaList triviaList)
+    {
+        for (var triviaIndex = 0; triviaIndex < triviaList.Count; triviaIndex++)
+        {
+            if (IsWhitespaceOrEndOfLineTrivia(triviaList[triviaIndex]) == false)
+            {
+                return triviaIndex;
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// Gets the indentation whitespace that appears immediately before the given trivia index
+    /// </summary>
+    /// <param name="leadingTrivia">Leading trivia</param>
+    /// <param name="significantTriviaIndex">Index of the first significant trivia</param>
+    /// <returns>Trivia list containing only the indentation whitespace</returns>
+    private static SyntaxTriviaList GetIndentationTriviaBefore(SyntaxTriviaList leadingTrivia, int significantTriviaIndex)
+    {
+        var result = new List<SyntaxTrivia>();
+
+        for (var triviaIndex = significantTriviaIndex - 1; triviaIndex >= 0; triviaIndex--)
+        {
+            if (leadingTrivia[triviaIndex].IsKind(SyntaxKind.WhitespaceTrivia))
+            {
+                result.Insert(0, leadingTrivia[triviaIndex]);
+
+                continue;
+            }
+
+            if (leadingTrivia[triviaIndex].IsKind(SyntaxKind.EndOfLineTrivia))
+            {
+                break;
+            }
+
+            result.Clear();
+
+            break;
+        }
+
+        return SyntaxFactory.TriviaList(result);
+    }
+
+    /// <summary>
+    /// Gets the whitespace-only prefix from the start of the trivia list
+    /// </summary>
+    /// <param name="triviaList">Trivia list</param>
+    /// <returns>The whitespace-only prefix</returns>
+    private static SyntaxTriviaList GetWhitespacePrefix(SyntaxTriviaList triviaList)
+    {
+        var result = new List<SyntaxTrivia>();
+
+        foreach (var trivia in triviaList)
+        {
+            if (IsWhitespaceOrEndOfLineTrivia(trivia) == false)
+            {
+                break;
+            }
+
+            result.Add(trivia);
+        }
+
+        return SyntaxFactory.TriviaList(result);
+    }
+
+    /// <summary>
+    /// Determines whether the trivia is whitespace or an end-of-line marker
+    /// </summary>
+    /// <param name="trivia">Trivia</param>
+    /// <returns><see langword="true"/> if the trivia is whitespace-only</returns>
+    private static bool IsWhitespaceOrEndOfLineTrivia(SyntaxTrivia trivia)
+    {
+        return trivia.IsKind(SyntaxKind.WhitespaceTrivia)
+               || trivia.IsKind(SyntaxKind.EndOfLineTrivia);
+    }
+
+    /// <summary>
+    /// Replaces the using directive list on a scope node
+    /// </summary>
+    /// <param name="scope">Compilation unit or namespace declaration</param>
+    /// <param name="usingDirectives">Updated using directives</param>
+    /// <returns>The updated scope node</returns>
+    private static SyntaxNode WithUsings(SyntaxNode scope, SyntaxList<UsingDirectiveSyntax> usingDirectives)
+    {
+        return scope switch
+               {
+                   CompilationUnitSyntax compilationUnit => compilationUnit.WithUsings(usingDirectives),
+                   BaseNamespaceDeclarationSyntax namespaceDeclaration => namespaceDeclaration.WithUsings(usingDirectives),
+                   _ => scope,
+               };
+    }
+
+    /// <summary>
     /// Organizes the provided using directives into grouped canonical order
     /// </summary>
     /// <param name="usingDirectives">Using directives to organize</param>
     /// <returns>The organized directives</returns>
     private SyntaxList<UsingDirectiveSyntax> OrganizeUsings(SyntaxList<UsingDirectiveSyntax> usingDirectives)
     {
-        var firstLeadingTrivia = usingDirectives.First().GetLeadingTrivia();
+        if (UsingDirectiveOrderingSafety.CanSafelyReorder(usingDirectives) == false)
+        {
+            return usingDirectives;
+        }
+
+        var firstLeadingTriviaPrefix = GetWhitespacePrefix(usingDirectives.First().GetLeadingTrivia());
         var canonical = ComputeCanonicalOrder(usingDirectives);
         var result = new List<UsingDirectiveSyntax>();
 
@@ -182,41 +333,19 @@ internal sealed class UsingDirectiveOrderingRewriter : CSharpSyntaxRewriter
 
             if (usingIndex == 0)
             {
-                result.Add(current.WithLeadingTrivia(firstLeadingTrivia));
+                result.Add(current.WithLeadingTrivia(CreateLeadingTrivia(current, firstLeadingTriviaPrefix, startsNewGroup: false, isFirst: true, _endOfLine)));
 
                 continue;
             }
 
-            var indentation = GetIndentationTrivia(current.GetLeadingTrivia());
-
-            if (AreInSameGroup(canonical[usingIndex - 1], current))
-            {
-                result.Add(current.WithLeadingTrivia(indentation));
-
-                continue;
-            }
-
-            result.Add(current.WithLeadingTrivia(SyntaxFactory.TriviaList(SyntaxFactory.EndOfLine(_endOfLine))
-                                                              .AddRange(indentation)));
+            result.Add(current.WithLeadingTrivia(CreateLeadingTrivia(current,
+                                                                     firstLeadingTriviaPrefix,
+                                                                     startsNewGroup: AreInSameGroup(canonical[usingIndex - 1], current) == false,
+                                                                     isFirst: false,
+                                                                     _endOfLine)));
         }
 
         return SyntaxFactory.List(result);
-    }
-
-    /// <summary>
-    /// Replaces the using directive list on a scope node
-    /// </summary>
-    /// <param name="scope">Compilation unit or namespace declaration</param>
-    /// <param name="usingDirectives">Updated using directives</param>
-    /// <returns>The updated scope node</returns>
-    private SyntaxNode WithUsings(SyntaxNode scope, SyntaxList<UsingDirectiveSyntax> usingDirectives)
-    {
-        return scope switch
-               {
-                   CompilationUnitSyntax compilationUnit => compilationUnit.WithUsings(usingDirectives),
-                   BaseNamespaceDeclarationSyntax namespaceDeclaration => namespaceDeclaration.WithUsings(usingDirectives),
-                   _ => scope,
-               };
     }
 
     #endregion // Methods

--- a/Reihitsu.Formatter/Pipeline/UsingDirectives/UsingDirectiveOrderingRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/UsingDirectives/UsingDirectiveOrderingRewriter.cs
@@ -202,9 +202,8 @@ internal sealed class UsingDirectiveOrderingRewriter : CSharpSyntaxRewriter
 
         var indentationBeforeSignificantTrivia = GetIndentationTriviaBefore(leadingTrivia, firstSignificantTriviaIndex);
         var linePrefix = startsNewGroup
-                             ? SyntaxFactory.TriviaList(SyntaxFactory.EndOfLine(endOfLine),
-                                                        SyntaxFactory.EndOfLine(endOfLine))
-                             : SyntaxFactory.TriviaList(SyntaxFactory.EndOfLine(endOfLine));
+                             ? SyntaxFactory.TriviaList(SyntaxFactory.EndOfLine(endOfLine))
+                             : SyntaxFactory.TriviaList();
 
         return linePrefix.AddRange(indentationBeforeSignificantTrivia)
                          .AddRange(significantLeadingTrivia);

--- a/Reihitsu.Formatter/Pipeline/UsingDirectives/UsingDirectiveOrderingSafety.cs
+++ b/Reihitsu.Formatter/Pipeline/UsingDirectives/UsingDirectiveOrderingSafety.cs
@@ -1,0 +1,49 @@
+using System.Text.RegularExpressions;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Reihitsu.Formatter.Pipeline.UsingDirectives;
+
+/// <summary>
+/// Safety checks for using directive reordering
+/// </summary>
+public static class UsingDirectiveOrderingSafety
+{
+    #region Methods
+
+    /// <summary>
+    /// Determines whether the given using block can be reordered safely
+    /// </summary>
+    /// <param name="usingDirectives">Using directives</param>
+    /// <returns><see langword="true"/> if the block can be reordered safely</returns>
+    public static bool CanSafelyReorder(SyntaxList<UsingDirectiveSyntax> usingDirectives)
+    {
+        return usingDirectives.Any(HasUnsafeTrivia) == false
+               && ContainsPreprocessorDirective(usingDirectives) == false;
+    }
+
+    /// <summary>
+    /// Determines whether a using directive contains trivia that must not be moved
+    /// </summary>
+    /// <param name="usingDirective">Using directive</param>
+    /// <returns><see langword="true"/> if the directive has unsafe trivia</returns>
+    private static bool HasUnsafeTrivia(UsingDirectiveSyntax usingDirective)
+    {
+        return usingDirective.GetLeadingTrivia()
+                             .Concat(usingDirective.GetTrailingTrivia())
+                             .Any(trivia => trivia.GetStructure() is DirectiveTriviaSyntax);
+    }
+
+    /// <summary>
+    /// Determines whether the using block contains a preprocessor directive line
+    /// </summary>
+    /// <param name="usingDirectives">Using directives</param>
+    /// <returns><see langword="true"/> if the block contains a preprocessor directive</returns>
+    private static bool ContainsPreprocessorDirective(SyntaxList<UsingDirectiveSyntax> usingDirectives)
+    {
+        return Regex.IsMatch(usingDirectives.ToFullString(), @"(^|\r?\n)\s*#", RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100));
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Formatter/Properties/AssemblyInfo.cs
+++ b/Reihitsu.Formatter/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("Reihitsu.Analyzer.CodeFixes")]
 [assembly: InternalsVisibleTo("Reihitsu.Analyzer.Test")]
 [assembly: InternalsVisibleTo("Reihitsu.Formatter.Test")]


### PR DESCRIPTION
## Summary
- preserve attached comment trivia when reordering using directives while skipping unsafe blocks that contain preprocessor-style directives
- route the RH0390 code fix through the formatter and suppress fixes when reordering would be unsafe
- add regression coverage for comments, `#nullable`, `#pragma`, and `#if`, and extract reusable analyzer/code-fix and formatter-phase test helpers

## Testing
- `dotnet test Reihitsu.Formatter.Test\Reihitsu.Formatter.Test.csproj -c Release --verbosity minimal`
- `dotnet test Reihitsu.Analyzer.Test\Reihitsu.Analyzer.Test.csproj -c Release --verbosity minimal`
- `dotnet build Reihitsu.sln -c Release --verbosity minimal`

Closes #56
