### PR TITLE
Add rule title metadata consistency check

### DIFF
--- a/Reihitsu.Analyzer.Package/README.MD
+++ b/Reihitsu.Analyzer.Package/README.MD
@@ -15,7 +15,7 @@ The **Formatter** column indicates whether running the Reihitsu formatter can au
 | ID| Description| Analyzer| Code Fix| Formatter|
 |--------|-----------------------------------------------------------------------|:--------:|:--------:|:--------:|
 || **Clarity**||||
-| [RH0001](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0001.md)| The logical operator ! should not be used for clarity.| ✔| ✔| ❌|
+| [RH0001](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0001.md)| Not operator should not be used.| ✔| ✔| ❌|
 | [RH0002](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0002.md)| Do not prefix calls with `base.` unless a local implementation exists.| ✔| ✔| ❌|
 | [RH0003](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0003.md)| Code must not contain empty statements.| ✔| ✔| ❌|
 | [RH0004](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0004.md)| Statement must not use unnecessary parentheses.| ✔| ✔| ❌|
@@ -48,14 +48,14 @@ The **Formatter** column indicates whether running the Reihitsu formatter can au
 | [RH0203](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0203.md)| Struct names should be in PascalCase.| ✔| ✔| ❌|
 | [RH0204](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0204.md)| Enum names should be in PascalCase.| ✔| ✔| ❌|
 | [RH0205](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0205.md)| Enum member names should be in PascalCase.| ✔| ✔| ❌|
-| [RH0206](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0206.md)| Interface names should be in PascalCase.| ✔| ✔| ❌|
+| [RH0206](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0206.md)| Interface names should use the I prefix and PascalCase.| ✔| ✔| ❌|
 | [RH0207](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0207.md)| Event names should be in PascalCase.| ✔| ✔| ❌|
 | [RH0208](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0208.md)| Delegate names should be in PascalCase.| ✔| ✔| ❌|
 | [RH0209](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0209.md)| Method names should be in PascalCase.| ✔| ✔| ❌|
 | [RH0210](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0210.md)| Local function names should be in PascalCase.| ✔| ✔| ❌|
 | [RH0211](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0211.md)| Method parameter names should be in camelCase.| ✔| ✔| ❌|
-| [RH0212](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0212.md)| Private field names should be in camelCase.| ✔| ✔| ❌|
-| [RH0213](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0213.md)| Protected field names should be in PascalCase.| ✔| ✔| ❌|
+| [RH0212](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0212.md)| Private field names should be in _camelCase.| ✔| ✔| ❌|
+| [RH0213](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0213.md)| Protected field names should be in _camelCase.| ✔| ✔| ❌|
 | [RH0214](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0214.md)| Internal field names should be in PascalCase.| ✔| ✔| ❌|
 | [RH0215](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0215.md)| Public field names should be in PascalCase.| ✔| ✔| ❌|
 | [RH0216](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0216.md)| Const field names should be in PascalCase.| ✔| ✔| ❌|
@@ -69,36 +69,36 @@ The **Formatter** column indicates whether running the Reihitsu formatter can au
 | [RH0224](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0224.md)| Tuple expression argument names should be in camelCase.| ✔| ✔| ❌|
 | [RH0225](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0225.md)| File scoped namespace declarations should be in PascalCase.| ✔| ❌| ❌|
 | [RH0226](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0226.md)| Namespace declarations should be in PascalCase.| ✔| ❌| ❌|
-| [RH0227](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0227.md)| The given namespace is not allowed (see reihitsu.json)| ✔| ❌| ❌|
+| [RH0227](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0227.md)| The given namespace is not allowed.| ✔| ❌| ❌|
 || **Formatting**||||
-| [RH0301](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0301.md)| The description of the #region and #endregion should match.| ✔| ✔| ✔|
-| [RH0302](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0302.md)| The object initializer should be formatted correctly.| ✔| ✔| ✔|
-| [RH0303](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0303.md)| The try-Statement should be preceded by a blank line.| ✔| ✔| ✔|
-| [RH0304](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0304.md)| The if-Statement should be preceded by a blank line.| ✔| ✔| ✔|
-| [RH0305](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0305.md)| The while-Statement should be preceded by a blank line.| ✔| ✔| ✔|
-| [RH0306](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0306.md)| The do-Statement should be preceded by a blank line.| ✔| ✔| ✔|
-| [RH0307](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0307.md)| The using-Statement should be preceded by a blank line.| ✔| ✔| ✔|
-| [RH0308](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0308.md)| The foreach-Statement should be preceded by a blank line.| ✔| ✔| ✔|
-| [RH0309](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0309.md)| The for-Statement should be preceded by a blank line.| ✔| ✔| ✔|
-| [RH0310](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0310.md)| The return-Statement should be preceded by a blank line.| ✔| ✔| ✔|
-| [RH0311](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0311.md)| The goto-Statement should be preceded by a blank line.| ✔| ✔| ✔|
-| [RH0312](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0312.md)| The break-Statement should be preceded by a blank line.| ✔| ✔| ✔|
-| [RH0313](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0313.md)| The break statement should be followed by a blank line.| ✔| ✔| ✔|
-| [RH0314](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0314.md)| The continue-Statement should be preceded by a blank line.| ✔| ✔| ✔|
-| [RH0315](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0315.md)| The throw-Statement should be preceded by a blank line.| ✔| ✔| ✔|
-| [RH0316](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0316.md)| The switch-Statement should be preceded by a blank line.| ✔| ✔| ✔|
-| [RH0317](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0317.md)| The checked-Statement should be preceded by a blank line.| ✔| ✔| ✔|
-| [RH0318](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0318.md)| The unchecked-Statement should be preceded by a blank line.| ✔| ✔| ✔|
-| [RH0319](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0319.md)| The fixed-Statement should be preceded by a blank line.| ✔| ✔| ✔|
-| [RH0320](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0320.md)| The lock-Statement should be preceded by a blank line.| ✔| ✔| ✔|
-| [RH0321](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0321.md)| The yield-Statement should be preceded by a blank line.| ✔| ✔| ✔|
+| [RH0301](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0301.md)| #region and #endregion descriptions should match.| ✔| ✔| ✔|
+| [RH0302](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0302.md)| Object initializer should be formatted correctly.| ✔| ✔| ✔|
+| [RH0303](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0303.md)| try-Statement should be preceded by a blank line.| ✔| ✔| ✔|
+| [RH0304](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0304.md)| if-Statement should be preceded by a blank line.| ✔| ✔| ✔|
+| [RH0305](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0305.md)| while-Statement should be preceded by a blank line.| ✔| ✔| ✔|
+| [RH0306](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0306.md)| do-Statement should be preceded by a blank line.| ✔| ✔| ✔|
+| [RH0307](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0307.md)| using-Statement should be preceded by a blank line.| ✔| ✔| ✔|
+| [RH0308](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0308.md)| foreach-Statement should be preceded by a blank line.| ✔| ✔| ✔|
+| [RH0309](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0309.md)| for-Statement should be preceded by a blank line.| ✔| ✔| ✔|
+| [RH0310](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0310.md)| return-Statement should be preceded by a blank line.| ✔| ✔| ✔|
+| [RH0311](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0311.md)| goto-Statement should be preceded by a blank line.| ✔| ✔| ✔|
+| [RH0312](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0312.md)| break-Statement should be preceded by a blank line.| ✔| ✔| ✔|
+| [RH0313](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0313.md)| break statement should be followed by a blank line.| ✔| ✔| ✔|
+| [RH0314](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0314.md)| continue-Statement should be preceded by a blank line.| ✔| ✔| ✔|
+| [RH0315](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0315.md)| throw-Statement should be preceded by a blank line.| ✔| ✔| ✔|
+| [RH0316](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0316.md)| switch-Statement should be preceded by a blank line.| ✔| ✔| ✔|
+| [RH0317](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0317.md)| checked-Statement should be preceded by a blank line.| ✔| ✔| ✔|
+| [RH0318](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0318.md)| unchecked-Statement should be preceded by a blank line.| ✔| ✔| ✔|
+| [RH0319](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0319.md)| fixed-Statement should be preceded by a blank line.| ✔| ✔| ✔|
+| [RH0320](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0320.md)| lock-Statement should be preceded by a blank line.| ✔| ✔| ✔|
+| [RH0321](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0321.md)| yield-Statement should be preceded by a blank line.| ✔| ✔| ✔|
 | [RH0322](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0322.md)| Single line comments should be preceded by a blank line.| ✔| ✔| ✔|
 | [RH0323](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0323.md)| Local declarations should be followed by a blank line.| ✔| ✔| ✔|
 | [RH0324](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0324.md)| Method chains should be aligned.| ✔| ✔| ✔|
 | [RH0325](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0325.md)| Expression style methods should not be used.| ✔| ✔| ✔|
 | [RH0326](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0326.md)| Expression style constructors should not be used.| ✔| ✔| ✔|
-| [RH0327](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0327.md)| Expression style get only properties should be single lined.| ✔| ✔| ✔|
-| [RH0328](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0328.md)| The description of the #region should start with an uppercase letter.| ✔| ✔| ✔|
+| [RH0327](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0327.md)| Expression style get-only properties should be single lined.| ✔| ✔| ✔|
+| [RH0328](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0328.md)| #region description should start with an uppercase letter.| ✔| ✔| ✔|
 | [RH0329](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0329.md)| Logical expressions should be formatted correctly.| ✔| ✔| ✔|
 | [RH0330](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0330.md)| Raw string literals should be formatted correctly.| ✔| ✔| ✔|
 | [RH0331](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0331.md)| The first argument should be on the same line as the opening parenthesis.| ✔| ✔| ✔|
@@ -127,7 +127,7 @@ The **Formatter** column indicates whether running the Reihitsu formatter can au
 | [RH0354](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0354.md)| Dereference and access-of symbols must be spaced correctly.| ✔| ✔| ✔|
 | [RH0355](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0355.md)| Colons must be spaced correctly.| ✔| ✔| ✔|
 | [RH0356](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0356.md)| No space after new for implicitly typed arrays.| ✔| ✔| ✔|
-| [RH0357](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0357.md)| Use tabs correctly.| ✔| ✔| ✔|
+| [RH0357](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0357.md)| Tab characters must not be used.| ✔| ✔| ✔|
 | [RH0358](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0358.md)| Code must not contain trailing whitespace.| ✔| ✔| ✔|
 | [RH0359](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0359.md)| Braces for multi-line statements must not share line.| ✔| ✔| ✔|
 | [RH0360](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0360.md)| Statement must not be on a single line.| ✔| ✔| ✔|
@@ -147,8 +147,8 @@ The **Formatter** column indicates whether running the Reihitsu formatter can au
 | [RH0374](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0374.md)| Use braces consistently.| ✔| ✔| ✔|
 | [RH0375](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0375.md)| Code must not contain multiple statements on one line.| ✔| ✔| ✔|
 | [RH0376](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0376.md)| Comments must be on their own line.| ✔| ✔| ✔|
-| [RH0377](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0377.md)| Opening parentheses must be on declaration line.| ✔| ✔| ✔|
-| [RH0378](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0378.md)| Closing parentheses must be on line of last argument.| ✔| ✔| ✔|
+| [RH0377](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0377.md)| Opening parenthesis must be on declaration line.| ✔| ✔| ✔|
+| [RH0378](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0378.md)| Closing parenthesis must be on line of last argument.| ✔| ✔| ✔|
 | [RH0379](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0379.md)| Comma must be on same line as previous parameter.| ✔| ✔| ✔|
 | [RH0380](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0380.md)| Parameter list must follow declaration.| ✔| ✔| ✔|
 | [RH0381](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0381.md)| Parameters must be on same line or separate lines.| ✔| ✔| ✔|
@@ -160,20 +160,20 @@ The **Formatter** column indicates whether running the Reihitsu formatter can au
 | [RH0387](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0387.md)| Types should be organized with regions.| ✔| ❌| ❌|
 | [RH0388](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0388.md)| Region descriptions should not end with implementation.| ✔| ✔| ❌|
 | [RH0389](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0389.md)| Indentation must use 4 spaces per scope level.| ✔| ✔| ✔|
-| [RH0390](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0390.md)| Using directives should be grouped by kind and namespace with blank lines between groups.| ✔| ✔| ✔|
-| [RH0391](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0391.md)| Assignments must keep the target, `=`, and value start on the same line.| ✔| ✔| ✔|
-| [RH0392](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0392.md)| Statement lambda opening braces should align with the lambda argument anchor.| ✔| ✔| ✔|
+| [RH0390](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0390.md)| Using directives should be organized into groups.| ✔| ✔| ✔|
+| [RH0391](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0391.md)| Assignments must have proper line breaks.| ✔| ✔| ✔|
+| [RH0392](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0392.md)| Statement lambda opening braces should be aligned.| ✔| ✔| ✔|
 | [RH0393](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0393.md)| Local declarations should be preceded by a blank line.| ✔| ✔| ✔|
 || **Documentation**||||
-| [RH0401](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0401.md)| The \<inheritdoc/> Tag should be used if possible.| ✔| ✔| ❌|
-| [RH0402](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0402.md)| Elements must be documented.| ✔| ❌| ❌|
-| [RH0403](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0403.md)| Partial elements must be documented.| ✔| ❌| ❌|
-| [RH0404](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0404.md)| Element documentation must have summary.| ✔| ❌| ❌|
-| [RH0405](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0405.md)| Partial element documentation must have summary.| ✔| ❌| ❌|
-| [RH0406](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0406.md)| Element documentation must have summary text.| ✔| ❌| ❌|
-| [RH0407](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0407.md)| Partial element documentation must have summary text.| ✔| ❌| ❌|
-| [RH0408](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0408.md)| Element documentation must not have default summary.| ✔| ❌| ❌|
-| [RH0409](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0409.md)| Property documentation must have value text.| ✔| ❌| ❌|
+| [RH0401](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0401.md)| The inheritdoc tag should be used if possible.| ✔| ✔| ❌|
+| [RH0402](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0402.md)| Non-private classes must be documented.| ✔| ❌| ❌|
+| [RH0403](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0403.md)| Private classes must be documented.| ✔| ❌| ❌|
+| [RH0404](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0404.md)| Non-private structs must be documented.| ✔| ❌| ❌|
+| [RH0405](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0405.md)| Private structs must be documented.| ✔| ❌| ❌|
+| [RH0406](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0406.md)| Non-private interfaces must be documented.| ✔| ❌| ❌|
+| [RH0407](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0407.md)| Private interfaces must be documented.| ✔| ❌| ❌|
+| [RH0408](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0408.md)| Non-private records must be documented.| ✔| ❌| ❌|
+| [RH0409](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0409.md)| Private records must be documented.| ✔| ❌| ❌|
 | [RH0410](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0410.md)| Non-private record structs must be documented.| ✔| ❌| ❌|
 | [RH0411](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0411.md)| Private record structs must be documented.| ✔| ❌| ❌|
 | [RH0412](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0412.md)| Non-private enums must be documented.| ✔| ❌| ❌|
@@ -209,7 +209,7 @@ The **Formatter** column indicates whether running the Reihitsu formatter can au
 | [RH0442](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0442.md)| Generic type parameter documentation must declare parameter name.| ✔| ❌| ❌|
 | [RH0443](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0443.md)| Generic type parameter documentation must have text.| ✔| ❌| ❌|
 | [RH0444](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0444.md)| Single-line comments must not use documentation style slashes.| ✔| ✔| ❌|
-| [RH0445](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0445.md)| \<inheritdoc/> must be used with inheriting class.| ✔| ❌| ❌|
+| [RH0445](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0445.md)| \<inheritdoc> must be used with inheriting class.| ✔| ❌| ❌|
 | [RH0446](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0446.md)| Do not use placeholder elements.| ✔| ✔| ❌|
 | [RH0447](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0447.md)| XML documentation elements must be on separate lines.| ✔| ✔| ❌|
 | [RH0448](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0448.md)| Summary element must span at least three lines.| ✔| ✔| ✔|
@@ -232,5 +232,5 @@ The **Formatter** column indicates whether running the Reihitsu formatter can au
 | [RH0613](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0613.md)| Using static directives must be placed at correct position.| ✔| ✔| ❌|
 | [RH0614](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0614.md)| Using static directives must be ordered alphabetically.| ✔| ✔| ❌|
 || **Performance**||||
-| [RH0501](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0501.md)| Types used as keys must implement equality members.| ✔| ❌| ❌|
+| [RH0501](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0501.md)| Types used as dictionary keys or in hash sets must implement equality members.| ✔| ❌| ❌|
 | [RH0502](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0502.md)| Types used for equality comparison must implement equality members.| ✔| ❌| ❌|

--- a/Reihitsu.Analyzer.Test/SelfHosting/AnalyzerMetadataDiscovery.cs
+++ b/Reihitsu.Analyzer.Test/SelfHosting/AnalyzerMetadataDiscovery.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Text.RegularExpressions;
 
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -25,6 +26,12 @@ internal static partial class AnalyzerMetadataDiscovery
     /// </summary>
     [GeneratedRegex(@"^\| \[(RH\d{4})\]\([^)]+\)\| (?<description>.*?)\| (?<analyzer>[✔❌])\| (?<codeFix>[✔❌])\| (?<formatter>[✔❌])\|$", RegexOptions.CultureInvariant, 100)]
     private static partial Regex PackageRuleRowRegex();
+
+    /// <summary>
+    /// Regex for rule document title headings
+    /// </summary>
+    [GeneratedRegex(@"^# (?<diagnosticId>RH\d{4}) [—-] (?<title>.+?)\s*$", RegexOptions.CultureInvariant, 100)]
+    private static partial Regex RuleDocumentationTitleRegex();
 
     /// <summary>
     /// Regex for diagnostic IDs encoded in formatter test class names
@@ -122,6 +129,40 @@ internal static partial class AnalyzerMetadataDiscovery
     }
 
     /// <summary>
+    /// Parses rule documentation titles from documentation files
+    /// </summary>
+    /// <returns>Parsed rule documentation metadata</returns>
+    internal static IReadOnlyList<RuleDocumentationMetadata> ParseRuleDocumentationTitles()
+    {
+        var ruleDocumentationDirectory = Path.Combine(FindRepositoryRoot(), "documentation", "rules");
+
+        return Directory.EnumerateFiles(ruleDocumentationDirectory, "RH*.md", SearchOption.TopDirectoryOnly)
+                        .Select(ParseRuleDocumentationTitle)
+                        .OrderBy(rule => rule.DiagnosticId, StringComparer.Ordinal)
+                        .ToArray();
+    }
+
+    /// <summary>
+    /// Normalizes a human-readable rule title for metadata comparisons
+    /// </summary>
+    /// <param name="value">Title to normalize</param>
+    /// <returns>Normalized title</returns>
+    internal static string NormalizeRuleTitle(string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        var normalizedValue = value.Normalize(NormalizationForm.FormKC)
+                                   .Replace(@"\<", "<", StringComparison.Ordinal)
+                                   .Replace(@"\>", ">", StringComparison.Ordinal);
+
+        normalizedValue = Regex.Replace(normalizedValue, @"<(?<name>[A-Za-z][A-Za-z0-9]*)\s*/>", "<${name}>", RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100));
+
+        return Regex.Replace(normalizedValue, @"\s+", " ")
+                    .Trim()
+                    .TrimEnd('.');
+    }
+
+    /// <summary>
     /// Creates analyzer metadata from the reflected analyzer type
     /// </summary>
     /// <param name="analyzerType">Analyzer type</param>
@@ -166,6 +207,25 @@ internal static partial class AnalyzerMetadataDiscovery
         return match.Success
                    ? match.Groups[1].Value
                    : throw new InvalidOperationException($"Formatter test class '{formatterTestClass.FullName}' does not start with a diagnostic ID.");
+    }
+
+    /// <summary>
+    /// Parses metadata from a single rule documentation file
+    /// </summary>
+    /// <param name="path">Rule documentation path</param>
+    /// <returns>Parsed rule documentation metadata</returns>
+    private static RuleDocumentationMetadata ParseRuleDocumentationTitle(string path)
+    {
+        var firstLine = File.ReadLines(path).FirstOrDefault()
+                            ?? throw new InvalidOperationException($"Rule documentation '{path}' is empty.");
+        var match = RuleDocumentationTitleRegex().Match(firstLine);
+
+        if (match.Success is false)
+        {
+            throw new InvalidOperationException($"Rule documentation '{path}' must start with a '# RH#### — Title' heading.");
+        }
+
+        return new RuleDocumentationMetadata(match.Groups["diagnosticId"].Value, match.Groups["title"].Value.Trim());
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer.Test/SelfHosting/AnalyzerPackageMetadataTests.cs
+++ b/Reihitsu.Analyzer.Test/SelfHosting/AnalyzerPackageMetadataTests.cs
@@ -118,6 +118,37 @@ public class AnalyzerPackageMetadataTests
     }
 
     /// <summary>
+    /// Verifies the analyzer package README descriptions match the rule documentation titles
+    /// </summary>
+    [TestMethod]
+    public void PackageReadmeDescriptionsMatchRuleDocumentationTitles()
+    {
+        var analyzers = AnalyzerMetadataDiscovery.DiscoverAnalyzers();
+        var packageRules = AnalyzerMetadataDiscovery.ParsePackageReadmeRules();
+        var documentedRules = AnalyzerMetadataDiscovery.ParseRuleDocumentationTitles();
+
+        var mismatches = analyzers.Select(analyzer => new
+                                                      {
+                                                          Analyzer = analyzer,
+                                                          PackageRule = packageRules.SingleOrDefault(rule => rule.DiagnosticId == analyzer.DiagnosticId),
+                                                          DocumentedRule = documentedRules.SingleOrDefault(rule => rule.DiagnosticId == analyzer.DiagnosticId)
+                                                      })
+                                  .Where(entry => entry.PackageRule == null
+                                                  || entry.DocumentedRule == null
+                                                  || string.Equals(AnalyzerMetadataDiscovery.NormalizeRuleTitle(entry.PackageRule.Description),
+                                                                   AnalyzerMetadataDiscovery.NormalizeRuleTitle(entry.DocumentedRule.Title),
+                                                                   StringComparison.OrdinalIgnoreCase) is false)
+                                  .Select(entry => entry.PackageRule == null
+                                                       ? $"{entry.Analyzer.DiagnosticId} ({entry.Analyzer.AnalyzerType.Name}) is missing from the analyzer package README."
+                                                       : entry.DocumentedRule == null
+                                                             ? $"{entry.Analyzer.DiagnosticId} ({entry.Analyzer.AnalyzerType.Name}) is missing rule documentation."
+                                                             : $"{entry.Analyzer.DiagnosticId} ({entry.Analyzer.AnalyzerType.Name}) README description '{entry.PackageRule.Description}' does not match rule title '{entry.DocumentedRule.Title}'.")
+                                  .ToArray();
+
+        Assert.IsEmpty(mismatches, $"The analyzer package README descriptions must match the rule documentation titles.{Environment.NewLine}{string.Join(Environment.NewLine, mismatches)}");
+    }
+
+    /// <summary>
     /// Verifies every analyzer has a matching analyzer unit-test class
     /// </summary>
     [TestMethod]

--- a/Reihitsu.Analyzer.Test/SelfHosting/RuleDocumentationMetadata.cs
+++ b/Reihitsu.Analyzer.Test/SelfHosting/RuleDocumentationMetadata.cs
@@ -1,0 +1,8 @@
+namespace Reihitsu.Analyzer.Test.SelfHosting;
+
+/// <summary>
+/// Parsed rule title metadata from rule documentation
+/// </summary>
+/// <param name="DiagnosticId">Diagnostic ID</param>
+/// <param name="Title">Rule title</param>
+internal sealed record RuleDocumentationMetadata(string DiagnosticId, string Title);


### PR DESCRIPTION
## Summary

- add a self-hosting metadata test that compares analyzer package README rule descriptions with rule documentation titles
- normalize harmless formatting differences and align existing README entries with the rule docs

## Why

The metadata suite already checked rule presence and capability columns, but it did not prevent the human-readable rule titles in the package README from drifting away from the rule documentation.

## Linked issues

Closes #100

## Review notes

The comparison intentionally tolerates minor formatting-only differences such as casing, whitespace, trailing periods, escaped XML tags, and self-closing XML tag variants.

## Follow-up work

None
