### PR TITLE
Refactor DocumentationAnalysisUtilities for clarity

### DIFF
--- a/Reihitsu.Analyzer/Core/DirectDocumentationSyntaxChecker.cs
+++ b/Reihitsu.Analyzer/Core/DirectDocumentationSyntaxChecker.cs
@@ -1,0 +1,81 @@
+using System.Collections.Immutable;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Reihitsu.Analyzer.Core;
+
+/// <summary>
+/// Performs direct XML documentation syntax inspection without semantic expansion
+/// </summary>
+internal static class DirectDocumentationSyntaxChecker
+{
+    #region Methods
+
+    /// <summary>
+    /// Gets the XML documentation comment for the declaration
+    /// </summary>
+    /// <param name="declaration">Declaration</param>
+    /// <returns>The documentation comment, when present</returns>
+    internal static DocumentationCommentTriviaSyntax GetDocumentationComment(SyntaxNode declaration)
+    {
+        return declaration.GetLeadingTrivia()
+                          .Select(obj => obj.GetStructure())
+                          .OfType<DocumentationCommentTriviaSyntax>()
+                          .FirstOrDefault();
+    }
+
+    /// <summary>
+    /// Gets the first direct XML node with the specified tag name
+    /// </summary>
+    /// <param name="documentationComment">Documentation comment</param>
+    /// <param name="tagName">Tag name</param>
+    /// <returns>The matching node, when present</returns>
+    internal static XmlNodeSyntax GetFirstDirectTag(DocumentationCommentTriviaSyntax documentationComment, string tagName)
+    {
+        return GetDirectTags(documentationComment, tagName).FirstOrDefault();
+    }
+
+    /// <summary>
+    /// Gets all direct XML nodes with the specified tag name
+    /// </summary>
+    /// <param name="documentationComment">Documentation comment</param>
+    /// <param name="tagName">Tag name</param>
+    /// <returns>Matching nodes</returns>
+    internal static ImmutableArray<XmlNodeSyntax> GetDirectTags(DocumentationCommentTriviaSyntax documentationComment, string tagName)
+    {
+        if (documentationComment == null)
+        {
+            return [];
+        }
+
+        var directNodes = documentationComment.Content
+                                              .Where(obj => obj is XmlElementSyntax or XmlEmptyElementSyntax)
+                                              .Where(obj => string.Equals(DocumentationAnalysisUtilities.GetTagName(obj), tagName, StringComparison.OrdinalIgnoreCase))
+                                              .ToImmutableArray();
+
+        if (directNodes.Length > 0)
+        {
+            return directNodes;
+        }
+
+        return documentationComment.DescendantNodes()
+                                   .Where(obj => obj is XmlElementSyntax or XmlEmptyElementSyntax)
+                                   .Cast<XmlNodeSyntax>()
+                                   .Where(obj => string.Equals(DocumentationAnalysisUtilities.GetTagName(obj), tagName, StringComparison.OrdinalIgnoreCase))
+                                   .ToImmutableArray();
+    }
+
+    /// <summary>
+    /// Determines whether the documentation contains a direct tag
+    /// </summary>
+    /// <param name="documentationComment">Documentation comment</param>
+    /// <param name="tagName">Tag name</param>
+    /// <returns><see langword="true"/> if the tag exists</returns>
+    internal static bool HasDirectTag(DocumentationCommentTriviaSyntax documentationComment, string tagName)
+    {
+        return GetDirectTags(documentationComment, tagName).Length > 0;
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Analyzer/Core/DocumentationAnalysisUtilities.cs
+++ b/Reihitsu.Analyzer/Core/DocumentationAnalysisUtilities.cs
@@ -1,6 +1,5 @@
 using System.Collections.Immutable;
 using System.Threading;
-using System.Xml;
 using System.Xml.Linq;
 
 using Microsoft.CodeAnalysis;
@@ -126,60 +125,6 @@ internal static class DocumentationAnalysisUtilities
     }
 
     /// <summary>
-    /// Gets the XML documentation comment for the declaration
-    /// </summary>
-    /// <param name="declaration">Declaration</param>
-    /// <returns>The documentation comment, when present</returns>
-    internal static DocumentationCommentTriviaSyntax GetDocumentationComment(SyntaxNode declaration)
-    {
-        return declaration.GetLeadingTrivia()
-                          .Select(obj => obj.GetStructure())
-                          .OfType<DocumentationCommentTriviaSyntax>()
-                          .FirstOrDefault();
-    }
-
-    /// <summary>
-    /// Gets the first direct XML node with the specified tag name
-    /// </summary>
-    /// <param name="documentationComment">Documentation comment</param>
-    /// <param name="tagName">Tag name</param>
-    /// <returns>The matching node, when present</returns>
-    internal static XmlNodeSyntax GetFirstDirectTag(DocumentationCommentTriviaSyntax documentationComment, string tagName)
-    {
-        return GetDirectTags(documentationComment, tagName).FirstOrDefault();
-    }
-
-    /// <summary>
-    /// Gets all direct XML nodes with the specified tag name
-    /// </summary>
-    /// <param name="documentationComment">Documentation comment</param>
-    /// <param name="tagName">Tag name</param>
-    /// <returns>Matching nodes</returns>
-    internal static ImmutableArray<XmlNodeSyntax> GetDirectTags(DocumentationCommentTriviaSyntax documentationComment, string tagName)
-    {
-        if (documentationComment == null)
-        {
-            return [];
-        }
-
-        var directNodes = documentationComment.Content
-                                              .Where(obj => obj is XmlElementSyntax or XmlEmptyElementSyntax)
-                                              .Where(obj => string.Equals(GetTagName(obj), tagName, StringComparison.OrdinalIgnoreCase))
-                                              .ToImmutableArray();
-
-        if (directNodes.Length > 0)
-        {
-            return directNodes;
-        }
-
-        return documentationComment.DescendantNodes()
-                                   .Where(obj => obj is XmlElementSyntax or XmlEmptyElementSyntax)
-                                   .Cast<XmlNodeSyntax>()
-                                   .Where(obj => string.Equals(GetTagName(obj), tagName, StringComparison.OrdinalIgnoreCase))
-                                   .ToImmutableArray();
-    }
-
-    /// <summary>
     /// Determines whether the XML node is empty
     /// </summary>
     /// <param name="node">XML node</param>
@@ -192,75 +137,6 @@ internal static class DocumentationAnalysisUtilities
                    XmlElementSyntax element => element.Content.Any(HasMeaningfulContent) == false,
                    _ => true
                };
-    }
-
-    /// <summary>
-    /// Parses the expanded documentation XML for the declaration
-    /// </summary>
-    /// <param name="declaration">Declaration</param>
-    /// <param name="semanticModel">Semantic model</param>
-    /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>The expanded XML documentation root, when available</returns>
-    internal static XElement GetExpandedDocumentation(MemberDeclarationSyntax declaration, SemanticModel semanticModel, CancellationToken cancellationToken)
-    {
-        var declaredSymbol = GetDeclaredSymbol(declaration, semanticModel, cancellationToken);
-        var rawDocumentation = declaredSymbol?.GetDocumentationCommentXml(expandIncludes: true, cancellationToken: cancellationToken);
-
-        if (string.IsNullOrWhiteSpace(rawDocumentation))
-        {
-            return null;
-        }
-
-        try
-        {
-            return XElement.Parse(rawDocumentation);
-        }
-        catch (XmlException)
-        {
-            return null;
-        }
-    }
-
-    /// <summary>
-    /// Determines whether the documentation contains a tag, considering expanded include XML
-    /// </summary>
-    /// <param name="documentationComment">Documentation comment</param>
-    /// <param name="expandedDocumentation">Expanded documentation</param>
-    /// <param name="tagName">Tag name</param>
-    /// <returns><see langword="true"/> if the tag exists</returns>
-    internal static bool HasTag(DocumentationCommentTriviaSyntax documentationComment, XElement expandedDocumentation, string tagName)
-    {
-        if (HasDirectTag(documentationComment, tagName))
-        {
-            return true;
-        }
-
-        return expandedDocumentation?.Elements().Any(obj => string.Equals(obj.Name.LocalName, tagName, StringComparison.OrdinalIgnoreCase)) == true;
-    }
-
-    /// <summary>
-    /// Gets the first expanded XML element for a tag name
-    /// </summary>
-    /// <param name="expandedDocumentation">Expanded documentation</param>
-    /// <param name="tagName">Tag name</param>
-    /// <returns>The first matching element, when present</returns>
-    internal static XElement GetFirstExpandedElement(XElement expandedDocumentation, string tagName)
-    {
-        return expandedDocumentation?.Elements().FirstOrDefault(obj => string.Equals(obj.Name.LocalName, tagName, StringComparison.OrdinalIgnoreCase));
-    }
-
-    /// <summary>
-    /// Gets the expanded XML elements for a tag name
-    /// </summary>
-    /// <param name="expandedDocumentation">Expanded documentation</param>
-    /// <param name="tagName">Tag name</param>
-    /// <returns>The matching elements</returns>
-    internal static ImmutableArray<XElement> GetExpandedElements(XElement expandedDocumentation, string tagName)
-    {
-        return expandedDocumentation?.Elements()
-                                    .Where(obj => string.Equals(obj.Name.LocalName, tagName, StringComparison.OrdinalIgnoreCase))
-                                    .ToImmutableArray()
-                   ?? [];
     }
 
     /// <summary>
@@ -331,17 +207,6 @@ internal static class DocumentationAnalysisUtilities
 
         return returnType != null
                && (returnType is not PredefinedTypeSyntax predefinedType || predefinedType.Keyword.IsKind(SyntaxKind.VoidKeyword) == false);
-    }
-
-    /// <summary>
-    /// Determines whether an <c>&lt;inheritdoc/&gt;</c> tag is present
-    /// </summary>
-    /// <param name="documentationComment">Documentation comment</param>
-    /// <param name="expandedDocumentation">Expanded documentation</param>
-    /// <returns><see langword="true"/> if an inheritdoc tag exists</returns>
-    internal static bool HasInheritdoc(DocumentationCommentTriviaSyntax documentationComment, XElement expandedDocumentation)
-    {
-        return HasTag(documentationComment, expandedDocumentation, "inheritdoc");
     }
 
     /// <summary>
@@ -487,31 +352,31 @@ internal static class DocumentationAnalysisUtilities
     /// <returns><see langword="true"/> if the declaration is documented sufficiently</returns>
     internal static bool HasRequiredDocumentation(MemberDeclarationSyntax declaration, SemanticModel semanticModel, CancellationToken cancellationToken)
     {
-        var documentationComment = GetDocumentationComment(declaration);
+        var documentationComment = DirectDocumentationSyntaxChecker.GetDocumentationComment(declaration);
 
         if (documentationComment == null)
         {
             return false;
         }
 
-        if (HasDirectTag(documentationComment, "inheritdoc"))
+        if (DirectDocumentationSyntaxChecker.HasDirectTag(documentationComment, "inheritdoc"))
         {
             return true;
         }
 
-        if (HasDirectTag(documentationComment, "summary"))
+        if (DirectDocumentationSyntaxChecker.HasDirectTag(documentationComment, "summary"))
         {
             return true;
         }
 
-        var expandedDocumentation = GetExpandedDocumentation(declaration, semanticModel, cancellationToken);
+        var expandedDocumentation = XmlDocumentationExpander.GetExpandedDocumentation(declaration, semanticModel, cancellationToken);
 
-        if (HasInheritdoc(documentationComment, expandedDocumentation))
+        if (XmlDocumentationExpander.HasInheritdoc(documentationComment, expandedDocumentation))
         {
             return true;
         }
 
-        if (HasTag(documentationComment, expandedDocumentation, "summary"))
+        if (XmlDocumentationExpander.HasTag(documentationComment, expandedDocumentation, "summary"))
         {
             return true;
         }
@@ -528,27 +393,27 @@ internal static class DocumentationAnalysisUtilities
     /// <returns><see langword="true"/> if the declaration is documented sufficiently</returns>
     internal static bool HasRequiredDocumentation(EnumMemberDeclarationSyntax declaration, SemanticModel semanticModel, CancellationToken cancellationToken)
     {
-        var documentationComment = GetDocumentationComment(declaration);
+        var documentationComment = DirectDocumentationSyntaxChecker.GetDocumentationComment(declaration);
 
         if (documentationComment == null)
         {
             return false;
         }
 
-        if (HasDirectTag(documentationComment, "inheritdoc"))
+        if (DirectDocumentationSyntaxChecker.HasDirectTag(documentationComment, "inheritdoc"))
         {
             return true;
         }
 
-        if (HasDirectTag(documentationComment, "summary"))
+        if (DirectDocumentationSyntaxChecker.HasDirectTag(documentationComment, "summary"))
         {
             return true;
         }
 
-        var expandedDocumentation = GetExpandedDocumentation(declaration, semanticModel, cancellationToken);
+        var expandedDocumentation = XmlDocumentationExpander.GetExpandedDocumentation(declaration, semanticModel, cancellationToken);
 
-        return HasInheritdoc(documentationComment, expandedDocumentation)
-               || HasTag(documentationComment, expandedDocumentation, "summary");
+        return XmlDocumentationExpander.HasInheritdoc(documentationComment, expandedDocumentation)
+               || XmlDocumentationExpander.HasTag(documentationComment, expandedDocumentation, "summary");
     }
 
     /// <summary>
@@ -598,44 +463,6 @@ internal static class DocumentationAnalysisUtilities
     }
 
     /// <summary>
-    /// Determines whether the documentation contains a direct tag
-    /// </summary>
-    /// <param name="documentationComment">Documentation comment</param>
-    /// <param name="tagName">Tag name</param>
-    /// <returns><see langword="true"/> if the tag exists</returns>
-    private static bool HasDirectTag(DocumentationCommentTriviaSyntax documentationComment, string tagName)
-    {
-        return GetDirectTags(documentationComment, tagName).Length > 0;
-    }
-
-    /// <summary>
-    /// Parses the expanded documentation XML for the enum member declaration
-    /// </summary>
-    /// <param name="declaration">Declaration</param>
-    /// <param name="semanticModel">Semantic model</param>
-    /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>The expanded XML documentation root, when available</returns>
-    private static XElement GetExpandedDocumentation(EnumMemberDeclarationSyntax declaration, SemanticModel semanticModel, CancellationToken cancellationToken)
-    {
-        var declaredSymbol = GetDeclaredSymbol(declaration, semanticModel, cancellationToken);
-        var rawDocumentation = declaredSymbol?.GetDocumentationCommentXml(expandIncludes: true, cancellationToken: cancellationToken);
-
-        if (string.IsNullOrWhiteSpace(rawDocumentation))
-        {
-            return null;
-        }
-
-        try
-        {
-            return XElement.Parse(rawDocumentation);
-        }
-        catch (XmlException)
-        {
-            return null;
-        }
-    }
-
-    /// <summary>
     /// Gets the declared symbol for the member
     /// </summary>
     /// <param name="declaration">Declaration</param>
@@ -662,18 +489,6 @@ internal static class DocumentationAnalysisUtilities
         }
 
         return null;
-    }
-
-    /// <summary>
-    /// Gets the declared symbol for the enum member
-    /// </summary>
-    /// <param name="declaration">Declaration</param>
-    /// <param name="semanticModel">Semantic model</param>
-    /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>The declared symbol, when available</returns>
-    private static ISymbol GetDeclaredSymbol(EnumMemberDeclarationSyntax declaration, SemanticModel semanticModel, CancellationToken cancellationToken)
-    {
-        return semanticModel.GetDeclaredSymbol(declaration, cancellationToken);
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer/Core/XmlDocumentationExpander.cs
+++ b/Reihitsu.Analyzer/Core/XmlDocumentationExpander.cs
@@ -1,0 +1,154 @@
+using System.Collections.Immutable;
+using System.Threading;
+using System.Xml;
+using System.Xml.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Reihitsu.Analyzer.Core;
+
+/// <summary>
+/// Expands and queries semantic XML documentation for declarations
+/// </summary>
+internal static class XmlDocumentationExpander
+{
+    #region Methods
+
+    /// <summary>
+    /// Parses the expanded documentation XML for the declaration
+    /// </summary>
+    /// <param name="declaration">Declaration</param>
+    /// <param name="semanticModel">Semantic model</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The expanded XML documentation root, when available</returns>
+    internal static XElement GetExpandedDocumentation(MemberDeclarationSyntax declaration, SemanticModel semanticModel, CancellationToken cancellationToken)
+    {
+        var declaredSymbol = GetDeclaredSymbol(declaration, semanticModel, cancellationToken);
+
+        return ParseExpandedDocumentation(declaredSymbol, cancellationToken);
+    }
+
+    /// <summary>
+    /// Parses the expanded documentation XML for the enum member declaration
+    /// </summary>
+    /// <param name="declaration">Declaration</param>
+    /// <param name="semanticModel">Semantic model</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The expanded XML documentation root, when available</returns>
+    internal static XElement GetExpandedDocumentation(EnumMemberDeclarationSyntax declaration, SemanticModel semanticModel, CancellationToken cancellationToken)
+    {
+        var declaredSymbol = semanticModel.GetDeclaredSymbol(declaration, cancellationToken);
+
+        return ParseExpandedDocumentation(declaredSymbol, cancellationToken);
+    }
+
+    /// <summary>
+    /// Determines whether the documentation contains a tag, considering expanded include XML
+    /// </summary>
+    /// <param name="documentationComment">Documentation comment</param>
+    /// <param name="expandedDocumentation">Expanded documentation</param>
+    /// <param name="tagName">Tag name</param>
+    /// <returns><see langword="true"/> if the tag exists</returns>
+    internal static bool HasTag(DocumentationCommentTriviaSyntax documentationComment, XElement expandedDocumentation, string tagName)
+    {
+        if (DirectDocumentationSyntaxChecker.HasDirectTag(documentationComment, tagName))
+        {
+            return true;
+        }
+
+        return expandedDocumentation?.Elements().Any(obj => string.Equals(obj.Name.LocalName, tagName, StringComparison.OrdinalIgnoreCase)) == true;
+    }
+
+    /// <summary>
+    /// Determines whether an <c>&lt;inheritdoc/&gt;</c> tag is present
+    /// </summary>
+    /// <param name="documentationComment">Documentation comment</param>
+    /// <param name="expandedDocumentation">Expanded documentation</param>
+    /// <returns><see langword="true"/> if an inheritdoc tag exists</returns>
+    internal static bool HasInheritdoc(DocumentationCommentTriviaSyntax documentationComment, XElement expandedDocumentation)
+    {
+        return HasTag(documentationComment, expandedDocumentation, "inheritdoc");
+    }
+
+    /// <summary>
+    /// Gets the first expanded XML element for a tag name
+    /// </summary>
+    /// <param name="expandedDocumentation">Expanded documentation</param>
+    /// <param name="tagName">Tag name</param>
+    /// <returns>The first matching element, when present</returns>
+    internal static XElement GetFirstExpandedElement(XElement expandedDocumentation, string tagName)
+    {
+        return expandedDocumentation?.Elements().FirstOrDefault(obj => string.Equals(obj.Name.LocalName, tagName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>
+    /// Gets the expanded XML elements for a tag name
+    /// </summary>
+    /// <param name="expandedDocumentation">Expanded documentation</param>
+    /// <param name="tagName">Tag name</param>
+    /// <returns>The matching elements</returns>
+    internal static ImmutableArray<XElement> GetExpandedElements(XElement expandedDocumentation, string tagName)
+    {
+        return expandedDocumentation?.Elements()
+                                    .Where(obj => string.Equals(obj.Name.LocalName, tagName, StringComparison.OrdinalIgnoreCase))
+                                    .ToImmutableArray()
+                   ?? [];
+    }
+
+    /// <summary>
+    /// Gets the declared symbol for the member
+    /// </summary>
+    /// <param name="declaration">Declaration</param>
+    /// <param name="semanticModel">Semantic model</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The declared symbol, when available</returns>
+    private static ISymbol GetDeclaredSymbol(MemberDeclarationSyntax declaration, SemanticModel semanticModel, CancellationToken cancellationToken)
+    {
+        var symbol = semanticModel.GetDeclaredSymbol(declaration, cancellationToken);
+
+        if (symbol != null)
+        {
+            return symbol;
+        }
+
+        if (declaration is FieldDeclarationSyntax fieldDeclaration)
+        {
+            return semanticModel.GetDeclaredSymbol(fieldDeclaration.Declaration.Variables[0], cancellationToken);
+        }
+
+        if (declaration is EventFieldDeclarationSyntax eventFieldDeclaration)
+        {
+            return semanticModel.GetDeclaredSymbol(eventFieldDeclaration.Declaration.Variables[0], cancellationToken);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Parses expanded documentation for a declared symbol
+    /// </summary>
+    /// <param name="declaredSymbol">Declared symbol</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The parsed XML root when available</returns>
+    private static XElement ParseExpandedDocumentation(ISymbol declaredSymbol, CancellationToken cancellationToken)
+    {
+        var rawDocumentation = declaredSymbol?.GetDocumentationCommentXml(expandIncludes: true, cancellationToken: cancellationToken);
+
+        if (string.IsNullOrWhiteSpace(rawDocumentation))
+        {
+            return null;
+        }
+
+        try
+        {
+            return XElement.Parse(rawDocumentation);
+        }
+        catch (XmlException)
+        {
+            return null;
+        }
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0431ElementDocumentationMustHaveSummaryTextAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0431ElementDocumentationMustHaveSummaryTextAnalyzer.cs
@@ -68,14 +68,14 @@ public class RH0431ElementDocumentationMustHaveSummaryTextAnalyzer : DiagnosticA
     /// <param name="declaration">Declaration node</param>
     private void AnalyzeDeclaration(SyntaxNodeAnalysisContext context, SyntaxNode declaration)
     {
-        var documentationComment = DocumentationAnalysisUtilities.GetDocumentationComment(declaration);
+        var documentationComment = DirectDocumentationSyntaxChecker.GetDocumentationComment(declaration);
 
         if (documentationComment == null)
         {
             return;
         }
 
-        var summaryNode = DocumentationAnalysisUtilities.GetFirstDirectTag(documentationComment, "summary");
+        var summaryNode = DirectDocumentationSyntaxChecker.GetFirstDirectTag(documentationComment, "summary");
 
         if (summaryNode == null)
         {

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0432ValueTagMustNotBeUsedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0432ValueTagMustNotBeUsedAnalyzer.cs
@@ -62,14 +62,14 @@ public class RH0432ValueTagMustNotBeUsedAnalyzer : DiagnosticAnalyzerBase<RH0432
             return;
         }
 
-        var documentationComment = DocumentationAnalysisUtilities.GetDocumentationComment(declaration);
+        var documentationComment = DirectDocumentationSyntaxChecker.GetDocumentationComment(declaration);
 
         if (documentationComment == null)
         {
             return;
         }
 
-        var valueNode = DocumentationAnalysisUtilities.GetFirstDirectTag(documentationComment, "value");
+        var valueNode = DirectDocumentationSyntaxChecker.GetFirstDirectTag(documentationComment, "value");
 
         if (valueNode == null)
         {

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0433ElementParametersMustBeDocumentedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0433ElementParametersMustBeDocumentedAnalyzer.cs
@@ -52,7 +52,7 @@ public class RH0433ElementParametersMustBeDocumentedAnalyzer : DiagnosticAnalyze
         }
 
         var parameters = DocumentationAnalysisUtilities.GetParameters(declaration);
-        var documentationComment = DocumentationAnalysisUtilities.GetDocumentationComment(declaration);
+        var documentationComment = DirectDocumentationSyntaxChecker.GetDocumentationComment(declaration);
 
         if (parameters.IsDefaultOrEmpty
             || documentationComment == null)
@@ -60,17 +60,17 @@ public class RH0433ElementParametersMustBeDocumentedAnalyzer : DiagnosticAnalyze
             return;
         }
 
-        var expandedDocumentation = DocumentationAnalysisUtilities.GetExpandedDocumentation(declaration, context.SemanticModel, context.CancellationToken);
+        var expandedDocumentation = XmlDocumentationExpander.GetExpandedDocumentation(declaration, context.SemanticModel, context.CancellationToken);
 
-        if (DocumentationAnalysisUtilities.HasInheritdoc(documentationComment, expandedDocumentation))
+        if (XmlDocumentationExpander.HasInheritdoc(documentationComment, expandedDocumentation))
         {
             return;
         }
 
-        var documentedParameterNames = DocumentationAnalysisUtilities.GetExpandedElements(expandedDocumentation, "param")
-                                                                     .Select(obj => obj.Attribute("name")?.Value)
-                                                                     .Where(obj => string.IsNullOrWhiteSpace(obj) == false)
-                                                                     .ToImmutableHashSet(StringComparer.Ordinal);
+        var documentedParameterNames = XmlDocumentationExpander.GetExpandedElements(expandedDocumentation, "param")
+                                                               .Select(obj => obj.Attribute("name")?.Value)
+                                                               .Where(obj => string.IsNullOrWhiteSpace(obj) == false)
+                                                               .ToImmutableHashSet(StringComparer.Ordinal);
 
         foreach (var parameter in parameters.Where(parameter => documentedParameterNames.Contains(parameter.Identifier.ValueText) == false))
         {

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0434ElementParameterDocumentationMustMatchElementParametersAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0434ElementParameterDocumentationMustMatchElementParametersAnalyzer.cs
@@ -51,7 +51,7 @@ public class RH0434ElementParameterDocumentationMustMatchElementParametersAnalyz
         }
 
         var parameters = DocumentationAnalysisUtilities.GetParameters(declaration);
-        var documentationComment = DocumentationAnalysisUtilities.GetDocumentationComment(declaration);
+        var documentationComment = DirectDocumentationSyntaxChecker.GetDocumentationComment(declaration);
 
         if (parameters.IsDefaultOrEmpty
             || documentationComment == null)
@@ -59,7 +59,7 @@ public class RH0434ElementParameterDocumentationMustMatchElementParametersAnalyz
             return;
         }
 
-        var paramNodes = DocumentationAnalysisUtilities.GetDirectTags(documentationComment, "param");
+        var paramNodes = DirectDocumentationSyntaxChecker.GetDirectTags(documentationComment, "param");
 
         if (paramNodes.IsDefaultOrEmpty)
         {

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0435ElementParameterDocumentationMustDeclareParameterNameAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0435ElementParameterDocumentationMustDeclareParameterNameAnalyzer.cs
@@ -48,15 +48,15 @@ public class RH0435ElementParameterDocumentationMustDeclareParameterNameAnalyzer
             return;
         }
 
-        var documentationComment = DocumentationAnalysisUtilities.GetDocumentationComment(declaration);
+        var documentationComment = DirectDocumentationSyntaxChecker.GetDocumentationComment(declaration);
 
         if (documentationComment == null)
         {
             return;
         }
 
-        foreach (var paramNode in DocumentationAnalysisUtilities.GetDirectTags(documentationComment, "param")
-                                                                .Where(paramNode => string.IsNullOrWhiteSpace(DocumentationAnalysisUtilities.GetNameAttributeValue(paramNode))))
+        foreach (var paramNode in DirectDocumentationSyntaxChecker.GetDirectTags(documentationComment, "param")
+                                                                  .Where(paramNode => string.IsNullOrWhiteSpace(DocumentationAnalysisUtilities.GetNameAttributeValue(paramNode))))
         {
             context.ReportDiagnostic(CreateDiagnostic(paramNode.GetLocation()));
         }

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0436ElementParameterDocumentationMustHaveTextAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0436ElementParameterDocumentationMustHaveTextAnalyzer.cs
@@ -48,15 +48,15 @@ public class RH0436ElementParameterDocumentationMustHaveTextAnalyzer : Diagnosti
             return;
         }
 
-        var documentationComment = DocumentationAnalysisUtilities.GetDocumentationComment(declaration);
+        var documentationComment = DirectDocumentationSyntaxChecker.GetDocumentationComment(declaration);
 
         if (documentationComment == null)
         {
             return;
         }
 
-        foreach (var paramNode in DocumentationAnalysisUtilities.GetDirectTags(documentationComment, "param")
-                                                                .Where(paramNode => DocumentationAnalysisUtilities.IsEmpty(paramNode)))
+        foreach (var paramNode in DirectDocumentationSyntaxChecker.GetDirectTags(documentationComment, "param")
+                                                                  .Where(paramNode => DocumentationAnalysisUtilities.IsEmpty(paramNode)))
         {
             context.ReportDiagnostic(CreateDiagnostic(paramNode.GetLocation()));
         }

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0437ElementReturnValueMustBeDocumentedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0437ElementReturnValueMustBeDocumentedAnalyzer.cs
@@ -50,17 +50,17 @@ public class RH0437ElementReturnValueMustBeDocumentedAnalyzer : DiagnosticAnalyz
             return;
         }
 
-        var documentationComment = DocumentationAnalysisUtilities.GetDocumentationComment(declaration);
+        var documentationComment = DirectDocumentationSyntaxChecker.GetDocumentationComment(declaration);
 
         if (documentationComment == null)
         {
             return;
         }
 
-        var expandedDocumentation = DocumentationAnalysisUtilities.GetExpandedDocumentation(declaration, context.SemanticModel, context.CancellationToken);
+        var expandedDocumentation = XmlDocumentationExpander.GetExpandedDocumentation(declaration, context.SemanticModel, context.CancellationToken);
 
-        if (DocumentationAnalysisUtilities.HasInheritdoc(documentationComment, expandedDocumentation)
-            || DocumentationAnalysisUtilities.HasTag(documentationComment, expandedDocumentation, "returns"))
+        if (XmlDocumentationExpander.HasInheritdoc(documentationComment, expandedDocumentation)
+            || XmlDocumentationExpander.HasTag(documentationComment, expandedDocumentation, "returns"))
         {
             return;
         }

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0438ElementReturnValueDocumentationMustHaveTextAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0438ElementReturnValueDocumentationMustHaveTextAnalyzer.cs
@@ -48,14 +48,14 @@ public class RH0438ElementReturnValueDocumentationMustHaveTextAnalyzer : Diagnos
             return;
         }
 
-        var documentationComment = DocumentationAnalysisUtilities.GetDocumentationComment(declaration);
+        var documentationComment = DirectDocumentationSyntaxChecker.GetDocumentationComment(declaration);
 
         if (documentationComment == null)
         {
             return;
         }
 
-        var returnsNode = DocumentationAnalysisUtilities.GetFirstDirectTag(documentationComment, "returns");
+        var returnsNode = DirectDocumentationSyntaxChecker.GetFirstDirectTag(documentationComment, "returns");
 
         if (returnsNode == null
             || DocumentationAnalysisUtilities.IsEmpty(returnsNode) == false)

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0439VoidReturnValueMustNotBeDocumentedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0439VoidReturnValueMustNotBeDocumentedAnalyzer.cs
@@ -49,14 +49,14 @@ public class RH0439VoidReturnValueMustNotBeDocumentedAnalyzer : DiagnosticAnalyz
             return;
         }
 
-        var documentationComment = DocumentationAnalysisUtilities.GetDocumentationComment(declaration);
+        var documentationComment = DirectDocumentationSyntaxChecker.GetDocumentationComment(declaration);
 
         if (documentationComment == null)
         {
             return;
         }
 
-        var returnsNode = DocumentationAnalysisUtilities.GetFirstDirectTag(documentationComment, "returns");
+        var returnsNode = DirectDocumentationSyntaxChecker.GetFirstDirectTag(documentationComment, "returns");
 
         if (returnsNode == null)
         {

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0440GenericTypeParametersMustBeDocumentedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0440GenericTypeParametersMustBeDocumentedAnalyzer.cs
@@ -52,7 +52,7 @@ public class RH0440GenericTypeParametersMustBeDocumentedAnalyzer : DiagnosticAna
         }
 
         var typeParameters = DocumentationAnalysisUtilities.GetTypeParameters(declaration);
-        var documentationComment = DocumentationAnalysisUtilities.GetDocumentationComment(declaration);
+        var documentationComment = DirectDocumentationSyntaxChecker.GetDocumentationComment(declaration);
 
         if (typeParameters.IsDefaultOrEmpty
             || documentationComment == null)
@@ -60,17 +60,17 @@ public class RH0440GenericTypeParametersMustBeDocumentedAnalyzer : DiagnosticAna
             return;
         }
 
-        var expandedDocumentation = DocumentationAnalysisUtilities.GetExpandedDocumentation(declaration, context.SemanticModel, context.CancellationToken);
+        var expandedDocumentation = XmlDocumentationExpander.GetExpandedDocumentation(declaration, context.SemanticModel, context.CancellationToken);
 
-        if (DocumentationAnalysisUtilities.HasInheritdoc(documentationComment, expandedDocumentation))
+        if (XmlDocumentationExpander.HasInheritdoc(documentationComment, expandedDocumentation))
         {
             return;
         }
 
-        var documentedTypeParameterNames = DocumentationAnalysisUtilities.GetExpandedElements(expandedDocumentation, "typeparam")
-                                                                         .Select(obj => obj.Attribute("name")?.Value)
-                                                                         .Where(obj => string.IsNullOrWhiteSpace(obj) == false)
-                                                                         .ToImmutableHashSet(StringComparer.Ordinal);
+        var documentedTypeParameterNames = XmlDocumentationExpander.GetExpandedElements(expandedDocumentation, "typeparam")
+                                                                   .Select(obj => obj.Attribute("name")?.Value)
+                                                                   .Where(obj => string.IsNullOrWhiteSpace(obj) == false)
+                                                                   .ToImmutableHashSet(StringComparer.Ordinal);
 
         foreach (var typeParameter in typeParameters.Where(typeParameter => documentedTypeParameterNames.Contains(typeParameter.Identifier.ValueText) == false))
         {

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0441GenericTypeParameterDocumentationMustMatchTypeParametersAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0441GenericTypeParameterDocumentationMustMatchTypeParametersAnalyzer.cs
@@ -51,7 +51,7 @@ public class RH0441GenericTypeParameterDocumentationMustMatchTypeParametersAnaly
         }
 
         var typeParameters = DocumentationAnalysisUtilities.GetTypeParameters(declaration);
-        var documentationComment = DocumentationAnalysisUtilities.GetDocumentationComment(declaration);
+        var documentationComment = DirectDocumentationSyntaxChecker.GetDocumentationComment(declaration);
 
         if (typeParameters.IsDefaultOrEmpty
             || documentationComment == null)
@@ -59,7 +59,7 @@ public class RH0441GenericTypeParameterDocumentationMustMatchTypeParametersAnaly
             return;
         }
 
-        var typeParameterNodes = DocumentationAnalysisUtilities.GetDirectTags(documentationComment, "typeparam");
+        var typeParameterNodes = DirectDocumentationSyntaxChecker.GetDirectTags(documentationComment, "typeparam");
 
         if (typeParameterNodes.IsDefaultOrEmpty)
         {

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0442GenericTypeParameterDocumentationMustDeclareParameterNameAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0442GenericTypeParameterDocumentationMustDeclareParameterNameAnalyzer.cs
@@ -48,14 +48,14 @@ public class RH0442GenericTypeParameterDocumentationMustDeclareParameterNameAnal
             return;
         }
 
-        var documentationComment = DocumentationAnalysisUtilities.GetDocumentationComment(declaration);
+        var documentationComment = DirectDocumentationSyntaxChecker.GetDocumentationComment(declaration);
 
         if (documentationComment == null)
         {
             return;
         }
 
-        var unnamedTypeParameterNodes = DocumentationAnalysisUtilities.GetDirectTags(documentationComment, "typeparam").Where(typeParameterNode => string.IsNullOrWhiteSpace(DocumentationAnalysisUtilities.GetNameAttributeValue(typeParameterNode)));
+        var unnamedTypeParameterNodes = DirectDocumentationSyntaxChecker.GetDirectTags(documentationComment, "typeparam").Where(typeParameterNode => string.IsNullOrWhiteSpace(DocumentationAnalysisUtilities.GetNameAttributeValue(typeParameterNode)));
 
         foreach (var typeParameterNode in unnamedTypeParameterNodes)
         {

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0443GenericTypeParameterDocumentationMustHaveTextAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0443GenericTypeParameterDocumentationMustHaveTextAnalyzer.cs
@@ -48,14 +48,14 @@ public class RH0443GenericTypeParameterDocumentationMustHaveTextAnalyzer : Diagn
             return;
         }
 
-        var documentationComment = DocumentationAnalysisUtilities.GetDocumentationComment(declaration);
+        var documentationComment = DirectDocumentationSyntaxChecker.GetDocumentationComment(declaration);
 
         if (documentationComment == null)
         {
             return;
         }
 
-        var emptyTypeParameterNodes = DocumentationAnalysisUtilities.GetDirectTags(documentationComment, "typeparam").Where(typeParameterNode => DocumentationAnalysisUtilities.IsEmpty(typeParameterNode));
+        var emptyTypeParameterNodes = DirectDocumentationSyntaxChecker.GetDirectTags(documentationComment, "typeparam").Where(typeParameterNode => DocumentationAnalysisUtilities.IsEmpty(typeParameterNode));
 
         foreach (var typeParameterNode in emptyTypeParameterNodes)
         {

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0445InheritdocMustBeUsedWithInheritingClassAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0445InheritdocMustBeUsedWithInheritingClassAnalyzer.cs
@@ -48,16 +48,16 @@ public class RH0445InheritdocMustBeUsedWithInheritingClassAnalyzer : DiagnosticA
             return;
         }
 
-        var documentationComment = DocumentationAnalysisUtilities.GetDocumentationComment(declaration);
+        var documentationComment = DirectDocumentationSyntaxChecker.GetDocumentationComment(declaration);
 
         if (documentationComment == null)
         {
             return;
         }
 
-        var inheritdocNode = DocumentationAnalysisUtilities.GetFirstDirectTag(documentationComment, "inheritdoc");
-        var expandedDocumentation = DocumentationAnalysisUtilities.GetExpandedDocumentation(declaration, context.SemanticModel, context.CancellationToken);
-        var expandedInheritdocElement = DocumentationAnalysisUtilities.GetFirstExpandedElement(expandedDocumentation, "inheritdoc");
+        var inheritdocNode = DirectDocumentationSyntaxChecker.GetFirstDirectTag(documentationComment, "inheritdoc");
+        var expandedDocumentation = XmlDocumentationExpander.GetExpandedDocumentation(declaration, context.SemanticModel, context.CancellationToken);
+        var expandedInheritdocElement = XmlDocumentationExpander.GetFirstExpandedElement(expandedDocumentation, "inheritdoc");
 
         if (inheritdocNode == null && expandedInheritdocElement == null)
         {


### PR DESCRIPTION
## Summary

Refactors documentation-analysis helpers by separating direct XML syntax checks and semantic XML expansion into dedicated utility classes, while keeping existing analyzer behavior intact.

## Why

`DocumentationAnalysisUtilities` mixed multiple responsibilities, which made the code harder to reason about and maintain safely.

## Linked issues

Closes #85

## Review notes

`DirectDocumentationSyntaxChecker` now owns direct tag/comment inspection, and `XmlDocumentationExpander` owns semantic XML expansion and expanded-tag queries. `DocumentationAnalysisUtilities` keeps focused helper logic for accessibility, declaration metadata, and shared XML-node helpers.

## Follow-up work

None
