### PR TITLE
Add RH0396 using declaration analyzer

### DIFF
--- a/Reihitsu.Analyzer.CodeFixes/CodeFixResources.cs
+++ b/Reihitsu.Analyzer.CodeFixes/CodeFixResources.cs
@@ -474,6 +474,11 @@ internal static class CodeFixResources
     internal static string RH0395Title => GetString(nameof(RH0395Title));
 
     /// <summary>
+    /// Gets the localized string for RH0396Title
+    /// </summary>
+    internal static string RH0396Title => GetString(nameof(RH0396Title));
+
+    /// <summary>
     /// Gets the localized string for RH0334Title
     /// </summary>
     internal static string RH0334Title => GetString(nameof(RH0334Title));

--- a/Reihitsu.Analyzer.CodeFixes/CodeFixResources.resx
+++ b/Reihitsu.Analyzer.CodeFixes/CodeFixResources.resx
@@ -552,6 +552,9 @@
   <data name="RH0395Title" xml:space="preserve">
     <value>Move break statement after explicit switch case block</value>
   </data>
+  <data name="RH0396Title" xml:space="preserve">
+    <value>Replace with using statement block</value>
+  </data>
   <data name="RH0601Title" xml:space="preserve">
     <value>Move constant field</value>
   </data>

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0396UsingDeclarationsShouldNotBeUsedCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0396UsingDeclarationsShouldNotBeUsedCodeFixProvider.cs
@@ -1,0 +1,112 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+using Reihitsu.Formatter;
+
+namespace Reihitsu.Analyzer.Rules.Formatting;
+
+/// <summary>
+/// Code fix provider for <see cref="RH0396UsingDeclarationsShouldNotBeUsedAnalyzer"/>
+/// </summary>
+[Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(RH0396UsingDeclarationsShouldNotBeUsedCodeFixProvider))]
+public class RH0396UsingDeclarationsShouldNotBeUsedCodeFixProvider : CodeFixProvider
+{
+    #region Methods
+
+    /// <summary>
+    /// Applies the code fix
+    /// </summary>
+    /// <param name="document">Document</param>
+    /// <param name="usingDeclaration">Using declaration</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The updated document</returns>
+    private static async Task<Document> ApplyCodeFixAsync(Document document, LocalDeclarationStatementSyntax usingDeclaration, CancellationToken cancellationToken)
+    {
+        if (usingDeclaration.Parent is not BlockSyntax parentBlock)
+        {
+            return document;
+        }
+
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+        if (root == null)
+        {
+            return document;
+        }
+
+        var statementIndex = parentBlock.Statements.IndexOf(usingDeclaration);
+
+        if (statementIndex < 0)
+        {
+            return document;
+        }
+
+        var followingStatements = parentBlock.Statements.Skip(statementIndex + 1);
+        var formattingAnnotation = new SyntaxAnnotation();
+        var newUsingStatement = SyntaxFactory.UsingStatement(usingDeclaration.Declaration, null, SyntaxFactory.Block(followingStatements))
+                                             .WithAwaitKeyword(usingDeclaration.AwaitKeyword)
+                                             .WithLeadingTrivia(usingDeclaration.GetLeadingTrivia())
+                                             .WithTrailingTrivia(usingDeclaration.GetTrailingTrivia())
+                                             .WithAdditionalAnnotations(formattingAnnotation);
+        var updatedStatements = SyntaxFactory.List(parentBlock.Statements.Take(statementIndex).Concat([newUsingStatement]));
+        var updatedBlock = parentBlock.WithStatements(updatedStatements);
+        var updatedRoot = root.ReplaceNode(parentBlock, updatedBlock);
+        var updatedDocument = document.WithSyntaxRoot(updatedRoot);
+        var formattedRoot = await updatedDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        var formattedUsingStatement = formattedRoot?.GetAnnotatedNodes(formattingAnnotation).OfType<UsingStatementSyntax>().FirstOrDefault();
+
+        return formattedUsingStatement == null
+                   ? updatedDocument
+                   : await ReihitsuFormatter.FormatNodeInDocumentAsync(updatedDocument, formattedUsingStatement, cancellationToken).ConfigureAwait(false);
+    }
+
+    #endregion // Methods
+
+    #region CodeFixProvider
+
+    /// <inheritdoc/>
+    public sealed override ImmutableArray<string> FixableDiagnosticIds => [RH0396UsingDeclarationsShouldNotBeUsedAnalyzer.DiagnosticId];
+
+    /// <inheritdoc/>
+    public sealed override FixAllProvider GetFixAllProvider()
+    {
+        return WellKnownFixAllProviders.BatchFixer;
+    }
+
+    /// <inheritdoc/>
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+        if (root == null)
+        {
+            return;
+        }
+
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var usingDeclaration = root.FindToken(diagnostic.Location.SourceSpan.Start).Parent?.AncestorsAndSelf()
+                                       .OfType<LocalDeclarationStatementSyntax>()
+                                       .FirstOrDefault();
+
+            if (usingDeclaration?.Parent is BlockSyntax)
+            {
+                context.RegisterCodeFix(CodeAction.Create(CodeFixResources.RH0396Title,
+                                                          token => ApplyCodeFixAsync(context.Document, usingDeclaration, token),
+                                                          nameof(RH0396UsingDeclarationsShouldNotBeUsedCodeFixProvider)),
+                                        diagnostic);
+            }
+        }
+    }
+
+    #endregion // CodeFixProvider
+}

--- a/Reihitsu.Analyzer.Package/README.MD
+++ b/Reihitsu.Analyzer.Package/README.MD
@@ -166,6 +166,7 @@ The **Formatter** column indicates whether running the Reihitsu formatter can au
 | [RH0393](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0393.md)| Local declarations should be preceded by a blank line.| ✔| ✔| ✔|
 | [RH0394](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0394.md)| Blank line after closing brace.| ✔| ✔| ✔|
 | [RH0395](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0395.md)| Break statements should not be inside explicit switch case blocks.| ✔| ✔| ❌|
+| [RH0396](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0396.md)| Using declarations should not be used.| ✔| ✔| ❌|
 || **Documentation**||||
 | [RH0401](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0401.md)| The inheritdoc tag should be used if possible.| ✔| ✔| ❌|
 | [RH0402](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0402.md)| Non-private classes must be documented.| ✔| ❌| ❌|

--- a/Reihitsu.Analyzer.Test/Formatting/RH0396UsingDeclarationsShouldNotBeUsedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH0396UsingDeclarationsShouldNotBeUsedAnalyzerTests.cs
@@ -1,0 +1,273 @@
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Analyzer.Rules.Formatting;
+using Reihitsu.Analyzer.Test.Base;
+
+namespace Reihitsu.Analyzer.Test.Formatting;
+
+/// <summary>
+/// Test methods for <see cref="RH0396UsingDeclarationsShouldNotBeUsedAnalyzer"/> and <see cref="RH0396UsingDeclarationsShouldNotBeUsedCodeFixProvider"/>
+/// </summary>
+[TestClass]
+public class RH0396UsingDeclarationsShouldNotBeUsedAnalyzerTests : AnalyzerTestsBase<RH0396UsingDeclarationsShouldNotBeUsedAnalyzer, RH0396UsingDeclarationsShouldNotBeUsedCodeFixProvider>
+{
+    #region Members
+
+    /// <summary>
+    /// Verifies a diagnostic is reported when a using declaration is used
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticWhenUsingDeclarationIsUsed()
+    {
+        const string testCode = """
+                                using System.IO;
+
+                                internal class RH0396
+                                {
+                                    public void Execute()
+                                    {
+                                        {|#0:using|} var stream = new MemoryStream();
+                                        _ = stream;
+                                    }
+                                }
+                                """;
+
+        await Verify(testCode, Diagnostics(RH0396UsingDeclarationsShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH0396MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies a diagnostic is reported when a using declaration uses an explicit type
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticWhenUsingDeclarationIsUsedWithExplicitType()
+    {
+        const string testCode = """
+                                using System.IO;
+
+                                internal class RH0396
+                                {
+                                    public void Execute()
+                                    {
+                                        {|#0:using|} System.IO.MemoryStream stream = new MemoryStream();
+                                        _ = stream;
+                                    }
+                                }
+                                """;
+
+        await Verify(testCode, Diagnostics(RH0396UsingDeclarationsShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH0396MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies diagnostics are reported for multiple using declarations
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticWhenMultipleUsingDeclarationsArePresent()
+    {
+        const string testCode = """
+                                using System.IO;
+
+                                internal class RH0396
+                                {
+                                    public void Execute()
+                                    {
+                                        {|#0:using|} var first = new MemoryStream();
+                                        {|#1:using|} var second = new MemoryStream();
+                                        _ = first;
+                                        _ = second;
+                                    }
+                                }
+                                """;
+
+        await Verify(testCode, Diagnostics(RH0396UsingDeclarationsShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH0396MessageFormat, 2));
+    }
+
+    /// <summary>
+    /// Verifies no diagnostic is reported when a using statement block is used
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticWhenUsingStatementBlockIsUsed()
+    {
+        const string testCode = """
+                                using System.IO;
+
+                                internal class RH0396
+                                {
+                                    public void Execute()
+                                    {
+                                        using (var stream = new MemoryStream())
+                                        {
+                                            _ = stream;
+                                        }
+                                    }
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
+    /// <summary>
+    /// Verifies no diagnostic is reported when a using directive is used
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticWhenUsingDirectiveIsUsed()
+    {
+        const string testCode = """
+                                using System;
+
+                                internal class RH0396
+                                {
+                                    public void Execute()
+                                    {
+                                        Console.WriteLine(string.Empty);
+                                    }
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
+    /// <summary>
+    /// Verifies the code fix transforms a using declaration into a using statement block
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCodeFixTransformsUsingDeclarationToUsingStatementBlock()
+    {
+        const string testCode = """
+                                using System.IO;
+
+                                internal class RH0396
+                                {
+                                    public void Execute()
+                                    {
+                                        {|#0:using|} var stream = new MemoryStream();
+                                        Consume(stream);
+                                    }
+
+                                    private void Consume(MemoryStream stream)
+                                    {
+                                    }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 using System.IO;
+
+                                 internal class RH0396
+                                 {
+                                     public void Execute()
+                                     {
+                                         using (var stream = new MemoryStream())
+                                         {
+                                             Consume(stream);
+                                         }
+                                     }
+
+                                     private void Consume(MemoryStream stream)
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH0396UsingDeclarationsShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH0396MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies the code fix creates an empty using statement block when no statements follow
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCodeFixTransformsUsingDeclarationWithNoFollowingStatements()
+    {
+        const string testCode = """
+                                using System.IO;
+
+                                internal class RH0396
+                                {
+                                    public void Execute()
+                                    {
+                                        {|#0:using|} var stream = new MemoryStream();
+                                    }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 using System.IO;
+
+                                 internal class RH0396
+                                 {
+                                     public void Execute()
+                                     {
+                                         using (var stream = new MemoryStream())
+                                         {
+                                         }
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH0396UsingDeclarationsShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH0396MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies the code fix moves multiple following statements into the using statement block
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCodeFixTransformsUsingDeclarationWithMultipleFollowingStatements()
+    {
+        const string testCode = """
+                                using System;
+                                using System.IO;
+
+                                internal class RH0396
+                                {
+                                    public void Execute()
+                                    {
+                                        var value = 0;
+                                        {|#0:using|} var stream = new MemoryStream();
+                                        Consume(stream);
+                                        value++;
+                                        Console.WriteLine(value);
+                                    }
+
+                                    private void Consume(MemoryStream stream)
+                                    {
+                                    }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 using System;
+                                 using System.IO;
+
+                                 internal class RH0396
+                                 {
+                                     public void Execute()
+                                     {
+                                         var value = 0;
+                                         using (var stream = new MemoryStream())
+                                         {
+                                             Consume(stream);
+                                             value++;
+                                             Console.WriteLine(value);
+                                         }
+                                     }
+
+                                     private void Consume(MemoryStream stream)
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH0396UsingDeclarationsShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH0396MessageFormat));
+    }
+
+    #endregion // Members
+}

--- a/Reihitsu.Analyzer/AnalyzerResources.cs
+++ b/Reihitsu.Analyzer/AnalyzerResources.cs
@@ -1055,6 +1055,16 @@ internal static class AnalyzerResources
     internal static string RH0395Title => GetString(nameof(RH0395Title));
 
     /// <summary>
+    /// Gets the localized string for RH0396MessageFormat
+    /// </summary>
+    internal static string RH0396MessageFormat => GetString(nameof(RH0396MessageFormat));
+
+    /// <summary>
+    /// Gets the localized string for RH0396Title
+    /// </summary>
+    internal static string RH0396Title => GetString(nameof(RH0396Title));
+
+    /// <summary>
     /// Gets the localized string for RH0334MessageFormat
     /// </summary>
     internal static string RH0334MessageFormat => GetString(nameof(RH0334MessageFormat));

--- a/Reihitsu.Analyzer/AnalyzerResources.resx
+++ b/Reihitsu.Analyzer/AnalyzerResources.resx
@@ -1119,6 +1119,12 @@
   <data name="RH0395MessageFormat" xml:space="preserve">
     <value>Move the break statement after the explicit switch case block.</value>
   </data>
+  <data name="RH0396Title" xml:space="preserve">
+    <value>Using declarations should not be used</value>
+  </data>
+  <data name="RH0396MessageFormat" xml:space="preserve">
+    <value>Replace the using declaration with a using statement block.</value>
+  </data>
    <data name="RH0401MessageFormat" xml:space="preserve">
     <value>The \&lt;inheritdoc/&gt; Tag should be used if possible.</value>
   </data>

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0396UsingDeclarationsShouldNotBeUsedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0396UsingDeclarationsShouldNotBeUsedAnalyzer.cs
@@ -1,0 +1,67 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Enumerations;
+
+namespace Reihitsu.Analyzer.Rules.Formatting;
+
+/// <summary>
+/// RH0396: Using declarations should not be used
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class RH0396UsingDeclarationsShouldNotBeUsedAnalyzer : DiagnosticAnalyzerBase<RH0396UsingDeclarationsShouldNotBeUsedAnalyzer>
+{
+    #region Constants
+
+    /// <summary>
+    /// Diagnostic ID
+    /// </summary>
+    public const string DiagnosticId = "RH0396";
+
+    #endregion // Constants
+
+    #region Constructor
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public RH0396UsingDeclarationsShouldNotBeUsedAnalyzer()
+        : base(DiagnosticId, DiagnosticCategory.Formatting, nameof(AnalyzerResources.RH0396Title), nameof(AnalyzerResources.RH0396MessageFormat))
+    {
+    }
+
+    #endregion // Constructor
+
+    #region Methods
+
+    /// <summary>
+    /// Analyzes local declarations
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnLocalDeclarationStatement(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not LocalDeclarationStatementSyntax { IsConst: false, UsingKeyword.RawKind: not 0 } usingDeclaration)
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(CreateDiagnostic(usingDeclaration.UsingKeyword.GetLocation()));
+    }
+
+    #endregion // Methods
+
+    #region DiagnosticAnalyzer
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        base.Initialize(context);
+
+        context.RegisterSyntaxNodeAction(OnLocalDeclarationStatement, SyntaxKind.LocalDeclarationStatement);
+    }
+
+    #endregion // DiagnosticAnalyzer
+}

--- a/Reihitsu.sln
+++ b/Reihitsu.sln
@@ -175,6 +175,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		documentation\rules\RH0393.md = documentation\rules\RH0393.md
 		documentation\rules\RH0394.md = documentation\rules\RH0394.md
 		documentation\rules\RH0395.md = documentation\rules\RH0395.md
+		documentation\rules\RH0396.md = documentation\rules\RH0396.md
 		documentation\rules\RH0401.md = documentation\rules\RH0401.md
 		documentation\rules\RH0402.md = documentation\rules\RH0402.md
 		documentation\rules\RH0403.md = documentation\rules\RH0403.md

--- a/documentation/rules/RH0396.md
+++ b/documentation/rules/RH0396.md
@@ -1,0 +1,42 @@
+# RH0396 — Using declarations should not be used
+
+| Property | Value |
+|----------|-------|
+| **ID** | RH0396 |
+| **Category** | Formatting |
+| **Severity** | Warning |
+| **Code Fix** | ✓ |
+
+## Description
+
+Using declarations such as `using var resource = ...;` should not be used. Prefer a `using` statement block with braces instead.
+
+## Why is this a problem?
+
+Using declarations extend the lifetime of the disposable resource to the end of the current scope. That makes the disposal point less obvious when reading the method.
+
+A `using` statement block makes the lifetime explicit. It is easier to see which statements run while the resource is still in scope and where disposal happens.
+
+## How to fix it
+
+Replace the using declaration with a `using` statement block and move the relevant statements into that block.
+
+Use the smallest block that clearly defines the lifetime of the disposable resource.
+
+## Examples
+
+### Violation
+
+```cs
+using var stream = new MemoryStream();
+Read(stream);
+```
+
+### Correction
+
+```cs
+using (var stream = new MemoryStream())
+{
+    Read(stream);
+}
+```


### PR DESCRIPTION
## Summary

Add RH0396 to disallow using declarations and provide a code fix that rewrites them as explicit `using (...) { ... }` blocks.

## Why

Using declarations hide the disposal boundary in the surrounding scope. Requiring a braced using statement makes the lifetime of disposable resources explicit and easier to review.

## Linked issues

Closes #97

## Review notes

The analyzer only reports local using declarations and does not flag existing `using (...)` statements. The code fix is intentionally limited to declarations inside a block so it can safely move following sibling statements into the new using block and then delegate final layout to the formatter.

## Follow-up work

None
