### PR TITLE
Add RH0395 switch case break placement rule

### DIFF
--- a/Reihitsu.Analyzer.CodeFixes/CodeFixResources.cs
+++ b/Reihitsu.Analyzer.CodeFixes/CodeFixResources.cs
@@ -469,6 +469,11 @@ internal static class CodeFixResources
     internal static string RH0394Title => GetString(nameof(RH0394Title));
 
     /// <summary>
+    /// Gets the localized string for RH0395Title
+    /// </summary>
+    internal static string RH0395Title => GetString(nameof(RH0395Title));
+
+    /// <summary>
     /// Gets the localized string for RH0334Title
     /// </summary>
     internal static string RH0334Title => GetString(nameof(RH0334Title));

--- a/Reihitsu.Analyzer.CodeFixes/CodeFixResources.resx
+++ b/Reihitsu.Analyzer.CodeFixes/CodeFixResources.resx
@@ -549,6 +549,9 @@
   <data name="RH0394Title" xml:space="preserve">
     <value>Insert blank line after closing brace</value>
   </data>
+  <data name="RH0395Title" xml:space="preserve">
+    <value>Move break statement after explicit switch case block</value>
+  </data>
   <data name="RH0601Title" xml:space="preserve">
     <value>Move constant field</value>
   </data>

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0395BreakStatementsShouldNotBeInsideExplicitSwitchCaseBlocksCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0395BreakStatementsShouldNotBeInsideExplicitSwitchCaseBlocksCodeFixProvider.cs
@@ -1,0 +1,176 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Reihitsu.Analyzer.Rules.Formatting;
+
+/// <summary>
+/// Code fix provider for <see cref="RH0395BreakStatementsShouldNotBeInsideExplicitSwitchCaseBlocksAnalyzer"/>
+/// </summary>
+[Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(RH0395BreakStatementsShouldNotBeInsideExplicitSwitchCaseBlocksCodeFixProvider))]
+public class RH0395BreakStatementsShouldNotBeInsideExplicitSwitchCaseBlocksCodeFixProvider : CodeFixProvider
+{
+    #region Methods
+
+    /// <summary>
+    /// Applies the code fix
+    /// </summary>
+    /// <param name="document">Document</param>
+    /// <param name="breakStatement">Break statement</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The updated document</returns>
+    private static async Task<Document> ApplyCodeFixAsync(Document document, BreakStatementSyntax breakStatement, CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+
+        if (root == null
+            || TryGetFixableNodes(breakStatement, out var block, out var switchSection) == false)
+        {
+            return document;
+        }
+
+        var updatedBreakStatement = breakStatement.WithLeadingTrivia(UpdateLeadingTriviaIndentation(breakStatement.GetLeadingTrivia(), GetIndentationTrivia(sourceText, block.CloseBraceToken)));
+        var updatedBlock = block.WithStatements(block.Statements.Remove(breakStatement));
+        var updatedSwitchSection = switchSection.WithStatements(switchSection.Statements.Replace(block, updatedBlock)
+                                                                                        .Add(updatedBreakStatement));
+
+        return document.WithSyntaxRoot(root.ReplaceNode(switchSection, updatedSwitchSection));
+    }
+
+    /// <summary>
+    /// Gets the indentation trivia from a token's current line
+    /// </summary>
+    /// <param name="sourceText">Source text</param>
+    /// <param name="token">Token</param>
+    /// <returns>The line indentation trivia</returns>
+    private static SyntaxTriviaList GetIndentationTrivia(SourceText sourceText, SyntaxToken token)
+    {
+        var line = sourceText.Lines.GetLineFromPosition(token.SpanStart);
+        var indentation = sourceText.ToString(TextSpan.FromBounds(line.Start, token.SpanStart));
+
+        return string.IsNullOrEmpty(indentation)
+                   ? []
+                   : SyntaxFactory.TriviaList(SyntaxFactory.Whitespace(indentation));
+    }
+
+    /// <summary>
+    /// Tries to get the nodes required for a safe code fix
+    /// </summary>
+    /// <param name="breakStatement">Break statement</param>
+    /// <param name="block">Containing block</param>
+    /// <param name="switchSection">Containing switch section</param>
+    /// <returns><see langword="true"/> if the common fixable pattern was found; otherwise, <see langword="false"/></returns>
+    private static bool TryGetFixableNodes(BreakStatementSyntax breakStatement, out BlockSyntax block, out SwitchSectionSyntax switchSection)
+    {
+        block = null;
+        switchSection = null;
+
+        if (breakStatement.Parent is not BlockSyntax breakBlock
+            || breakBlock.Parent is not SwitchSectionSyntax containingSwitchSection
+            || breakBlock.Statements.Count == 0
+            || breakBlock.Statements[breakBlock.Statements.Count - 1] != breakStatement
+            || containingSwitchSection.Statements.Count == 0
+            || containingSwitchSection.Statements[containingSwitchSection.Statements.Count - 1] != breakBlock)
+        {
+            return false;
+        }
+
+        block = breakBlock;
+        switchSection = containingSwitchSection;
+
+        return true;
+    }
+
+    /// <summary>
+    /// Updates indentation in leading trivia to match the target indentation
+    /// </summary>
+    /// <param name="leadingTrivia">Leading trivia</param>
+    /// <param name="indentationTrivia">Target indentation</param>
+    /// <returns>The updated leading trivia</returns>
+    private static SyntaxTriviaList UpdateLeadingTriviaIndentation(SyntaxTriviaList leadingTrivia, SyntaxTriviaList indentationTrivia)
+    {
+        List<SyntaxTrivia> updatedLeadingTrivia = [];
+        var isAtLineStart = true;
+
+        if (leadingTrivia.Count == 0)
+        {
+            updatedLeadingTrivia.AddRange(indentationTrivia);
+
+            return SyntaxFactory.TriviaList(updatedLeadingTrivia);
+        }
+
+        foreach (var trivia in leadingTrivia)
+        {
+            if (isAtLineStart)
+            {
+                if (trivia.IsKind(SyntaxKind.WhitespaceTrivia))
+                {
+                    updatedLeadingTrivia.AddRange(indentationTrivia);
+                    isAtLineStart = false;
+
+                    continue;
+                }
+
+                if (trivia.IsKind(SyntaxKind.EndOfLineTrivia) == false)
+                {
+                    updatedLeadingTrivia.AddRange(indentationTrivia);
+                    isAtLineStart = false;
+                }
+            }
+
+            updatedLeadingTrivia.Add(trivia);
+            isAtLineStart = trivia.IsKind(SyntaxKind.EndOfLineTrivia);
+        }
+
+        return SyntaxFactory.TriviaList(updatedLeadingTrivia);
+    }
+
+    #endregion // Methods
+
+    #region CodeFixProvider
+
+    /// <inheritdoc/>
+    public sealed override ImmutableArray<string> FixableDiagnosticIds => [RH0395BreakStatementsShouldNotBeInsideExplicitSwitchCaseBlocksAnalyzer.DiagnosticId];
+
+    /// <inheritdoc/>
+    public sealed override FixAllProvider GetFixAllProvider()
+    {
+        return WellKnownFixAllProviders.BatchFixer;
+    }
+
+    /// <inheritdoc/>
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+        if (root != null)
+        {
+            foreach (var diagnostic in context.Diagnostics)
+            {
+                var breakStatement = root.FindToken(diagnostic.Location.SourceSpan.Start).Parent?.FirstAncestorOrSelf<BreakStatementSyntax>();
+
+                if (breakStatement != null
+                    && TryGetFixableNodes(breakStatement, out _, out _))
+                {
+                    context.RegisterCodeFix(CodeAction.Create(CodeFixResources.RH0395Title,
+                                                              token => ApplyCodeFixAsync(context.Document, breakStatement, token),
+                                                              nameof(RH0395BreakStatementsShouldNotBeInsideExplicitSwitchCaseBlocksCodeFixProvider)),
+                                            diagnostic);
+                }
+            }
+        }
+    }
+
+    #endregion // CodeFixProvider
+}

--- a/Reihitsu.Analyzer.Package/README.MD
+++ b/Reihitsu.Analyzer.Package/README.MD
@@ -165,6 +165,7 @@ The **Formatter** column indicates whether running the Reihitsu formatter can au
 | [RH0392](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0392.md)| Statement lambda opening braces should be aligned.| ✔| ✔| ✔|
 | [RH0393](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0393.md)| Local declarations should be preceded by a blank line.| ✔| ✔| ✔|
 | [RH0394](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0394.md)| Blank line after closing brace.| ✔| ✔| ✔|
+| [RH0395](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0395.md)| Break statements should not be inside explicit switch case blocks.| ✔| ✔| ❌|
 || **Documentation**||||
 | [RH0401](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0401.md)| The inheritdoc tag should be used if possible.| ✔| ✔| ❌|
 | [RH0402](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0402.md)| Non-private classes must be documented.| ✔| ❌| ❌|

--- a/Reihitsu.Analyzer.Test/Formatting/RH0395BreakStatementsShouldNotBeInsideExplicitSwitchCaseBlocksAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH0395BreakStatementsShouldNotBeInsideExplicitSwitchCaseBlocksAnalyzerTests.cs
@@ -1,0 +1,280 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Analyzer.Rules.Formatting;
+using Reihitsu.Analyzer.Test.Base;
+
+namespace Reihitsu.Analyzer.Test.Formatting;
+
+/// <summary>
+/// Test methods for <see cref="RH0395BreakStatementsShouldNotBeInsideExplicitSwitchCaseBlocksAnalyzer"/> and <see cref="RH0395BreakStatementsShouldNotBeInsideExplicitSwitchCaseBlocksCodeFixProvider"/>
+/// </summary>
+[TestClass]
+public class RH0395BreakStatementsShouldNotBeInsideExplicitSwitchCaseBlocksAnalyzerTests : AnalyzerTestsBase<RH0395BreakStatementsShouldNotBeInsideExplicitSwitchCaseBlocksAnalyzer, RH0395BreakStatementsShouldNotBeInsideExplicitSwitchCaseBlocksCodeFixProvider>
+{
+    #region Members
+
+    /// <summary>
+    /// Verifies diagnostics are reported when a switch case block ends with a break statement
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticWhenBreakStatementIsInsideExplicitSwitchCaseBlock()
+    {
+        const string testCode = """
+                                internal class RH0395
+                                {
+                                    public void Execute(int value)
+                                    {
+                                        switch (value)
+                                        {
+                                            case 1:
+                                                {
+                                                    Consume();
+                                                    {|#0:break|};
+                                                }
+                                        }
+                                    }
+
+                                    private void Consume()
+                                    {
+                                    }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 internal class RH0395
+                                 {
+                                     public void Execute(int value)
+                                     {
+                                         switch (value)
+                                         {
+                                             case 1:
+                                                 {
+                                                     Consume();
+                                                 }
+                                                 break;
+                                         }
+                                     }
+
+                                     private void Consume()
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH0395BreakStatementsShouldNotBeInsideExplicitSwitchCaseBlocksAnalyzer.DiagnosticId, AnalyzerResources.RH0395MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies the code fix keeps comments attached to the moved break statement
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCodeFixPreservesCommentsWhenMovingBreakStatement()
+    {
+        const string testCode = """
+                                internal class RH0395
+                                {
+                                    public void Execute(int value)
+                                    {
+                                        switch (value)
+                                        {
+                                            case 1:
+                                                {
+                                                    Consume();
+                                                    // Exit this case
+                                                    {|#0:break|}; // trailing comment
+                                                }
+                                        }
+                                    }
+
+                                    private void Consume()
+                                    {
+                                    }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 internal class RH0395
+                                 {
+                                     public void Execute(int value)
+                                     {
+                                         switch (value)
+                                         {
+                                             case 1:
+                                                 {
+                                                     Consume();
+                                                 }
+                                                 // Exit this case
+                                                 break; // trailing comment
+                                         }
+                                     }
+
+                                     private void Consume()
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH0395BreakStatementsShouldNotBeInsideExplicitSwitchCaseBlocksAnalyzer.DiagnosticId, AnalyzerResources.RH0395MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies the code fix does not reformat unrelated switch section layout
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCodeFixDoesNotReformatNonCompliantSwitchSectionLayout()
+    {
+        const string testCode = """
+                                internal class RH0395
+                                {
+                                    public void Execute(int value)
+                                    {
+                                        switch (value)
+                                        {
+                                        case 1:
+                                        {
+                                            Consume();
+                                            {|#0:break|};
+                                        }
+                                        }
+                                    }
+
+                                    private void Consume()
+                                    {
+                                    }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 internal class RH0395
+                                 {
+                                     public void Execute(int value)
+                                     {
+                                         switch (value)
+                                         {
+                                         case 1:
+                                         {
+                                             Consume();
+                                         }
+                                         break;
+                                         }
+                                     }
+
+                                     private void Consume()
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH0395BreakStatementsShouldNotBeInsideExplicitSwitchCaseBlocksAnalyzer.DiagnosticId, AnalyzerResources.RH0395MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies no diagnostics are reported when the break statement already follows the explicit switch case block
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticWhenBreakStatementFollowsExplicitSwitchCaseBlock()
+    {
+        const string testCode = """
+                                internal class RH0395
+                                {
+                                    public void Execute(int value)
+                                    {
+                                        switch (value)
+                                        {
+                                            case 1:
+                                                {
+                                                    Consume();
+                                                }
+                                                break;
+                                        }
+                                    }
+
+                                    private void Consume()
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
+    /// <summary>
+    /// Verifies no diagnostics are reported for break statements inside nested loop blocks
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticWhenBreakStatementBelongsToNestedLoop()
+    {
+        const string testCode = """
+                                internal class RH0395
+                                {
+                                    public void Execute(int value)
+                                    {
+                                        switch (value)
+                                        {
+                                            case 1:
+                                                {
+                                                    while (true) 
+                                                    {
+                                                        break;
+                                                    }
+                                                }
+                                                break;
+                                        }
+                                    }
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
+    /// <summary>
+    /// Verifies no code fix is offered when the break statement is not the last statement in the explicit switch case block
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoCodeFixWhenBreakStatementIsNotLastStatementInExplicitSwitchCaseBlock()
+    {
+        const string testCode = """
+                                internal class RH0395
+                                {
+                                    public void Execute(int value)
+                                    {
+                                        switch (value)
+                                        {
+                                            case 1:
+                                                {
+                                                    break;
+                                                    Consume();
+                                                }
+                                        }
+                                    }
+
+                                    private void Consume()
+                                    {
+                                    }
+                                }
+                                """;
+
+        var actions = await GetCodeFixActionsAsync(testCode,
+                                                   RH0395BreakStatementsShouldNotBeInsideExplicitSwitchCaseBlocksAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<BreakStatementSyntax>()
+                                                               .Single()
+                                                               .BreakKeyword
+                                                               .GetLocation());
+
+        Assert.IsEmpty(actions);
+    }
+
+    #endregion // Members
+}

--- a/Reihitsu.Analyzer/AnalyzerResources.cs
+++ b/Reihitsu.Analyzer/AnalyzerResources.cs
@@ -1045,6 +1045,16 @@ internal static class AnalyzerResources
     internal static string RH0394Title => GetString(nameof(RH0394Title));
 
     /// <summary>
+    /// Gets the localized string for RH0395MessageFormat
+    /// </summary>
+    internal static string RH0395MessageFormat => GetString(nameof(RH0395MessageFormat));
+
+    /// <summary>
+    /// Gets the localized string for RH0395Title
+    /// </summary>
+    internal static string RH0395Title => GetString(nameof(RH0395Title));
+
+    /// <summary>
     /// Gets the localized string for RH0334MessageFormat
     /// </summary>
     internal static string RH0334MessageFormat => GetString(nameof(RH0334MessageFormat));

--- a/Reihitsu.Analyzer/AnalyzerResources.resx
+++ b/Reihitsu.Analyzer/AnalyzerResources.resx
@@ -1113,6 +1113,12 @@
   <data name="RH0394MessageFormat" xml:space="preserve">
     <value>Add a blank line after the closing brace.</value>
   </data>
+  <data name="RH0395Title" xml:space="preserve">
+    <value>Break statements should not be inside explicit switch case blocks.</value>
+  </data>
+  <data name="RH0395MessageFormat" xml:space="preserve">
+    <value>Move the break statement after the explicit switch case block.</value>
+  </data>
    <data name="RH0401MessageFormat" xml:space="preserve">
     <value>The \&lt;inheritdoc/&gt; Tag should be used if possible.</value>
   </data>

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0395BreakStatementsShouldNotBeInsideExplicitSwitchCaseBlocksAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0395BreakStatementsShouldNotBeInsideExplicitSwitchCaseBlocksAnalyzer.cs
@@ -1,0 +1,67 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Enumerations;
+
+namespace Reihitsu.Analyzer.Rules.Formatting;
+
+/// <summary>
+/// RH0395: Break statements should not be inside explicit switch case blocks
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class RH0395BreakStatementsShouldNotBeInsideExplicitSwitchCaseBlocksAnalyzer : DiagnosticAnalyzerBase<RH0395BreakStatementsShouldNotBeInsideExplicitSwitchCaseBlocksAnalyzer>
+{
+    #region Constants
+
+    /// <summary>
+    /// Diagnostic ID
+    /// </summary>
+    public const string DiagnosticId = "RH0395";
+
+    #endregion // Constants
+
+    #region Constructor
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public RH0395BreakStatementsShouldNotBeInsideExplicitSwitchCaseBlocksAnalyzer()
+        : base(DiagnosticId, DiagnosticCategory.Formatting, nameof(AnalyzerResources.RH0395Title), nameof(AnalyzerResources.RH0395MessageFormat))
+    {
+    }
+
+    #endregion // Constructor
+
+    #region Methods
+
+    /// <summary>
+    /// Analyzes break statements
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnBreakStatement(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not BreakStatementSyntax { Parent: BlockSyntax { Parent: SwitchSectionSyntax } } breakStatement)
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(CreateDiagnostic(breakStatement.BreakKeyword.GetLocation()));
+    }
+
+    #endregion // Methods
+
+    #region DiagnosticAnalyzer
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        base.Initialize(context);
+
+        context.RegisterSyntaxNodeAction(OnBreakStatement, SyntaxKind.BreakStatement);
+    }
+
+    #endregion // DiagnosticAnalyzer
+}

--- a/Reihitsu.sln
+++ b/Reihitsu.sln
@@ -174,6 +174,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		documentation\rules\RH0392.md = documentation\rules\RH0392.md
 		documentation\rules\RH0393.md = documentation\rules\RH0393.md
 		documentation\rules\RH0394.md = documentation\rules\RH0394.md
+		documentation\rules\RH0395.md = documentation\rules\RH0395.md
 		documentation\rules\RH0401.md = documentation\rules\RH0401.md
 		documentation\rules\RH0402.md = documentation\rules\RH0402.md
 		documentation\rules\RH0403.md = documentation\rules\RH0403.md

--- a/documentation/rules/RH0395.md
+++ b/documentation/rules/RH0395.md
@@ -1,0 +1,48 @@
+# RH0395 — Break statements should not be inside explicit switch case blocks
+
+| Property | Value |
+|----------|-------|
+| **ID** | RH0395 |
+| **Category** | Formatting |
+| **Severity** | Warning |
+| **Code Fix** | ✓ |
+
+## Description
+
+When a switch case section uses an explicit block for scoping, the terminating `break` should appear after the closing brace, not inside the block.
+
+## Why is this a problem?
+
+Keeping the `break` inside the block makes the case terminator look like part of the scoped block contents. Moving it outside makes it clearer that the block exists for local scope while the `break` terminates the case section.
+
+## How to fix it
+
+Keep the explicit block if it is needed for scoping, but move the final `break` below the closing brace and keep it in the same case section. The code fix does this for the common trailing-`break` pattern.
+
+## Examples
+
+### Violation
+
+```cs
+switch (value)
+{
+    case 1:
+        {
+            var result = GetValue();
+            break;
+        }
+}
+```
+
+### Correction
+
+```cs
+switch (value)
+{
+    case 1:
+        {
+            var result = GetValue();
+        }
+        break;
+}
+```


### PR DESCRIPTION
## Summary

Add analyzer rule RH0395 to require `break;` statements outside explicit switch case blocks, with a targeted code fix and rule documentation.

## Why

Keeping `break;` outside explicit switch case blocks makes the case termination easier to see while still allowing scoped case bodies.

## Linked issues

Closes #111

## Review notes

The code fix intentionally performs only the minimal syntax move and does not run the formatter, so unrelated switch-section layout is preserved.

## Follow-up work

None
