### PR TITLE
Fix detached-node raw string formatting

### DIFF
--- a/Reihitsu.Formatter.Test/Unit/ReihitsuFormatterTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/ReihitsuFormatterTests.cs
@@ -2,6 +2,7 @@ using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -202,7 +203,7 @@ public class ReihitsuFormatterTests : FormatterTestsBase
 
         var tree = CSharpSyntaxTree.ParseText(input, cancellationToken: TestContext.CancellationTokenSource.Token);
         var root = tree.GetRoot(TestContext.CancellationTokenSource.Token);
-        var methodNode = root.DescendantNodes().First(n => n is Microsoft.CodeAnalysis.CSharp.Syntax.MethodDeclarationSyntax);
+        var methodNode = root.DescendantNodes().OfType<MethodDeclarationSyntax>().Single();
 
         // Act
         var result = ReihitsuFormatter.FormatNode(methodNode, cancellationToken: TestContext.CancellationTokenSource.Token);
@@ -210,6 +211,77 @@ public class ReihitsuFormatterTests : FormatterTestsBase
 
         // Assert
         Assert.AreNotEqual(methodNode.ToFullString(), actual, "FormatNode should have modified the method node.");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ReihitsuFormatter.FormatNode"/> formats documentation comments for detached/generated nodes
+    /// </summary>
+    [TestMethod]
+    public void FormatNodeWithDetachedDocumentationCommentNodeFormatsWithSynthesizedSyntaxTree()
+    {
+        // Arrange
+        const string expectedDocumentationComment = """
+                                                    /// <summary>
+                                                    /// Summary text
+                                                    /// </summary>
+                                                    """;
+        var detachedMethodNode = SyntaxFactory.MethodDeclaration(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.VoidKeyword)), SyntaxFactory.Identifier("Foo"))
+                                              .WithModifiers(SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PublicKeyword)))
+                                              .WithLeadingTrivia(SyntaxFactory.ParseLeadingTrivia(CrLf("""
+                                                                                                       /// <summary>Summary text</summary>
+                                                                                                       """)))
+                                              .WithBody(SyntaxFactory.Block());
+
+        if (detachedMethodNode.Parent != null)
+        {
+            Assert.Fail("Test setup must use a detached/generated node.");
+        }
+
+        Assert.IsNotNull(detachedMethodNode.SyntaxTree, "Detached/generated nodes should receive a synthesized syntax tree from Roslyn.");
+
+        // Act
+        var result = ReihitsuFormatter.FormatNode(detachedMethodNode, cancellationToken: TestContext.CancellationTokenSource.Token);
+        var actual = result.ToFullString();
+
+        // Assert
+        Assert.AreEqual("Foo", ((MethodDeclarationSyntax)result).Identifier.ValueText, "Detached/generated node identity should be preserved.");
+        Assert.Contains(expectedDocumentationComment, actual, "Documentation comments should be normalized for detached/generated nodes.");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ReihitsuFormatter.FormatNode"/> aligns raw strings for detached/generated nodes
+    /// </summary>
+    [TestMethod]
+    public void FormatNodeWithDetachedRawStringNodeFormatsWithSynthesizedSyntaxTree()
+    {
+        // Arrange
+        var rawStringStatement = SyntaxFactory.ParseStatement(CrLf("var text = \"\"\"\nHello\n\"\"\";"));
+        var detachedMethodNode = SyntaxFactory.MethodDeclaration(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.VoidKeyword)), SyntaxFactory.Identifier("Foo"))
+                                              .WithModifiers(SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PublicKeyword)))
+                                              .WithBody(SyntaxFactory.Block(rawStringStatement));
+
+        if (detachedMethodNode.Parent != null)
+        {
+            Assert.Fail("Test setup must use a detached/generated node.");
+        }
+
+        Assert.IsNotNull(detachedMethodNode.SyntaxTree, "Detached/generated nodes should receive a synthesized syntax tree from Roslyn.");
+
+        // Act
+        var result = ReihitsuFormatter.FormatNode(detachedMethodNode, cancellationToken: TestContext.CancellationTokenSource.Token);
+        var rawStringToken = result.DescendantNodes()
+                                   .OfType<LiteralExpressionSyntax>()
+                                   .Single()
+                                   .Token;
+        var rawStringLines = rawStringToken.Text.Split('\n');
+        var openingColumn = rawStringToken.GetLocation().GetLineSpan().StartLinePosition.Character;
+        var contentColumn = rawStringLines[1].TakeWhile(ch => ch == ' ').Count();
+        var closingColumn = rawStringLines[^1].TakeWhile(ch => ch == ' ').Count();
+
+        // Assert
+        Assert.AreEqual("Foo", ((MethodDeclarationSyntax)result).Identifier.ValueText, "Detached/generated node identity should be preserved.");
+        Assert.AreEqual(openingColumn, contentColumn, "Raw string content should align with the opening delimiter for detached/generated nodes.");
+        Assert.AreEqual(openingColumn, closingColumn, "Raw string closing delimiter should align with the opening delimiter for detached/generated nodes.");
     }
 
     /// <summary>

--- a/Reihitsu.Formatter/Pipeline/RawStringAlignment/RawStringAlignmentPhase.cs
+++ b/Reihitsu.Formatter/Pipeline/RawStringAlignment/RawStringAlignmentPhase.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Reihitsu.Formatter.Pipeline.RawStringAlignment;
 
@@ -26,21 +25,13 @@ internal static class RawStringAlignmentPhase
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var adjustments = CollectAdjustments(root, cancellationToken);
-
-        if (adjustments.Count == 0)
-        {
-            return root;
-        }
-
-        var sourceText = SourceText.From(root.ToFullString());
-        var newSourceText = sourceText.WithChanges(adjustments);
-
         var options = root.SyntaxTree.Options as CSharpParseOptions
                           ?? CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest);
+        var replacements = CollectReplacements(root, options, cancellationToken);
 
-        return CSharpSyntaxTree.ParseText(newSourceText, options, cancellationToken: cancellationToken)
-                               .GetRoot(cancellationToken);
+        return replacements.Count == 0
+                   ? root
+                   : root.ReplaceNodes(replacements.Keys, (originalNode, _) => replacements[originalNode]);
     }
 
     #endregion // Methods
@@ -48,49 +39,49 @@ internal static class RawStringAlignmentPhase
     #region Private methods
 
     /// <summary>
-    /// Collects all necessary text adjustments for misaligned raw string literals.
-    /// Skips raw strings whose spans overlap with previously collected adjustments
-    /// to handle nested raw string cases
+    /// Collects replacement nodes for misaligned raw string literals
     /// </summary>
     /// <param name="root">The syntax root to scan</param>
+    /// <param name="options">Parse options used to reparse adjusted raw strings</param>
     /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>A list of non-overlapping text changes</returns>
-    private static List<TextChange> CollectAdjustments(SyntaxNode root, CancellationToken cancellationToken)
+    /// <returns>A mapping from original nodes to adjusted replacements</returns>
+    private static Dictionary<SyntaxNode, SyntaxNode> CollectReplacements(SyntaxNode root, CSharpParseOptions options, CancellationToken cancellationToken)
     {
-        var adjustments = new List<TextChange>();
+        var replacements = new Dictionary<SyntaxNode, SyntaxNode>();
 
-        foreach (var node in root.DescendantNodes())
+        foreach (var node in root.DescendantNodesAndSelf())
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            TextChange? change = null;
+            SyntaxNode replacement = null;
 
             if (node is LiteralExpressionSyntax literal
                 && literal.Token.IsKind(SyntaxKind.MultiLineRawStringLiteralToken))
             {
-                change = ComputeNonInterpolatedChange(literal);
+                replacement = ComputeNonInterpolatedReplacement(literal, options);
             }
             else if (node is InterpolatedStringExpressionSyntax interpolated
                      && interpolated.StringStartToken.IsKind(SyntaxKind.InterpolatedMultiLineRawStringStartToken))
             {
-                change = ComputeInterpolatedChange(interpolated);
+                replacement = ComputeInterpolatedReplacement(interpolated, options);
             }
 
-            if (change != null)
+            if (replacement != null)
             {
-                adjustments.Add(change.Value);
+                replacements[node] = replacement;
             }
         }
 
-        return adjustments;
+        return replacements;
     }
 
     /// <summary>
-    /// Computes the text change for a non-interpolated multiline raw string literal
+    /// Computes the replacement for a non-interpolated multiline raw string literal
     /// </summary>
     /// <param name="literal">The literal expression containing the raw string token</param>
-    /// <returns>A text change if the raw string is misaligned; otherwise <see langword="null"/></returns>
-    private static TextChange? ComputeNonInterpolatedChange(LiteralExpressionSyntax literal)
+    /// <param name="options">Parse options used to reparse the adjusted raw string</param>
+    /// <returns>A replacement node if the raw string is misaligned; otherwise <see langword="null"/></returns>
+    private static LiteralExpressionSyntax ComputeNonInterpolatedReplacement(LiteralExpressionSyntax literal, CSharpParseOptions options)
     {
         var token = literal.Token;
         var tokenText = token.Text;
@@ -111,15 +102,16 @@ internal static class RawStringAlignmentPhase
         var delta = openingColumn - closingColumn;
         var adjustedText = AdjustContentLines(tokenText, delta);
 
-        return new TextChange(token.Span, adjustedText);
+        return (SyntaxFactory.ParseExpression(adjustedText, 0, options, true) as LiteralExpressionSyntax)?.WithTriviaFrom(literal);
     }
 
     /// <summary>
-    /// Computes the text change for an interpolated multiline raw string literal
+    /// Computes the replacement for an interpolated multiline raw string literal
     /// </summary>
     /// <param name="interpolated">The interpolated string expression</param>
-    /// <returns>A text change if the raw string is misaligned; otherwise <see langword="null"/></returns>
-    private static TextChange? ComputeInterpolatedChange(InterpolatedStringExpressionSyntax interpolated)
+    /// <param name="options">Parse options used to reparse the adjusted raw string</param>
+    /// <returns>A replacement node if the raw string is misaligned; otherwise <see langword="null"/></returns>
+    private static InterpolatedStringExpressionSyntax ComputeInterpolatedReplacement(InterpolatedStringExpressionSyntax interpolated, CSharpParseOptions options)
     {
         var startToken = interpolated.StringStartToken;
         var endToken = interpolated.StringEndToken;
@@ -137,7 +129,7 @@ internal static class RawStringAlignmentPhase
         var expressionText = interpolated.ToString();
         var adjustedText = AdjustContentLines(expressionText, delta);
 
-        return new TextChange(interpolated.Span, adjustedText);
+        return (SyntaxFactory.ParseExpression(adjustedText, 0, options, true) as InterpolatedStringExpressionSyntax)?.WithTriviaFrom(interpolated);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- fix detached-node raw string alignment in `ReihitsuFormatter.FormatNode(...)` by replacing raw-string nodes in place instead of reparsing the entire detached node as a full syntax tree
- add regression coverage for detached/generated nodes with synthesized Roslyn syntax trees, including documentation comments and raw strings

## Why

Detached/generated `SyntaxNode` instances still get a synthesized `SyntaxTree` from Roslyn, so the bug was not a null `SyntaxTree`. The actual unsafe behavior was reparsing a detached non-root node as a full syntax tree during raw-string alignment, which can lose the original node shape and context.

## Linked issues

Closes #58

## Review notes

- the fix is intentionally scoped to raw-string alignment, which was the detached-node-sensitive phase in this branch
- the new detached-node tests assert Roslyn's synthesized-tree behavior so the contract is documented in executable form

## Follow-up work

None
