### PR TITLE
Harden reihitsu.json parsing against invalid configuration

### DIFF
--- a/Reihitsu.Analyzer.Test/Naming/RH0227NamespaceNotAllowedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Naming/RH0227NamespaceNotAllowedAnalyzerTests.cs
@@ -112,5 +112,28 @@ public class RH0227NamespaceNotAllowedAnalyzerTests : AnalyzerTestsBase<RH0227Na
                      });
     }
 
+    /// <summary>
+    /// Invalid configuration json
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task InvalidConfiguration()
+    {
+        await Verify(TestCode,
+                     test =>
+                     {
+                         const string configuration = """
+                                                      {
+                                                         "Naming":{
+                                                            "AllowedNamespaceDeclarations":[
+                                                               "TestNameSpace"
+                                                         }
+                                                      }
+                                                      """;
+
+                         test.TestState.AdditionalFiles.Add(("reihitsu.json", configuration));
+                     });
+    }
+
     #endregion // Methods
 }

--- a/Reihitsu.Analyzer/Data/ConfigurationManager.cs
+++ b/Reihitsu.Analyzer/Data/ConfigurationManager.cs
@@ -24,15 +24,23 @@ internal static class ConfigurationManager
 
         var file = additionalFiles.FirstOrDefault(file => file.Path.EndsWith("reihitsu.json"));
 
-        if (file != null)
+        if (file == null)
         {
-            var text = file.GetText()?.ToString();
+            return false;
+        }
 
-            if (string.IsNullOrWhiteSpace(text) == false)
+        var text = file.GetText()?.ToString();
+
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return false;
+        }
+
+        try
+        {
+            using (var jsonDocument = JsonDocument.Parse(text))
             {
                 configuration = new Configuration();
-
-                var jsonDocument = JsonDocument.Parse(text);
 
                 if (jsonDocument.RootElement.TryGetProperty(nameof(Configuration.Naming), out var namingElement))
                 {
@@ -50,6 +58,10 @@ internal static class ConfigurationManager
 
                 return true;
             }
+        }
+        catch (JsonException)
+        {
+            configuration = null;
         }
 
         return false;


### PR DESCRIPTION
## Summary

- Catch invalid `reihitsu.json` content and treat it as no usable configuration.
- Dispose the parsed `JsonDocument` in the configuration loader.
- Add a regression test covering malformed configuration for `RH0227`.

## Why

Invalid JSON in `reihitsu.json` currently throws during analyzer startup and leaves the parsed document undisposed. This change makes configuration loading fail closed and keeps analyzer execution predictable.

## Linked issues

Closes #63

## Review notes

The fallback behavior for malformed configuration is the same as if no usable configuration file were present, so `RH0227` simply does not register when the config cannot be parsed.

## Follow-up work

None
