### PR TITLE
Fix argument splitting after anonymous object expansion

### DIFF
--- a/Reihitsu.Formatter.Test/Regression/FullPipeline/ArgumentFormattingFullPipelineTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/FullPipeline/ArgumentFormattingFullPipelineTests.cs
@@ -273,6 +273,111 @@ public class ArgumentFormattingFullPipelineTests : FormatterTestsBase
     }
 
     /// <summary>
+    /// Verifies that outer arguments fully split when a nested anonymous object becomes multi-line
+    /// </summary>
+    [TestMethod]
+    public void FormatsArgumentsWhenNestedAnonymousObjectBecomesMultiLine()
+    {
+        const string input = """
+                             internal class NestedAnonymousObjectArgumentTestData
+                             {
+                                 void Method()
+                                 {
+                                     Call("first", Project(new { Alpha = 1, Beta = 2 }), "third");
+                                 }
+
+                                 string Project(object value) => value.ToString();
+
+                                 void Call(string first, string second, string third) { }
+                             }
+                             """;
+
+        const string expected = """
+                                internal class NestedAnonymousObjectArgumentTestData
+                                {
+                                    void Method()
+                                    {
+                                        Call("first",
+                                             Project(new
+                                                     {
+                                                         Alpha = 1,
+                                                         Beta = 2
+                                                     }),
+                                             "third");
+                                    }
+
+                                    string Project(object value)
+                                    {
+                                        return value.ToString();
+                                    }
+
+                                    void Call(string first, string second, string third)
+                                    {
+                                    }
+                                }
+                                """;
+
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that outer arguments fully split when a nested invocation becomes multi-line after child rewrites
+    /// </summary>
+    [TestMethod]
+    public void FormatsOuterArgumentsWhenNestedInvocationBecomesMultiLine()
+    {
+        const string input = """
+                             internal class NestedInvocationArgumentTestData
+                             {
+                                 void Method()
+                                 {
+                                     Outer("first", Inner("prefix", Wrap(new { Alpha = 1, Beta = 2 }), "suffix"), "third");
+                                 }
+
+                                 string Wrap(object value) => value.ToString();
+
+                                 string Inner(string prefix, string value, string suffix) => prefix + value + suffix;
+
+                                 void Outer(string first, string second, string third) { }
+                             }
+                             """;
+
+        const string expected = """
+                                internal class NestedInvocationArgumentTestData
+                                {
+                                    void Method()
+                                    {
+                                        Outer("first",
+                                              Inner("prefix",
+                                                    Wrap(new
+                                                         {
+                                                             Alpha = 1,
+                                                             Beta = 2
+                                                         }),
+                                                    "suffix"),
+                                              "third");
+                                    }
+
+                                    string Wrap(object value)
+                                    {
+                                        return value.ToString();
+                                    }
+
+                                    string Inner(string prefix, string value, string suffix)
+                                    {
+                                        return prefix + value + suffix;
+                                    }
+
+                                    void Outer(string first, string second, string third)
+                                    {
+                                    }
+                                }
+                                """;
+
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
     /// Verifies that method chains with mixed-line arguments are formatted correctly
     /// </summary>
     [TestMethod]

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/LineBreakRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/LineBreakRewriter.cs
@@ -289,7 +289,7 @@ internal sealed class LineBreakRewriter : CSharpSyntaxRewriter
             return node;
         }
 
-        return EnsureSeparatorsHaveEndOfLine(node, node.Arguments, endOfLine);
+        return EnsureSeparatorsHaveEndOfLine(node, node.Arguments, endOfLine, HasMultiLineAnonymousObjectElement(node.Arguments));
     }
 
     /// <summary>
@@ -305,7 +305,7 @@ internal sealed class LineBreakRewriter : CSharpSyntaxRewriter
             return node;
         }
 
-        return EnsureSeparatorsHaveEndOfLine(node, node.Arguments, endOfLine);
+        return EnsureSeparatorsHaveEndOfLine(node, node.Arguments, endOfLine, HasMultiLineAnonymousObjectElement(node.Arguments));
     }
 
     /// <summary>
@@ -321,7 +321,7 @@ internal sealed class LineBreakRewriter : CSharpSyntaxRewriter
             return node;
         }
 
-        return EnsureSeparatorsHaveEndOfLine(node, node.Arguments, endOfLine);
+        return EnsureSeparatorsHaveEndOfLine(node, node.Arguments, endOfLine, HasMultiLineAnonymousObjectElement(node.Arguments));
     }
 
     /// <summary>
@@ -361,7 +361,7 @@ internal sealed class LineBreakRewriter : CSharpSyntaxRewriter
             return node;
         }
 
-        var hasEndOfLine = false;
+        var hasEndOfLine = treatAsMultiLine;
         var tokensToReplace = new List<SyntaxToken>();
         var replacementMap = new Dictionary<SyntaxToken, SyntaxToken>();
 
@@ -668,6 +668,29 @@ internal sealed class LineBreakRewriter : CSharpSyntaxRewriter
         var text = node.GetText();
 
         return text.Lines.Count > 1;
+    }
+
+    /// <summary>
+    /// Determines whether any element in a separated list contains a multi-line anonymous object
+    /// </summary>
+    /// <typeparam name="TElement">The element syntax type</typeparam>
+    /// <param name="list">The separated list to inspect</param>
+    /// <returns><see langword="true"/> if any element contains a multi-line anonymous object; otherwise, <see langword="false"/></returns>
+    private static bool HasMultiLineAnonymousObjectElement<TElement>(SeparatedSyntaxList<TElement> list)
+        where TElement : SyntaxNode
+    {
+        foreach (var element in list)
+        {
+            foreach (var anonymousObject in element.DescendantNodesAndSelf().OfType<AnonymousObjectCreationExpressionSyntax>())
+            {
+                if (IsMultiLine(anonymousObject))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- fix mixed argument layouts after nested anonymous-object expansion
- add regression coverage for direct and nested invocation cases

## Why

Issue #101 reports invocations that stay partially single-line after one argument becomes multiline during formatting. This change makes the formatter split the surrounding argument list consistently while keeping unrelated multiline argument shapes unchanged.

## Linked issues

Closes #101

## Review notes

The fix is intentionally narrow: it only treats an argument list as multiline when an argument contains a multiline anonymous object after child rewrites.

## Follow-up work

None
