### PR TITLE
Add permissions section to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration by explicitly setting the permissions for the workflow to have read-only access to repository contents.