### PR TITLE
Fix RH0101 private auto-property code fix semantics

### DIFF
--- a/Reihitsu.Analyzer.CodeFixes/Rules/Design/RH0101PrivateAutoPropertiesShouldNotBeUsedCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Design/RH0101PrivateAutoPropertiesShouldNotBeUsedCodeFixProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Immutable;
 using System.Composition;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,6 +12,9 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Rename;
 using Microsoft.CodeAnalysis.Text;
+
+using Reihitsu.Analyzer.Core;
+using Reihitsu.Formatter;
 
 namespace Reihitsu.Analyzer.Rules.Design;
 
@@ -30,8 +34,13 @@ public class RH0101PrivateAutoPropertiesShouldNotBeUsedCodeFixProvider : CodeFix
     /// <param name="node">Node with diagnostics</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
-    private async Task<Solution> ApplyCodeFixAsync(Document document, PropertyDeclarationSyntax node, CancellationToken cancellationToken)
+    private static async Task<Solution> ApplyCodeFixAsync(Document document, PropertyDeclarationSyntax node, CancellationToken cancellationToken)
     {
+        if (TryCreateFieldDeclaration(node, out _) == false)
+        {
+            return document.Project.Solution;
+        }
+
         var solution = document.Project.Solution;
         var location = node.GetLocation().SourceSpan;
 
@@ -58,18 +67,18 @@ public class RH0101PrivateAutoPropertiesShouldNotBeUsedCodeFixProvider : CodeFix
             {
                 node = syntaxRoot.FindNode(location) as PropertyDeclarationSyntax;
 
-                if (node != null)
+                if (node != null
+                    && TryCreateFieldDeclaration(node, out var fieldDeclaration))
                 {
-                    var variableDeclaration = SyntaxFactory.VariableDeclaration(node.Type)
-                                                           .AddVariables(SyntaxFactory.VariableDeclarator(fieldName));
+                    var formattingAnnotation = new SyntaxAnnotation();
+                    var updatedFieldDeclaration = fieldDeclaration.WithAdditionalAnnotations(formattingAnnotation);
+                    var updatedDocument = document.WithSyntaxRoot(syntaxRoot.ReplaceNode(node, updatedFieldDeclaration));
+                    var formattedRoot = await updatedDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+                    var formattedFieldDeclaration = formattedRoot?.GetAnnotatedNodes(formattingAnnotation).OfType<FieldDeclarationSyntax>().FirstOrDefault();
 
-                    var fieldDeclaration = SyntaxFactory.FieldDeclaration(variableDeclaration)
-                                                        .AddModifiers(SyntaxFactory.Token(SyntaxKind.PrivateKeyword))
-                                                        .WithLeadingTrivia(node.GetLeadingTrivia())
-                                                        .WithTrailingTrivia(node.GetTrailingTrivia());
-
-                    syntaxRoot = syntaxRoot.ReplaceNode(node, fieldDeclaration);
-                    solution = solution.WithDocumentSyntaxRoot(document.Id, syntaxRoot);
+                    solution = formattedFieldDeclaration == null
+                                   ? updatedDocument.Project.Solution
+                                   : (await ReihitsuFormatter.FormatNodeInDocumentAsync(updatedDocument, formattedFieldDeclaration, cancellationToken).ConfigureAwait(false)).Project.Solution;
                 }
             }
         }
@@ -83,9 +92,60 @@ public class RH0101PrivateAutoPropertiesShouldNotBeUsedCodeFixProvider : CodeFix
     /// <param name="node">Property node</param>
     /// <param name="fieldName">Field name</param>
     /// <returns>Is the name changed?</returns>
-    private bool GetFieldName(PropertyDeclarationSyntax node, out string fieldName)
+    private static bool GetFieldName(PropertyDeclarationSyntax node, out string fieldName)
+    {
+        fieldName = GetFieldName(node);
+
+        return fieldName != node.Identifier.ValueText;
+    }
+
+    /// <summary>
+    /// Tries to create a field declaration that preserves the supported property semantics
+    /// </summary>
+    /// <param name="node">Property declaration</param>
+    /// <param name="fieldDeclaration">Field declaration</param>
+    /// <returns><see langword="true"/> if the property shape is safe to convert</returns>
+    private static bool TryCreateFieldDeclaration(PropertyDeclarationSyntax node, out FieldDeclarationSyntax fieldDeclaration)
+    {
+        fieldDeclaration = null;
+
+        if (IsSupportedPropertyShape(node) == false)
+        {
+            return false;
+        }
+
+        var fieldName = GetFieldName(node);
+        var modifiers = node.Modifiers;
+
+        if (IsGetOnlyProperty(node))
+        {
+            modifiers = ModifierOrderingUtilities.OrderModifiersForRh0604(modifiers.Add(SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword)));
+        }
+
+        fieldDeclaration = SyntaxFactory.FieldDeclaration(SyntaxFactory.VariableDeclaration(node.Type)
+                                                                       .AddVariables(SyntaxFactory.VariableDeclarator(fieldName)
+                                                                                                  .WithInitializer(node.Initializer)))
+                                        .WithAttributeLists(node.AttributeLists)
+                                        .WithModifiers(modifiers)
+                                        .WithLeadingTrivia(node.GetLeadingTrivia())
+                                        .WithTrailingTrivia(node.GetTrailingTrivia());
+
+        return true;
+    }
+
+    /// <summary>
+    /// Gets the field name for a property declaration
+    /// </summary>
+    /// <param name="node">Property declaration</param>
+    /// <returns>Field name</returns>
+    private static string GetFieldName(PropertyDeclarationSyntax node)
     {
         var propertyName = node.Identifier.ValueText.TrimStart('_');
+
+        if (string.IsNullOrEmpty(propertyName))
+        {
+            return node.Identifier.ValueText;
+        }
 
         var builder = new StringBuilder(propertyName.Length + 1);
 
@@ -97,9 +157,76 @@ public class RH0101PrivateAutoPropertiesShouldNotBeUsedCodeFixProvider : CodeFix
             builder.Append(propertyName.Substring(1));
         }
 
-        fieldName = builder.ToString();
+        return builder.ToString();
+    }
 
-        return fieldName != node.Identifier.ValueText;
+    /// <summary>
+    /// Checks whether the property shape is safe to convert automatically
+    /// </summary>
+    /// <param name="node">Property declaration</param>
+    /// <returns><see langword="true"/> if the fixer can safely convert the property</returns>
+    private static bool IsSupportedPropertyShape(PropertyDeclarationSyntax node)
+    {
+        if (node.AttributeLists.Count > 0 || node.AccessorList == null || node.ExpressionBody != null)
+        {
+            return false;
+        }
+
+        var hasGetter = false;
+        var hasSetter = false;
+
+        foreach (var accessor in node.AccessorList.Accessors)
+        {
+            if (accessor.AttributeLists.Count > 0
+                || accessor.Modifiers.Count > 0
+                || accessor.Body != null
+                || accessor.ExpressionBody != null)
+            {
+                return false;
+            }
+
+            switch (accessor.Kind())
+            {
+                case SyntaxKind.GetAccessorDeclaration:
+                    {
+                        if (hasGetter)
+                        {
+                            return false;
+                        }
+
+                        hasGetter = true;
+                    }
+                    break;
+
+                case SyntaxKind.SetAccessorDeclaration:
+                    {
+                        if (hasSetter)
+                        {
+                            return false;
+                        }
+
+                        hasSetter = true;
+                    }
+                    break;
+
+                default:
+                    {
+                        return false;
+                    }
+            }
+        }
+
+        return hasGetter;
+    }
+
+    /// <summary>
+    /// Checks whether the property only exposes a getter
+    /// </summary>
+    /// <param name="node">Property declaration</param>
+    /// <returns><see langword="true"/> if the property is get-only</returns>
+    private static bool IsGetOnlyProperty(PropertyDeclarationSyntax node)
+    {
+        return node.AccessorList?.Accessors.Count == 1 && node.AccessorList.Accessors[0].IsKind(SyntaxKind.GetAccessorDeclaration);
     }
 
     #endregion // Methods
@@ -124,7 +251,7 @@ public class RH0101PrivateAutoPropertiesShouldNotBeUsedCodeFixProvider : CodeFix
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (root.FindNode(diagnostic.Location.SourceSpan) is PropertyDeclarationSyntax node)
+                if (root.FindNode(diagnostic.Location.SourceSpan) is PropertyDeclarationSyntax node && IsSupportedPropertyShape(node))
                 {
                     context.RegisterCodeFix(CodeAction.Create(CodeFixResources.RH0101Title,
                                                               c => ApplyCodeFixAsync(context.Document, node, c),

--- a/Reihitsu.Analyzer.Test/Design/RH0101PrivateAutoPropertiesShouldNotBeUsedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Design/RH0101PrivateAutoPropertiesShouldNotBeUsedAnalyzerTests.cs
@@ -1,5 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
 
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Reihitsu.Analyzer.Rules.Design;
@@ -16,73 +18,152 @@ public class RH0101PrivateAutoPropertiesShouldNotBeUsedAnalyzerTests : AnalyzerT
     #region Members
 
     /// <summary>
-    /// Verifying that private auto property triggers diagnostic and is converted to private field
+    /// Verifies that a private auto-property is reported and converted to a backing field
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
     [TestMethod]
     public async Task VerifyPrivateAutoPropertyDiagnostic()
     {
         const string testData = """
-                                using System;
-                                using System.Collections.Generic;
-                                using System.Text;
-
                                 namespace Reihitsu.Analyzer.Test.Design.Resources
                                 {
                                     internal class RH0101
                                     {
-                                        private bool _field;
-
                                         private bool {|#0:PrivateAutoProperty|} { get; set; }
-                                
-                                        protected bool ProtectedAutoProperty { get; set; }
-
-                                        internal bool InternalAutoProperty { get; set; }
-
-                                        public bool PublicAutoProperty { get; set; }
-
-                                        private bool PrivateProperty { get => _field; set => _field = value; }
-
-                                        protected bool ProtectedProperty { get => _field; set => _field = value; }
-
-                                        internal bool InternalProperty { get => _field; set => _field = value; }
-
-                                        public bool PublicProperty { get => _field; set => _field = value; }
                                     }
                                 }
                                 """;
 
         const string resultData = """
-                                  using System;
-                                  using System.Collections.Generic;
-                                  using System.Text;
-
                                   namespace Reihitsu.Analyzer.Test.Design.Resources
                                   {
                                       internal class RH0101
                                       {
-                                          private bool _field;
-
                                           private bool _privateAutoProperty;
-
-                                          protected bool ProtectedAutoProperty { get; set; }
-
-                                          internal bool InternalAutoProperty { get; set; }
-
-                                          public bool PublicAutoProperty { get; set; }
-
-                                          private bool PrivateProperty { get => _field; set => _field = value; }
-
-                                          protected bool ProtectedProperty { get => _field; set => _field = value; }
-
-                                          internal bool InternalProperty { get => _field; set => _field = value; }
-
-                                          public bool PublicProperty { get => _field; set => _field = value; }
                                       }
                                   }
                                   """;
 
         await Verify(testData, resultData, Diagnostics(RH0101PrivateAutoPropertiesShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH0101MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that modifiers and initializers are preserved for supported property shapes
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyPrivateStaticAutoPropertyCodeFixPreservesModifiersAndInitializer()
+    {
+        const string testData = """
+                                namespace Reihitsu.Analyzer.Test.Design.Resources
+                                {
+                                    internal class RH0101
+                                    {
+                                        private static string {|#0:CacheKey|} { get; set; } = "cached";
+                                    }
+                                }
+                                """;
+
+        const string resultData = """
+                                  namespace Reihitsu.Analyzer.Test.Design.Resources
+                                  {
+                                      internal class RH0101
+                                      {
+                                          private static string _cacheKey = "cached";
+                                      }
+                                  }
+                                  """;
+
+        await Verify(testData, resultData, Diagnostics(RH0101PrivateAutoPropertiesShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH0101MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that get-only auto-properties are converted to readonly fields
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyPrivateGetOnlyAutoPropertyCodeFixCreatesReadonlyField()
+    {
+        const string testData = """
+                                namespace Reihitsu.Analyzer.Test.Design.Resources
+                                {
+                                    internal class RH0101
+                                    {
+                                        private int {|#0:Count|} { get; } = 1;
+                                    }
+                                }
+                                """;
+
+        const string resultData = """
+                                  namespace Reihitsu.Analyzer.Test.Design.Resources
+                                  {
+                                      internal class RH0101
+                                      {
+                                          private readonly int _count = 1;
+                                      }
+                                  }
+                                  """;
+
+        await Verify(testData, resultData, Diagnostics(RH0101PrivateAutoPropertiesShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH0101MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that attributed private auto-properties do not receive an unsafe code fix
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task NoCodeFixForAttributedPrivateAutoProperty()
+    {
+        const string testData = """
+                                using System;
+
+                                namespace Reihitsu.Analyzer.Test.Design.Resources
+                                {
+                                    internal class RH0101
+                                    {
+                                        [Obsolete]
+                                        private int Value { get; set; }
+                                    }
+                                }
+                                """;
+
+        var actions = await GetCodeFixActionsAsync(testData,
+                                                   RH0101PrivateAutoPropertiesShouldNotBeUsedAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<PropertyDeclarationSyntax>()
+                                                               .Single()
+                                                               .Identifier
+                                                               .GetLocation());
+
+        Assert.IsEmpty(actions);
+    }
+
+    /// <summary>
+    /// Verifies that init-only auto-properties do not receive an unsafe code fix
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task NoCodeFixForInitOnlyPrivateAutoProperty()
+    {
+        const string testData = """
+                                namespace Reihitsu.Analyzer.Test.Design.Resources
+                                {
+                                    internal class RH0101
+                                    {
+                                        private int Value { get; init; }
+                                    }
+                                }
+                                """;
+
+        var actions = await GetCodeFixActionsAsync(testData,
+                                                   RH0101PrivateAutoPropertiesShouldNotBeUsedAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<PropertyDeclarationSyntax>()
+                                                               .Single()
+                                                               .Identifier
+                                                               .GetLocation());
+
+        Assert.IsEmpty(actions);
     }
 
     #endregion // Members

--- a/documentation/rules/RH0101.md
+++ b/documentation/rules/RH0101.md
@@ -19,6 +19,8 @@ Private auto-properties offer no benefit over plain fields and add unnecessary s
 
 Replace the private auto-implemented property with a private field.
 
+The automatic code fix is only offered for property shapes that can be converted safely without changing semantics. Properties that use attributes or `init` accessors must be updated manually.
+
 ## Examples
 
 ### Violation


### PR DESCRIPTION
## Summary

- narrow the RH0101 code fix to property shapes that can be converted safely
- preserve supported modifiers and initializers when converting private auto-properties to fields
- map private get-only auto-properties to `readonly` fields and add regression coverage

## Why

The existing RH0101 fixer could silently change semantics by dropping details such as modifiers, initializers, and effective immutability. This change makes the fixer conservative for unsupported shapes and semantics-preserving for supported ones.

## Linked issues

Closes #59

## Review notes

- the fixer is now withheld for attributed properties and `init` accessors instead of applying an unsafe transformation
- tests cover supported conversions and explicitly rejected shapes

## Follow-up work

None
