### PR TITLE
Broaden string line skipping in formatting analyzers

### DIFF
--- a/Reihitsu.Analyzer.Test/Core/FormattingTextAnalysisUtilitiesTests.cs
+++ b/Reihitsu.Analyzer.Test/Core/FormattingTextAnalysisUtilitiesTests.cs
@@ -1,0 +1,129 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Analyzer.Core;
+
+namespace Reihitsu.Analyzer.Test.Core;
+
+/// <summary>
+/// Unit tests for <see cref="FormattingTextAnalysisUtilities"/>
+/// </summary>
+[TestClass]
+public class FormattingTextAnalysisUtilitiesTests
+{
+    #region Properties
+
+    /// <summary>
+    /// Gets or sets the test context for the current test
+    /// </summary>
+    public TestContext TestContext { get; set; }
+
+    #endregion // Properties
+
+    #region Tests
+
+    /// <summary>
+    /// Verifies that general string line collection covers literals and interpolated variants consistently
+    /// </summary>
+    [TestMethod]
+    public void GetStringLineIndicesReturnsLinesForAllSupportedStringVariants()
+    {
+        const string source = """"
+                              internal class Sample
+                              {
+                                  private static void Test(int value)
+                                  {
+                                      var regular = "regular";
+                                      var utf8 = "utf8"u8;
+                                      var regularInterpolated = $"regular {value}";
+                                      var verbatim = @"line 1
+                                                       line 2";
+                                      var verbatimInterpolated = $@"line {value}
+                                                                    line 2";
+                                      var raw = """
+                                                raw line
+                                                """;
+                                      var rawInterpolated = $$"""
+                                                            raw {{value}}
+                                                            """;
+                                      var singleLineRaw = """single""";
+                                      var singleLineRawInterpolated = $"""value {value}""";
+                                  }
+                              }
+                              """";
+        var syntaxTree = CSharpSyntaxTree.ParseText(source, cancellationToken: TestContext.CancellationToken);
+        var root = syntaxTree.GetRoot(TestContext.CancellationToken);
+        var sourceText = syntaxTree.GetText(TestContext.CancellationToken);
+        var expectedLineIndices = GetLineIndicesForVariables(sourceText,
+                                                             root,
+                                                             "regular",
+                                                             "utf8",
+                                                             "regularInterpolated",
+                                                             "verbatim",
+                                                             "verbatimInterpolated",
+                                                             "raw",
+                                                             "rawInterpolated",
+                                                             "singleLineRaw",
+                                                             "singleLineRawInterpolated");
+        var actualLineIndices = FormattingTextAnalysisUtilities.GetStringLineIndices(root, sourceText);
+
+        CollectionAssert.AreEquivalent(expectedLineIndices.ToArray(), actualLineIndices.ToArray());
+    }
+
+    #endregion // Tests
+
+    #region Methods
+
+    /// <summary>
+    /// Gets the line indices occupied by the initializer spans of the specified variables
+    /// </summary>
+    /// <param name="sourceText">Source text</param>
+    /// <param name="root">Syntax root</param>
+    /// <param name="variableNames">Variable names</param>
+    /// <returns>The occupied line indices</returns>
+    private static HashSet<int> GetLineIndicesForVariables(SourceText sourceText, SyntaxNode root, params string[] variableNames)
+    {
+        var variableNamesSet = new HashSet<string>(variableNames);
+        var lineIndices = new HashSet<int>();
+
+        foreach (var variable in root.DescendantNodes().OfType<VariableDeclaratorSyntax>())
+        {
+            if (variableNamesSet.Contains(variable.Identifier.ValueText) == false)
+            {
+                continue;
+            }
+
+            Assert.IsNotNull(variable.Initializer);
+
+            foreach (var lineIndex in GetIntersectingLineIndices(sourceText, variable.Initializer.Value.FullSpan))
+            {
+                lineIndices.Add(lineIndex);
+            }
+        }
+
+        return lineIndices;
+    }
+
+    /// <summary>
+    /// Gets the line indices touched by the specified span
+    /// </summary>
+    /// <param name="sourceText">Source text</param>
+    /// <param name="span">Span to map</param>
+    /// <returns>The touched line indices</returns>
+    private static IEnumerable<int> GetIntersectingLineIndices(SourceText sourceText, TextSpan span)
+    {
+        var startLineIndex = sourceText.Lines.GetLineFromPosition(span.Start).LineNumber;
+        var endPosition = span.Length == 0 ? span.End : span.End - 1;
+        var endLineIndex = sourceText.Lines.GetLineFromPosition(endPosition).LineNumber;
+
+        return Enumerable.Range(startLineIndex, endLineIndex - startLineIndex + 1);
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Analyzer/Core/FormattingTextAnalysisUtilities.cs
+++ b/Reihitsu.Analyzer/Core/FormattingTextAnalysisUtilities.cs
@@ -62,48 +62,24 @@ internal static class FormattingTextAnalysisUtilities
     }
 
     /// <summary>
-    /// Gets the line indices occupied by multi-line raw strings
-    /// </summary>
-    /// <param name="root">Syntax root</param>
-    /// <param name="sourceText">Source text</param>
-    /// <returns>The occupied line indices</returns>
-    internal static HashSet<int> GetRawStringLineIndices(SyntaxNode root, SourceText sourceText)
-    {
-        var rawStringLineIndices = new HashSet<int>();
-
-        foreach (var token in root.DescendantTokens().Where(currentToken => currentToken.IsKind(SyntaxKind.MultiLineRawStringLiteralToken)))
-        {
-            AddIntersectingLineIndices(rawStringLineIndices, sourceText, token.FullSpan);
-        }
-
-        foreach (var interpolatedString in root.DescendantNodes()
-                                               .OfType<InterpolatedStringExpressionSyntax>()
-                                               .Where(IsRawInterpolatedString))
-        {
-            AddIntersectingLineIndices(rawStringLineIndices, sourceText, interpolatedString.FullSpan);
-        }
-
-        return rawStringLineIndices;
-    }
-
-    /// <summary>
-    /// Gets the line indices occupied by multi-line string literals (including verbatim and raw forms)
+    /// Gets the line indices occupied by raw string literals and interpolated raw strings
     /// </summary>
     /// <param name="root">Syntax root</param>
     /// <param name="sourceText">Source text</param>
     /// <returns>The occupied line indices</returns>
     internal static HashSet<int> GetStringLineIndices(SyntaxNode root, SourceText sourceText)
     {
-        var stringLineIndices = GetRawStringLineIndices(root, sourceText);
+        var stringLineIndices = new HashSet<int>();
 
-        foreach (var token in root.DescendantTokens().Where(obj => obj.IsKind(SyntaxKind.StringLiteralToken) || obj.IsKind(SyntaxKind.Utf8StringLiteralToken)))
+        foreach (var literalExpression in root.DescendantNodes().OfType<LiteralExpressionSyntax>())
         {
-            AddIntersectingLineIndices(stringLineIndices, sourceText, token.FullSpan);
+            if (IsTrackedStringLiteral(literalExpression))
+            {
+                AddIntersectingLineIndices(stringLineIndices, sourceText, literalExpression.FullSpan);
+            }
         }
 
-        foreach (var interpolatedString in root.DescendantNodes()
-                                               .OfType<InterpolatedStringExpressionSyntax>()
-                                               .Where(obj => obj.StringStartToken.IsKind(SyntaxKind.InterpolatedVerbatimStringStartToken)))
+        foreach (var interpolatedString in root.DescendantNodes().OfType<InterpolatedStringExpressionSyntax>())
         {
             AddIntersectingLineIndices(stringLineIndices, sourceText, interpolatedString.FullSpan);
         }
@@ -186,7 +162,23 @@ internal static class FormattingTextAnalysisUtilities
     /// <returns><see langword="true"/> if the string is raw</returns>
     private static bool IsRawInterpolatedString(InterpolatedStringExpressionSyntax interpolatedString)
     {
-        return interpolatedString.StringStartToken.IsKind(SyntaxKind.InterpolatedMultiLineRawStringStartToken);
+        return interpolatedString.StringStartToken.Text.Contains("\"\"\"", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Determines whether the specified literal expression represents a tracked string literal
+    /// </summary>
+    /// <param name="literalExpression">Literal expression</param>
+    /// <returns><see langword="true"/> if the literal should be tracked</returns>
+    private static bool IsTrackedStringLiteral(LiteralExpressionSyntax literalExpression)
+    {
+        if (literalExpression.IsKind(SyntaxKind.StringLiteralExpression) == false
+            && literalExpression.IsKind(SyntaxKind.Utf8StringLiteralExpression) == false)
+        {
+            return false;
+        }
+
+        return true;
     }
 
     #endregion // Methods

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0337DocumentationLinesMustBeginWithSingleSpaceAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0337DocumentationLinesMustBeginWithSingleSpaceAnalyzer.cs
@@ -58,7 +58,7 @@ public class RH0337DocumentationLinesMustBeginWithSingleSpaceAnalyzer : Diagnost
     {
         var root = context.Tree.GetRoot(context.CancellationToken);
         var sourceText = context.Tree.GetText(context.CancellationToken);
-        var rawStringLineIndices = FormattingTextAnalysisUtilities.GetRawStringLineIndices(root, sourceText);
+        var rawStringLineIndices = FormattingTextAnalysisUtilities.GetStringLineIndices(root, sourceText);
 
         for (var lineIndex = 0; lineIndex < sourceText.Lines.Count; lineIndex++)
         {

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0338PreprocessorKeywordsMustNotBePrecededBySpaceAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0338PreprocessorKeywordsMustNotBePrecededBySpaceAnalyzer.cs
@@ -45,7 +45,7 @@ public class RH0338PreprocessorKeywordsMustNotBePrecededBySpaceAnalyzer : Diagno
     {
         var root = context.Tree.GetRoot(context.CancellationToken);
         var sourceText = context.Tree.GetText(context.CancellationToken);
-        var rawStringLineIndices = FormattingTextAnalysisUtilities.GetRawStringLineIndices(root, sourceText);
+        var rawStringLineIndices = FormattingTextAnalysisUtilities.GetStringLineIndices(root, sourceText);
 
         foreach (var line in sourceText.Lines)
         {

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0363OpeningBraceMustNotBeFollowedByBlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0363OpeningBraceMustNotBeFollowedByBlankLineAnalyzer.cs
@@ -45,7 +45,7 @@ public class RH0363OpeningBraceMustNotBeFollowedByBlankLineAnalyzer : Diagnostic
     {
         var root = context.Tree.GetRoot(context.CancellationToken);
         var sourceText = context.Tree.GetText(context.CancellationToken);
-        var rawStringLineIndices = FormattingTextAnalysisUtilities.GetRawStringLineIndices(root, sourceText);
+        var rawStringLineIndices = FormattingTextAnalysisUtilities.GetStringLineIndices(root, sourceText);
 
         for (var lineIndex = 0; lineIndex < sourceText.Lines.Count - 1; lineIndex++)
         {

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0364ElementDocumentationHeadersMustNotBeFollowedByBlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0364ElementDocumentationHeadersMustNotBeFollowedByBlankLineAnalyzer.cs
@@ -45,7 +45,7 @@ public class RH0364ElementDocumentationHeadersMustNotBeFollowedByBlankLineAnalyz
     {
         var root = context.Tree.GetRoot(context.CancellationToken);
         var sourceText = context.Tree.GetText(context.CancellationToken);
-        var rawStringLineIndices = FormattingTextAnalysisUtilities.GetRawStringLineIndices(root, sourceText);
+        var rawStringLineIndices = FormattingTextAnalysisUtilities.GetStringLineIndices(root, sourceText);
 
         var lineIndex = 0;
 

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0366ClosingBraceMustNotBePrecededByBlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0366ClosingBraceMustNotBePrecededByBlankLineAnalyzer.cs
@@ -45,7 +45,7 @@ public class RH0366ClosingBraceMustNotBePrecededByBlankLineAnalyzer : Diagnostic
     {
         var root = context.Tree.GetRoot(context.CancellationToken);
         var sourceText = context.Tree.GetText(context.CancellationToken);
-        var rawStringLineIndices = FormattingTextAnalysisUtilities.GetRawStringLineIndices(root, sourceText);
+        var rawStringLineIndices = FormattingTextAnalysisUtilities.GetStringLineIndices(root, sourceText);
 
         for (var lineIndex = 1; lineIndex < sourceText.Lines.Count; lineIndex++)
         {

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0367OpeningBraceMustNotBePrecededByBlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0367OpeningBraceMustNotBePrecededByBlankLineAnalyzer.cs
@@ -45,7 +45,7 @@ public class RH0367OpeningBraceMustNotBePrecededByBlankLineAnalyzer : Diagnostic
     {
         var root = context.Tree.GetRoot(context.CancellationToken);
         var sourceText = context.Tree.GetText(context.CancellationToken);
-        var rawStringLineIndices = FormattingTextAnalysisUtilities.GetRawStringLineIndices(root, sourceText);
+        var rawStringLineIndices = FormattingTextAnalysisUtilities.GetStringLineIndices(root, sourceText);
 
         for (var lineIndex = 1; lineIndex < sourceText.Lines.Count; lineIndex++)
         {

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0368ChainedStatementBlocksMustNotBePrecededByBlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0368ChainedStatementBlocksMustNotBePrecededByBlankLineAnalyzer.cs
@@ -45,7 +45,7 @@ public class RH0368ChainedStatementBlocksMustNotBePrecededByBlankLineAnalyzer : 
     {
         var root = context.Tree.GetRoot(context.CancellationToken);
         var sourceText = context.Tree.GetText(context.CancellationToken);
-        var rawStringLineIndices = FormattingTextAnalysisUtilities.GetRawStringLineIndices(root, sourceText);
+        var rawStringLineIndices = FormattingTextAnalysisUtilities.GetStringLineIndices(root, sourceText);
 
         for (var lineIndex = 1; lineIndex < sourceText.Lines.Count; lineIndex++)
         {

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0370ElementDocumentationHeaderMustBePrecededByBlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0370ElementDocumentationHeaderMustBePrecededByBlankLineAnalyzer.cs
@@ -45,7 +45,7 @@ public class RH0370ElementDocumentationHeaderMustBePrecededByBlankLineAnalyzer :
     {
         var root = context.Tree.GetRoot(context.CancellationToken);
         var sourceText = context.Tree.GetText(context.CancellationToken);
-        var rawStringLineIndices = FormattingTextAnalysisUtilities.GetRawStringLineIndices(root, sourceText);
+        var rawStringLineIndices = FormattingTextAnalysisUtilities.GetStringLineIndices(root, sourceText);
 
         for (var lineIndex = 1; lineIndex < sourceText.Lines.Count; lineIndex++)
         {


### PR DESCRIPTION
## Summary

Broaden the formatting analyzer string-line skip logic to cover all string forms and remove the separate raw-only helper path.

## Why

Several line-based formatting analyzers should ignore multi-line content embedded in verbatim and interpolated strings just like raw strings. Consolidating on one string-line helper avoids duplicated logic and matches the intended behavior more closely.

## Linked issues

Closes #95

## Review notes

The raw-string-specific helper was removed. The affected analyzers now use the shared string-line collector, and the new core test covers regular, verbatim, UTF-8, raw, and interpolated string variants.

## Follow-up work

None
