### PR TITLE
Upgrade Roslyn-related package versions to 5.3.0

### DIFF
--- a/Reihitsu.Analyzer.CodeFixes/Reihitsu.Analyzer.CodeFixes.csproj
+++ b/Reihitsu.Analyzer.CodeFixes/Reihitsu.Analyzer.CodeFixes.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Reihitsu.Analyzer.Test/Reihitsu.Analyzer.Test.csproj
+++ b/Reihitsu.Analyzer.Test/Reihitsu.Analyzer.Test.csproj
@@ -8,13 +8,13 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="4.2.2" />
     <PackageReference Include="MSTest.TestFramework" Version="4.2.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.14.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" Version="1.1.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing" Version="1.1.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing" Version="1.1.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.3" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.3" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" Version="1.1.3" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing" Version="1.1.3" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing" Version="1.1.3" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing" Version="1.1.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Reihitsu.Analyzer.CodeFixes\Reihitsu.Analyzer.CodeFixes.csproj" />

--- a/Reihitsu.Analyzer/Reihitsu.Analyzer.csproj
+++ b/Reihitsu.Analyzer/Reihitsu.Analyzer.csproj
@@ -11,12 +11,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.6" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageReference Include="System.Text.Json" Version="10.0.7" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/Reihitsu.Cli.Test/Reihitsu.Cli.Test.csproj
+++ b/Reihitsu.Cli.Test/Reihitsu.Cli.Test.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="4.2.2" />
     <PackageReference Include="MSTest.TestFramework" Version="4.2.2" />
     <PackageReference Include="NSubstitute" Version="5.*" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Reihitsu.Formatter.Test/Reihitsu.Formatter.Test.csproj
+++ b/Reihitsu.Formatter.Test/Reihitsu.Formatter.Test.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="4.2.2" />
     <PackageReference Include="MSTest.TestFramework" Version="4.2.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Reihitsu.Formatter/Reihitsu.Formatter.csproj
+++ b/Reihitsu.Formatter/Reihitsu.Formatter.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Upgrade Roslyn-related NuGet dependencies across analyzer, formatter, and test projects to the latest major versions currently targeted in this repository.

## Why

Keeping these packages aligned reduces version drift between runtime and test surfaces, and ensures the solution uses a consistent Roslyn toolchain.

## Linked issues

None.

## Review notes

- `Microsoft.CodeAnalysis*` package references were updated from `4.14.0` to `5.3.0` where applicable.
- Roslyn testing packages in `Reihitsu.Analyzer.Test` were updated from `1.1.2` to `1.1.3`.
- `System.Text.Json` in `Reihitsu.Analyzer` was updated from `8.0.6` to `10.0.7`.

## Follow-up work

None.
