### PR TITLE
Disable unsafe tuple-element casing code fixes

### DIFF
--- a/Reihitsu.Analyzer.CodeFixes/Rules/Naming/CasingCodeFixProviderBase{T}.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Naming/CasingCodeFixProviderBase{T}.cs
@@ -71,6 +71,16 @@ public abstract class CasingCodeFixProviderBase<T> : CodeFixProvider
     protected abstract string GetIdentifier(T node);
 
     /// <summary>
+    /// Determines whether a code fix can be safely registered for the specified node
+    /// </summary>
+    /// <param name="node">Node</param>
+    /// <returns><see langword="true"/> if the code fix can be safely registered; otherwise, <see langword="false"/></returns>
+    protected virtual bool CanRegisterCodeFix(T node)
+    {
+        return true;
+    }
+
+    /// <summary>
     /// Applying the code fix
     /// </summary>
     /// <param name="document">Document</param>
@@ -149,7 +159,8 @@ public abstract class CasingCodeFixProviderBase<T> : CodeFixProvider
             {
                 var diagnosticSpan = diagnostic.Location.SourceSpan;
 
-                if (root.FindNode(diagnosticSpan) is T node)
+                if (root.FindNode(diagnosticSpan) is T node
+                    && CanRegisterCodeFix(node))
                 {
                     context.RegisterCodeFix(CodeAction.Create(_title,
                                                               c => ApplyCodeFixAsync(context.Document, node, c),

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Naming/RH0222TupleElementCasingCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Naming/RH0222TupleElementCasingCodeFixProvider.cs
@@ -37,6 +37,12 @@ public class RH0222TupleElementCasingCodeFixProvider : CasingCodeFixProviderBase
     }
 
     /// <inheritdoc/>
+    protected override bool CanRegisterCodeFix(TupleElementSyntax node)
+    {
+        return false;
+    }
+
+    /// <inheritdoc/>
     protected override SyntaxNode ReplaceIdentifier(TupleElementSyntax node, string identifier)
     {
         return node.WithIdentifier(SyntaxFactory.Identifier(identifier));

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Naming/RH0224TupleElementCasingCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Naming/RH0224TupleElementCasingCodeFixProvider.cs
@@ -37,6 +37,12 @@ public class RH0224TupleElementCasingCodeFixProvider : CasingCodeFixProviderBase
     }
 
     /// <inheritdoc/>
+    protected override bool CanRegisterCodeFix(IdentifierNameSyntax node)
+    {
+        return false;
+    }
+
+    /// <inheritdoc/>
     protected override SyntaxNode ReplaceIdentifier(IdentifierNameSyntax node, string identifier)
     {
         return node.WithIdentifier(SyntaxFactory.Identifier(identifier));

--- a/Reihitsu.Analyzer.Test/Naming/RH0222TupleElementCasingAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Naming/RH0222TupleElementCasingAnalyzerTests.cs
@@ -1,5 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
 
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Reihitsu.Analyzer.Rules.Naming;
@@ -35,20 +37,45 @@ public class RH0222TupleElementCasingAnalyzerTests : AnalyzerTestsBase<RH0222Tup
                                 }
                                 """;
 
-        const string fixedCode = """
-                                 namespace Reihitsu.Analyzer.Test.Naming.Resources
-                                 {
-                                     public class DataLoader
-                                     {
-                                         public (int FirstValue, int SecondValue) Load()
-                                         {
-                                             return default;
-                                         }
-                                     }
-                                 }
-                                 """;
+        await Verify(testCode, Diagnostics(RH0222TupleElementCasingAnalyzer.DiagnosticId, AnalyzerResources.RH0222MessageFormat));
+    }
 
-        await Verify(testCode, fixedCode, Diagnostics(RH0222TupleElementCasingAnalyzer.DiagnosticId, AnalyzerResources.RH0222MessageFormat));
+    /// <summary>
+    /// Verifies no code fix is offered for tuple type elements when usage sites would become stale
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task NoCodeFixForTupleTypeElementWithMultipleUsageSites()
+    {
+        const string testCode = """
+                                namespace Reihitsu.Analyzer.Test.Naming.Resources
+                                {
+                                    public class DataLoader
+                                    {
+                                        public (int firstValue, int SecondValue) Load()
+                                        {
+                                            return (1, 2);
+                                        }
+
+                                        public int Sum()
+                                        {
+                                            var values = Load();
+
+                                            return values.firstValue + Load().firstValue;
+                                        }
+                                    }
+                                }
+                                """;
+
+        var actions = await GetCodeFixActionsAsync(testCode,
+                                                   RH0222TupleElementCasingAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<TupleElementSyntax>()
+                                                               .Single(element => element.Identifier.ValueText == "firstValue")
+                                                               .Identifier
+                                                               .GetLocation());
+
+        Assert.IsEmpty(actions);
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer.Test/Naming/RH0224TupleElementCasingAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Naming/RH0224TupleElementCasingAnalyzerTests.cs
@@ -1,5 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
 
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Reihitsu.Analyzer.Rules.Naming;
@@ -35,20 +37,41 @@ public class RH0224TupleElementCasingAnalyzerTests : AnalyzerTestsBase<RH0224Tup
                                 }
                                 """;
 
-        const string fixedCode = """
-                                 namespace Reihitsu.Analyzer.Test.Naming.Resources
-                                 {
-                                     public class DataLoader
-                                     {
-                                         public (int FirstValue, int SecondValue) Load()
-                                         {
-                                             return (FirstValue: 1, SecondValue: 2);
-                                         }
-                                     }
-                                 }
-                                 """;
+        await Verify(testCode, Diagnostics(RH0224TupleElementCasingAnalyzer.DiagnosticId, AnalyzerResources.RH0224MessageFormat));
+    }
 
-        await Verify(testCode, fixedCode, Diagnostics(RH0224TupleElementCasingAnalyzer.DiagnosticId, AnalyzerResources.RH0224MessageFormat));
+    /// <summary>
+    /// Verifies no code fix is offered for tuple expression names when usage sites would become stale
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task NoCodeFixForTupleExpressionElementWithMultipleUsageSites()
+    {
+        const string testCode = """
+                                namespace Reihitsu.Analyzer.Test.Naming.Resources
+                                {
+                                    public class DataLoader
+                                    {
+                                        public int Sum()
+                                        {
+                                            var values = (firstValue: 1, SecondValue: 2);
+
+                                            return values.firstValue + values.firstValue;
+                                        }
+                                    }
+                                }
+                                """;
+
+        var actions = await GetCodeFixActionsAsync(testCode,
+                                                   RH0224TupleElementCasingAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<IdentifierNameSyntax>()
+                                                               .Single(identifier => identifier.Identifier.ValueText == "firstValue"
+                                                                                     && identifier.Parent is NameColonSyntax)
+                                                               .Identifier
+                                                               .GetLocation());
+
+        Assert.IsEmpty(actions);
     }
 
     /// <summary>

--- a/documentation/rules/RH0222.md
+++ b/documentation/rules/RH0222.md
@@ -5,7 +5,7 @@
 | **ID**       | RH0222       |
 | **Category** | Naming       |
 | **Severity** | Warning      |
-| **Code Fix** | ✓            |
+| **Code Fix** | ✗            |
 
 ## Description
 

--- a/documentation/rules/RH0224.md
+++ b/documentation/rules/RH0224.md
@@ -5,7 +5,7 @@
 | **ID**       | RH0224       |
 | **Category** | Naming       |
 | **Severity** | Warning      |
-| **Code Fix** | ✓            |
+| **Code Fix** | ✗            |
 
 ## Description
 


### PR DESCRIPTION
## Summary

Disable the unsafe tuple-element naming code fixes for RH0222 and RH0224.
Add regression coverage that verifies no fix is offered when tuple element usages would be left stale, and update the rule docs to reflect the manual-rename guidance.

## Why

The tuple-element casing fixers could fall back to a local syntax replacement instead of a reference-safe rename.
That could rename the declaration without updating tuple member usages, so removing the fix is safer than shipping a broken autofix.

## Linked issues

Closes #61

## Review notes

The shared casing code-fix base now supports opting out of registration.
Both tuple-specific code-fix providers opt out, so the analyzers still report diagnostics but no code action is offered for these tuple-element cases.

## Follow-up work

None
