### PR TITLE
Fix async Task expression-bodied rewrites

### DIFF
--- a/Reihitsu.Formatter.Test/Regression/Structural/ExpressionBodiedLocalFunctionTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Structural/ExpressionBodiedLocalFunctionTests.cs
@@ -8,21 +8,24 @@ namespace Reihitsu.Formatter.Test.Regression.Structural;
 /// Unit tests for <see cref="Reihitsu.Formatter.Pipeline.FormattingPipeline"/>
 /// </summary>
 [TestClass]
-public class ExpressionBodiedMethodTests : FormatterTestsBase
+public class ExpressionBodiedLocalFunctionTests : FormatterTestsBase
 {
     #region Methods
 
     /// <summary>
-    /// Verifies that an expression-bodied void method is converted to a block body with an expression statement
+    /// Verifies that an expression-bodied void local function is converted to a block body with an expression statement
     /// </summary>
     [TestMethod]
-    public void VoidMethodConvertsToExpressionStatement()
+    public void VoidLocalFunctionConvertsToExpressionStatement()
     {
         // Arrange
         const string input = """
                              class C
                              {
-                                 void M() => Console.WriteLine();
+                                 void M()
+                                 {
+                                     void Local() => Console.WriteLine();
+                                 }
                              }
                              """;
         const string expected = """
@@ -30,7 +33,10 @@ public class ExpressionBodiedMethodTests : FormatterTestsBase
                                 {
                                     void M()
                                     {
-                                        Console.WriteLine();
+                                        void Local()
+                                        {
+                                            Console.WriteLine();
+                                        }
                                     }
                                 }
                                 """;
@@ -40,24 +46,30 @@ public class ExpressionBodiedMethodTests : FormatterTestsBase
     }
 
     /// <summary>
-    /// Verifies that an expression-bodied returning method is converted to a block body with a return statement
+    /// Verifies that an expression-bodied returning local function is converted to a block body with a return statement
     /// </summary>
     [TestMethod]
-    public void ReturningMethodConvertsToReturnStatement()
+    public void ReturningLocalFunctionConvertsToReturnStatement()
     {
         // Arrange
         const string input = """
                              class C
                              {
-                                 int M() => 42;
+                                 void M()
+                                 {
+                                     int Local() => 42;
+                                 }
                              }
                              """;
         const string expected = """
                                 class C
                                 {
-                                    int M()
+                                    void M()
                                     {
-                                        return 42;
+                                        int Local()
+                                        {
+                                            return 42;
+                                        }
                                     }
                                 }
                                 """;
@@ -67,18 +79,21 @@ public class ExpressionBodiedMethodTests : FormatterTestsBase
     }
 
     /// <summary>
-    /// Verifies that a method with an existing block body remains unchanged
+    /// Verifies that a local function with an existing block body remains unchanged
     /// </summary>
     [TestMethod]
-    public void MethodWithBlockBodyRemainsUnchanged()
+    public void LocalFunctionWithBlockBodyRemainsUnchanged()
     {
         // Arrange
         const string input = """
                              class C
                              {
-                                 int M()
+                                 void M()
                                  {
-                                     return 42;
+                                     int Local()
+                                     {
+                                         return 42;
+                                     }
                                  }
                              }
                              """;
@@ -88,24 +103,30 @@ public class ExpressionBodiedMethodTests : FormatterTestsBase
     }
 
     /// <summary>
-    /// Verifies that an async expression-bodied method is converted correctly
+    /// Verifies that an async expression-bodied local function is converted correctly
     /// </summary>
     [TestMethod]
-    public void AsyncMethodConvertsCorrectly()
+    public void AsyncLocalFunctionConvertsCorrectly()
     {
         // Arrange
         const string input = """
                              class C
                              {
-                                 async Task<int> M() => await Task.FromResult(1);
+                                 void M()
+                                 {
+                                     async Task<int> Local() => await Task.FromResult(1);
+                                 }
                              }
                              """;
         const string expected = """
                                 class C
                                 {
-                                    async Task<int> M()
+                                    void M()
                                     {
-                                        return await Task.FromResult(1);
+                                        async Task<int> Local()
+                                        {
+                                            return await Task.FromResult(1);
+                                        }
                                     }
                                 }
                                 """;
@@ -115,24 +136,30 @@ public class ExpressionBodiedMethodTests : FormatterTestsBase
     }
 
     /// <summary>
-    /// Verifies that an async Task expression-bodied method is converted to a block body with an expression statement
+    /// Verifies that an async Task expression-bodied local function is converted to a block body with an expression statement
     /// </summary>
     [TestMethod]
-    public void AsyncTaskMethodConvertsToExpressionStatement()
+    public void AsyncTaskLocalFunctionConvertsToExpressionStatement()
     {
         // Arrange
         const string input = """
                              class C
                              {
-                                 async Task DoWorkAsync() => await Task.CompletedTask;
+                                 void M()
+                                 {
+                                     async Task DoWorkAsync() => await Task.CompletedTask;
+                                 }
                              }
                              """;
         const string expected = """
                                 class C
                                 {
-                                    async Task DoWorkAsync()
+                                    void M()
                                     {
-                                        await Task.CompletedTask;
+                                        async Task DoWorkAsync()
+                                        {
+                                            await Task.CompletedTask;
+                                        }
                                     }
                                 }
                                 """;
@@ -142,24 +169,30 @@ public class ExpressionBodiedMethodTests : FormatterTestsBase
     }
 
     /// <summary>
-    /// Verifies that method parameters are preserved during conversion
+    /// Verifies that local-function parameters are preserved during conversion
     /// </summary>
     [TestMethod]
-    public void MethodWithParametersConvertsCorrectly()
+    public void LocalFunctionWithParametersConvertsCorrectly()
     {
         // Arrange
         const string input = """
                              class C
                              {
-                                 int Add(int a, int b) => a + b;
+                                 void M()
+                                 {
+                                     int Add(int a, int b) => a + b;
+                                 }
                              }
                              """;
         const string expected = """
                                 class C
                                 {
-                                    int Add(int a, int b)
+                                    void M()
                                     {
-                                        return a + b;
+                                        int Add(int a, int b)
+                                        {
+                                            return a + b;
+                                        }
                                     }
                                 }
                                 """;
@@ -169,24 +202,30 @@ public class ExpressionBodiedMethodTests : FormatterTestsBase
     }
 
     /// <summary>
-    /// Verifies that a generic expression-bodied method is converted correctly
+    /// Verifies that a generic expression-bodied local function is converted correctly
     /// </summary>
     [TestMethod]
-    public void GenericMethodConvertsCorrectly()
+    public void GenericLocalFunctionConvertsCorrectly()
     {
         // Arrange
         const string input = """
                              class C
                              {
-                                 T M<T>() => default;
+                                 void M()
+                                 {
+                                     T Local<T>() => default;
+                                 }
                              }
                              """;
         const string expected = """
                                 class C
                                 {
-                                    T M<T>()
+                                    void M()
                                     {
-                                        return default;
+                                        T Local<T>()
+                                        {
+                                            return default;
+                                        }
                                     }
                                 }
                                 """;
@@ -196,24 +235,30 @@ public class ExpressionBodiedMethodTests : FormatterTestsBase
     }
 
     /// <summary>
-    /// Verifies that a static expression-bodied method is converted correctly
+    /// Verifies that a static expression-bodied local function is converted correctly
     /// </summary>
     [TestMethod]
-    public void StaticMethodConvertsCorrectly()
+    public void StaticLocalFunctionConvertsCorrectly()
     {
         // Arrange
         const string input = """
                              class C
                              {
-                                 static int M() => 1;
+                                 void M()
+                                 {
+                                     static int Local() => 1;
+                                 }
                              }
                              """;
         const string expected = """
                                 class C
                                 {
-                                    static int M()
+                                    void M()
                                     {
-                                        return 1;
+                                        static int Local()
+                                        {
+                                            return 1;
+                                        }
                                     }
                                 }
                                 """;

--- a/Reihitsu.Formatter.Test/Unit/StructuralTransforms/ExpressionBodiedLocalFunctionTransformTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/StructuralTransforms/ExpressionBodiedLocalFunctionTransformTests.cs
@@ -1,0 +1,381 @@
+using System.Threading;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Formatter.Pipeline.StructuralTransforms;
+using Reihitsu.Formatter.Test.Helpers;
+
+namespace Reihitsu.Formatter.Test.Unit.StructuralTransforms;
+
+/// <summary>
+/// Tests for <see cref="StructuralTransformPhase"/> local-function expression-bodied transforms
+/// </summary>
+[TestClass]
+public class ExpressionBodiedLocalFunctionTransformTests : FormatterPhaseTestsBase
+{
+    #region Tests
+
+    /// <summary>
+    /// Verifies that an expression-bodied local function is converted to block body
+    /// </summary>
+    [TestMethod]
+    public void ConvertsExpressionBodiedLocalFunctionToBlockBody()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     int Add(int a, int b) => a + b;
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        int Add(int a, int b) {returna + b;}
+                                    }
+                                }
+                                """;
+
+        // Act
+        var actual = ApplyPhase(input);
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    /// <summary>
+    /// Verifies that an expression-bodied void local function is converted to block body with an expression statement
+    /// </summary>
+    [TestMethod]
+    public void ConvertsVoidExpressionBodiedLocalFunctionToBlockBody()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     void Local() => Console.WriteLine();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        void Local() {Console.WriteLine();}
+                                    }
+                                }
+                                """;
+
+        // Act
+        var actual = ApplyPhase(input);
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    /// <summary>
+    /// Verifies that an async Task expression-bodied local function is converted without a return statement
+    /// </summary>
+    [TestMethod]
+    public void ConvertsAsyncTaskExpressionBodiedLocalFunctionToExpressionStatement()
+    {
+        // Arrange
+        const string input = """
+                             using System.Threading.Tasks;
+
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     async Task AwaitAndReturnNothing() => await Task.CompletedTask;
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                using System.Threading.Tasks;
+
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        async Task AwaitAndReturnNothing() {await Task.CompletedTask;}
+                                    }
+                                }
+                                """;
+
+        // Act
+        var actual = ApplyPhase(input);
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    /// <summary>
+    /// Verifies that an async Task{T} expression-bodied local function is converted with a return statement
+    /// </summary>
+    [TestMethod]
+    public void ConvertsAsyncGenericTaskExpressionBodiedLocalFunctionToReturnStatement()
+    {
+        // Arrange
+        const string input = """
+                             using System.Threading.Tasks;
+
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     async Task<int> AwaitAndReturnValue() => await Task.FromResult(1);
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                using System.Threading.Tasks;
+
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        async Task<int> AwaitAndReturnValue() {returnawait Task.FromResult(1);}
+                                    }
+                                }
+                                """;
+
+        // Act
+        var actual = ApplyPhase(input);
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    /// <summary>
+    /// Verifies that an async void expression-bodied local function is converted without a return statement
+    /// </summary>
+    [TestMethod]
+    public void ConvertsAsyncVoidExpressionBodiedLocalFunctionToExpressionStatement()
+    {
+        // Arrange
+        const string input = """
+                             using System.Threading.Tasks;
+
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     async void Notify() => await Task.CompletedTask;
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                using System.Threading.Tasks;
+
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        async void Notify() {await Task.CompletedTask;}
+                                    }
+                                }
+                                """;
+
+        // Act
+        var actual = ApplyPhase(input);
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    /// <summary>
+    /// Verifies that a non-async Task expression-bodied local function is converted with a return statement
+    /// </summary>
+    [TestMethod]
+    public void ConvertsNonAsyncTaskExpressionBodiedLocalFunctionToReturnStatement()
+    {
+        // Arrange
+        const string input = """
+                             using System.Threading.Tasks;
+
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     Task PassThrough() => Task.CompletedTask;
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                using System.Threading.Tasks;
+
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        Task PassThrough() {returnTask.CompletedTask;}
+                                    }
+                                }
+                                """;
+
+        // Act
+        var actual = ApplyPhase(input);
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    /// <summary>
+    /// Verifies that an expression-bodied generic local function is converted to block body
+    /// </summary>
+    [TestMethod]
+    public void ConvertsGenericExpressionBodiedLocalFunctionToBlockBody()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     T Local<T>() => default;
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        T Local<T>() {returndefault;}
+                                    }
+                                }
+                                """;
+
+        // Act
+        var actual = ApplyPhase(input);
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    /// <summary>
+    /// Verifies that a static expression-bodied local function is converted to block body
+    /// </summary>
+    [TestMethod]
+    public void ConvertsStaticExpressionBodiedLocalFunctionToBlockBody()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     static int Local() => 1;
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        static int Local() {return1;}
+                                    }
+                                }
+                                """;
+
+        // Act
+        var actual = ApplyPhase(input);
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    /// <summary>
+    /// Verifies that a static async Task expression-bodied local function is converted without a return statement
+    /// </summary>
+    [TestMethod]
+    public void ConvertsStaticAsyncTaskExpressionBodiedLocalFunctionToExpressionStatement()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     static async Task LocalAsync() => await Task.CompletedTask;
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        static async Task LocalAsync() {await Task.CompletedTask;}
+                                    }
+                                }
+                                """;
+
+        // Act
+        var actual = ApplyPhase(input);
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    /// <summary>
+    /// Verifies that a local function already using block body is not modified
+    /// </summary>
+    [TestMethod]
+    public void PreservesBlockBodiedLocalFunction()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     int Local()
+                                     {
+                                         return 42;
+                                     }
+                                 }
+                             }
+                             """;
+
+        // Act
+        var actual = ApplyPhase(input);
+
+        // Assert
+        Assert.AreEqual(input, actual);
+    }
+
+    #endregion // Tests
+
+    #region FormatterPhaseTestsBase
+
+    /// <inheritdoc/>
+    protected override SyntaxNode ExecutePhase(SyntaxNode root, CancellationToken cancellationToken)
+    {
+        var context = new FormattingContext(Environment.NewLine);
+
+        return StructuralTransformPhase.Execute(root, context, cancellationToken);
+    }
+
+    #endregion // FormatterPhaseTestsBase
+}

--- a/Reihitsu.Formatter.Test/Unit/StructuralTransforms/ExpressionBodiedTransformTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/StructuralTransforms/ExpressionBodiedTransformTests.cs
@@ -1,28 +1,20 @@
 using System.Threading;
 
-using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Reihitsu.Formatter.Pipeline.StructuralTransforms;
+using Reihitsu.Formatter.Test.Helpers;
 
 namespace Reihitsu.Formatter.Test.Unit.StructuralTransforms;
 
 /// <summary>
-/// Tests for <see cref="StructuralTransformPhase"/> expression-bodied transforms
+/// Tests for <see cref="StructuralTransformPhase"/> expression-bodied member transforms
 /// </summary>
 [TestClass]
-public class ExpressionBodiedTransformTests
+public class ExpressionBodiedTransformTests : FormatterPhaseTestsBase
 {
-    #region Properties
-
-    /// <summary>
-    /// Gets or sets the test context for the current test
-    /// </summary>
-    public TestContext TestContext { get; set; }
-
-    #endregion // Properties
-
-    #region Methods
+    #region Tests
 
     /// <summary>
     /// Verifies that an expression-bodied method returning a value is converted to block body with a return statement
@@ -46,7 +38,7 @@ public class ExpressionBodiedTransformTests
                                 """;
 
         // Act
-        var actual = RunTransform(input, TestContext.CancellationTokenSource.Token);
+        var actual = ApplyPhase(input);
 
         // Assert
         Assert.AreEqual(expected, actual);
@@ -74,7 +66,135 @@ public class ExpressionBodiedTransformTests
                                 """;
 
         // Act
-        var actual = RunTransform(input, TestContext.CancellationTokenSource.Token);
+        var actual = ApplyPhase(input);
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    /// <summary>
+    /// Verifies that an async Task expression-bodied method is converted without a return statement
+    /// </summary>
+    [TestMethod]
+    public void ConvertsAsyncTaskExpressionBodiedMethodToExpressionStatement()
+    {
+        // Arrange
+        const string input = """
+                             using System.Threading.Tasks;
+
+                             class C
+                             {
+                                 async Task AwaitAndReturnNothing() => await Task.CompletedTask;
+                             }
+                             """;
+
+        const string expected = """
+                                using System.Threading.Tasks;
+
+                                class C
+                                {
+                                    async Task AwaitAndReturnNothing(){await Task.CompletedTask;}
+                                }
+                                """;
+
+        // Act
+        var actual = ApplyPhase(input);
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    /// <summary>
+    /// Verifies that an async Task{T} expression-bodied method is converted with a return statement
+    /// </summary>
+    [TestMethod]
+    public void ConvertsAsyncGenericTaskExpressionBodiedMethodToReturnStatement()
+    {
+        // Arrange
+        const string input = """
+                             using System.Threading.Tasks;
+
+                             class C
+                             {
+                                 async Task<int> AwaitAndReturnValue() => await Task.FromResult(1);
+                             }
+                             """;
+
+        const string expected = """
+                                using System.Threading.Tasks;
+
+                                class C
+                                {
+                                    async Task<int> AwaitAndReturnValue(){returnawait Task.FromResult(1);}
+                                }
+                                """;
+
+        // Act
+        var actual = ApplyPhase(input);
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    /// <summary>
+    /// Verifies that an async void expression-bodied method is converted without a return statement
+    /// </summary>
+    [TestMethod]
+    public void ConvertsAsyncVoidExpressionBodiedMethodToExpressionStatement()
+    {
+        // Arrange
+        const string input = """
+                             using System.Threading.Tasks;
+
+                             class C
+                             {
+                                 async void Notify() => await Task.CompletedTask;
+                             }
+                             """;
+
+        const string expected = """
+                                using System.Threading.Tasks;
+
+                                class C
+                                {
+                                    async void Notify(){await Task.CompletedTask;}
+                                }
+                                """;
+
+        // Act
+        var actual = ApplyPhase(input);
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    /// <summary>
+    /// Verifies that a non-async Task expression-bodied method is converted with a return statement
+    /// </summary>
+    [TestMethod]
+    public void ConvertsNonAsyncTaskExpressionBodiedMethodToReturnStatement()
+    {
+        // Arrange
+        const string input = """
+                             using System.Threading.Tasks;
+
+                             class C
+                             {
+                                 Task PassThrough() => Task.CompletedTask;
+                             }
+                             """;
+
+        const string expected = """
+                                using System.Threading.Tasks;
+
+                                class C
+                                {
+                                    Task PassThrough(){returnTask.CompletedTask;}
+                                }
+                                """;
+
+        // Act
+        var actual = ApplyPhase(input);
 
         // Assert
         Assert.AreEqual(expected, actual);
@@ -98,7 +218,7 @@ public class ExpressionBodiedTransformTests
                              """;
 
         // Act
-        var actual = RunTransform(input, TestContext.CancellationTokenSource.Token);
+        var actual = ApplyPhase(input);
 
         // Assert
         Assert.AreEqual(input, actual);
@@ -128,41 +248,7 @@ public class ExpressionBodiedTransformTests
                                 """;
 
         // Act
-        var actual = RunTransform(input, TestContext.CancellationTokenSource.Token);
-
-        // Assert
-        Assert.AreEqual(expected, actual);
-    }
-
-    /// <summary>
-    /// Verifies that an expression-bodied local function is converted to block body
-    /// </summary>
-    [TestMethod]
-    public void ConvertsExpressionBodiedLocalFunctionToBlockBody()
-    {
-        // Arrange
-        const string input = """
-                             class C
-                             {
-                                 void M()
-                                 {
-                                     int Add(int a, int b) => a + b;
-                                 }
-                             }
-                             """;
-
-        const string expected = """
-                                class C
-                                {
-                                    void M()
-                                    {
-                                        int Add(int a, int b) {returna + b;}
-                                    }
-                                }
-                                """;
-
-        // Act
-        var actual = RunTransform(input, TestContext.CancellationTokenSource.Token);
+        var actual = ApplyPhase(input);
 
         // Assert
         Assert.AreEqual(expected, actual);
@@ -190,7 +276,7 @@ public class ExpressionBodiedTransformTests
                                 """;
 
         // Act
-        var actual = RunTransform(input, TestContext.CancellationTokenSource.Token);
+        var actual = ApplyPhase(input);
 
         // Assert
         Assert.AreEqual(expected, actual);
@@ -220,7 +306,7 @@ public class ExpressionBodiedTransformTests
                                 """;
 
         // Act
-        var actual = RunTransform(input, TestContext.CancellationTokenSource.Token);
+        var actual = ApplyPhase(input);
 
         // Assert
         Assert.AreEqual(expected, actual);
@@ -248,7 +334,7 @@ public class ExpressionBodiedTransformTests
                                 """;
 
         // Act
-        var actual = RunTransform(input, TestContext.CancellationTokenSource.Token);
+        var actual = ApplyPhase(input);
 
         // Assert
         Assert.AreEqual(expected, actual);
@@ -276,7 +362,7 @@ public class ExpressionBodiedTransformTests
                                 """;
 
         // Act
-        var actual = RunTransform(input, TestContext.CancellationTokenSource.Token);
+        var actual = ApplyPhase(input);
 
         // Assert
         Assert.AreEqual(expected, actual);
@@ -297,7 +383,7 @@ public class ExpressionBodiedTransformTests
                              """;
 
         // Act
-        var actual = RunTransform(input, TestContext.CancellationTokenSource.Token);
+        var actual = ApplyPhase(input);
 
         // Assert
         Assert.AreEqual(input, actual);
@@ -327,7 +413,7 @@ public class ExpressionBodiedTransformTests
                                 """;
 
         // Act
-        var actual = RunTransform(input, TestContext.CancellationTokenSource.Token);
+        var actual = ApplyPhase(input);
 
         // Assert
         Assert.AreEqual(expected, actual);
@@ -355,26 +441,23 @@ public class ExpressionBodiedTransformTests
                                 """;
 
         // Act
-        var actual = RunTransform(input, TestContext.CancellationTokenSource.Token);
+        var actual = ApplyPhase(input);
 
         // Assert
         Assert.AreEqual(expected, actual);
     }
 
-    /// <summary>
-    /// Runs the structural transform phase on the given input
-    /// </summary>
-    /// <param name="input">The source text to transform</param>
-    /// <param name="token">The cancellation token</param>
-    /// <returns>The transformed source text</returns>
-    private static string RunTransform(string input, CancellationToken token)
-    {
-        var tree = CSharpSyntaxTree.ParseText(input, cancellationToken: token);
-        var context = new FormattingContext(Environment.NewLine);
-        var result = StructuralTransformPhase.Execute(tree.GetRoot(token), context, token);
+    #endregion // Tests
 
-        return result.ToFullString();
+    #region FormatterPhaseTestsBase
+
+    /// <inheritdoc/>
+    protected override SyntaxNode ExecutePhase(SyntaxNode root, CancellationToken cancellationToken)
+    {
+        var context = new FormattingContext(Environment.NewLine);
+
+        return StructuralTransformPhase.Execute(root, context, cancellationToken);
     }
 
-    #endregion // Methods
+    #endregion // FormatterPhaseTestsBase
 }

--- a/Reihitsu.Formatter/Pipeline/StructuralTransforms/ExpressionBodiedLocalFunctionTransform.cs
+++ b/Reihitsu.Formatter/Pipeline/StructuralTransforms/ExpressionBodiedLocalFunctionTransform.cs
@@ -6,8 +6,8 @@ namespace Reihitsu.Formatter.Pipeline.StructuralTransforms;
 
 /// <summary>
 /// Converts expression-bodied local functions to block body.
-/// Non-void functions wrap the expression in a <see cref="ReturnStatementSyntax"/>.
-/// Void functions wrap it in an <see cref="ExpressionStatementSyntax"/>
+/// Value-returning functions wrap the expression in a <see cref="ReturnStatementSyntax"/>.
+/// Void and non-generic async task functions wrap it in an <see cref="ExpressionStatementSyntax"/>
 /// </summary>
 internal sealed class ExpressionBodiedLocalFunctionTransform : CSharpSyntaxRewriter
 {
@@ -36,11 +36,12 @@ internal sealed class ExpressionBodiedLocalFunctionTransform : CSharpSyntaxRewri
     #region Methods
 
     /// <summary>
-    /// Determines whether the given return type represents <see langword="void"/>
+    /// Determines whether the given local function should use an expression statement when converting to a block body
     /// </summary>
     /// <param name="returnType">The return type syntax to check</param>
-    /// <returns><see langword="true"/> if the return type is <see langword="void"/>; otherwise, <see langword="false"/></returns>
-    private static bool IsVoidReturn(TypeSyntax returnType)
+    /// <param name="modifiers">The local function modifiers</param>
+    /// <returns><see langword="true"/> if the converted body should use an expression statement; otherwise, <see langword="false"/></returns>
+    private static bool UsesExpressionStatement(TypeSyntax returnType, SyntaxTokenList modifiers)
     {
         if (returnType is PredefinedTypeSyntax predefined
             && predefined.Keyword.IsKind(SyntaxKind.VoidKeyword))
@@ -48,7 +49,41 @@ internal sealed class ExpressionBodiedLocalFunctionTransform : CSharpSyntaxRewri
             return true;
         }
 
+        return HasAsyncModifier(modifiers) && IsNonGenericTaskReturnType(returnType);
+    }
+
+    /// <summary>
+    /// Determines whether the provided modifiers include <see langword="async"/>
+    /// </summary>
+    /// <param name="modifiers">The modifiers to inspect</param>
+    /// <returns><see langword="true"/> if an async modifier is present; otherwise, <see langword="false"/></returns>
+    private static bool HasAsyncModifier(SyntaxTokenList modifiers)
+    {
+        foreach (var modifier in modifiers)
+        {
+            if (modifier.IsKind(SyntaxKind.AsyncKeyword))
+            {
+                return true;
+            }
+        }
+
         return false;
+    }
+
+    /// <summary>
+    /// Determines whether the given return type represents a non-generic task
+    /// </summary>
+    /// <param name="returnType">The return type syntax to check</param>
+    /// <returns><see langword="true"/> if the return type is a non-generic task; otherwise, <see langword="false"/></returns>
+    private static bool IsNonGenericTaskReturnType(TypeSyntax returnType)
+    {
+        return returnType switch
+               {
+                   IdentifierNameSyntax identifier => identifier.Identifier.ValueText == "Task",
+                   QualifiedNameSyntax qualified => qualified.Right.Identifier.ValueText == "Task" && qualified.Right is GenericNameSyntax == false,
+                   AliasQualifiedNameSyntax aliasQualified => aliasQualified.Name.Identifier.ValueText == "Task" && aliasQualified.Name is GenericNameSyntax == false,
+                   _ => false,
+               };
     }
 
     #endregion // Methods
@@ -68,11 +103,11 @@ internal sealed class ExpressionBodiedLocalFunctionTransform : CSharpSyntaxRewri
         }
 
         var expression = node.ExpressionBody.Expression;
-        var isVoid = IsVoidReturn(node.ReturnType);
+        var useExpressionStatement = UsesExpressionStatement(node.ReturnType, node.Modifiers);
 
         StatementSyntax statement;
 
-        if (isVoid)
+        if (useExpressionStatement)
         {
             statement = SyntaxFactory.ExpressionStatement(expression);
         }

--- a/Reihitsu.Formatter/Pipeline/StructuralTransforms/ExpressionBodiedMethodTransform.cs
+++ b/Reihitsu.Formatter/Pipeline/StructuralTransforms/ExpressionBodiedMethodTransform.cs
@@ -6,8 +6,8 @@ namespace Reihitsu.Formatter.Pipeline.StructuralTransforms;
 
 /// <summary>
 /// Converts expression-bodied methods to block body.
-/// Non-void methods wrap the expression in a <see cref="ReturnStatementSyntax"/>.
-/// Void methods wrap it in an <see cref="ExpressionStatementSyntax"/>
+/// Value-returning methods wrap the expression in a <see cref="ReturnStatementSyntax"/>.
+/// Void and non-generic async task methods wrap it in an <see cref="ExpressionStatementSyntax"/>
 /// </summary>
 internal sealed class ExpressionBodiedMethodTransform : CSharpSyntaxRewriter
 {
@@ -36,11 +36,12 @@ internal sealed class ExpressionBodiedMethodTransform : CSharpSyntaxRewriter
     #region Methods
 
     /// <summary>
-    /// Determines whether the given return type represents <see langword="void"/>
+    /// Determines whether the given member should use an expression statement when converting to a block body
     /// </summary>
     /// <param name="returnType">The return type syntax to check</param>
-    /// <returns><see langword="true"/> if the return type is <see langword="void"/>; otherwise, <see langword="false"/></returns>
-    private static bool IsVoidReturn(TypeSyntax returnType)
+    /// <param name="modifiers">The member modifiers</param>
+    /// <returns><see langword="true"/> if the converted body should use an expression statement; otherwise, <see langword="false"/></returns>
+    private static bool UsesExpressionStatement(TypeSyntax returnType, SyntaxTokenList modifiers)
     {
         if (returnType is PredefinedTypeSyntax predefined
             && predefined.Keyword.IsKind(SyntaxKind.VoidKeyword))
@@ -48,7 +49,41 @@ internal sealed class ExpressionBodiedMethodTransform : CSharpSyntaxRewriter
             return true;
         }
 
+        return HasAsyncModifier(modifiers) && IsNonGenericTaskReturnType(returnType);
+    }
+
+    /// <summary>
+    /// Determines whether the provided modifiers include <see langword="async"/>
+    /// </summary>
+    /// <param name="modifiers">The modifiers to inspect</param>
+    /// <returns><see langword="true"/> if an async modifier is present; otherwise, <see langword="false"/></returns>
+    private static bool HasAsyncModifier(SyntaxTokenList modifiers)
+    {
+        foreach (var modifier in modifiers)
+        {
+            if (modifier.IsKind(SyntaxKind.AsyncKeyword))
+            {
+                return true;
+            }
+        }
+
         return false;
+    }
+
+    /// <summary>
+    /// Determines whether the given return type represents a non-generic task
+    /// </summary>
+    /// <param name="returnType">The return type syntax to check</param>
+    /// <returns><see langword="true"/> if the return type is a non-generic task; otherwise, <see langword="false"/></returns>
+    private static bool IsNonGenericTaskReturnType(TypeSyntax returnType)
+    {
+        return returnType switch
+               {
+                   IdentifierNameSyntax identifier => identifier.Identifier.ValueText == "Task",
+                   QualifiedNameSyntax qualified => qualified.Right.Identifier.ValueText == "Task" && qualified.Right is GenericNameSyntax == false,
+                   AliasQualifiedNameSyntax aliasQualified => aliasQualified.Name.Identifier.ValueText == "Task" && aliasQualified.Name is GenericNameSyntax == false,
+                   _ => false,
+               };
     }
 
     /// <summary>
@@ -78,11 +113,11 @@ internal sealed class ExpressionBodiedMethodTransform : CSharpSyntaxRewriter
         }
 
         var expression = node.ExpressionBody.Expression;
-        var isVoid = IsVoidReturn(node.ReturnType);
+        var useExpressionStatement = UsesExpressionStatement(node.ReturnType, node.Modifiers);
 
         StatementSyntax statement;
 
-        if (isVoid)
+        if (useExpressionStatement)
         {
             statement = SyntaxFactory.ExpressionStatement(expression);
         }


### PR DESCRIPTION
## Summary
- fix structural expression-bodied rewrites so `async Task` methods and local functions are emitted without invalid `return` statements
- add focused unit coverage for methods and local functions, including a dedicated local-function transform test class and static local-function cases
- add regression coverage for method and local-function formatter behavior

## Testing
- `dotnet test Reihitsu.Formatter.Test\Reihitsu.Formatter.Test.csproj -c Release --verbosity minimal`
- `dotnet build Reihitsu.sln -c Release --verbosity minimal`

Closes #57
