### PR TITLE
Add RH0397 region description analyzer

### DIFF
--- a/Reihitsu.Analyzer.Package/README.MD
+++ b/Reihitsu.Analyzer.Package/README.MD
@@ -167,6 +167,7 @@ The **Formatter** column indicates whether running the Reihitsu formatter can au
 | [RH0394](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0394.md)| Blank line after closing brace.| ✔| ✔| ✔|
 | [RH0395](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0395.md)| Break statements should not be inside explicit switch case blocks.| ✔| ✔| ❌|
 | [RH0396](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0396.md)| Using declarations should not be used.| ✔| ✔| ❌|
+| [RH0397](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0397.md)| Region descriptions should not be Member or Members.| ✔| ❌| ❌|
 || **Documentation**||||
 | [RH0401](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0401.md)| The inheritdoc tag should be used if possible.| ✔| ✔| ❌|
 | [RH0402](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0402.md)| Non-private classes must be documented.| ✔| ❌| ❌|

--- a/Reihitsu.Analyzer.Test/Formatting/RH0397RegionDescriptionsShouldNotBeMemberOrMembersAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH0397RegionDescriptionsShouldNotBeMemberOrMembersAnalyzerTests.cs
@@ -1,0 +1,111 @@
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Analyzer.Rules.Formatting;
+using Reihitsu.Analyzer.Test.Base;
+
+namespace Reihitsu.Analyzer.Test.Formatting;
+
+/// <summary>
+/// Test methods for <see cref="RH0397RegionDescriptionsShouldNotBeMemberOrMembersAnalyzer"/>
+/// </summary>
+[TestClass]
+public class RH0397RegionDescriptionsShouldNotBeMemberOrMembersAnalyzerTests : AnalyzerTestsBase<RH0397RegionDescriptionsShouldNotBeMemberOrMembersAnalyzer>
+{
+    #region Members
+
+    /// <summary>
+    /// Verifies that descriptive region labels do not produce diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForDescriptiveRegionLabels()
+    {
+        const string testData = """
+                                internal class Example
+                                {
+                                    #region Methods
+
+                                    internal void DoWork()
+                                    {
+                                    }
+
+                                    #endregion // Methods
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that region descriptions equal to Member are detected
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyRegionDescriptionEqualToMemberIsDetected()
+    {
+        const string testData = """
+                                internal class Example
+                                {
+                                    {|#0:#region Member|}
+
+                                    internal void DoWork()
+                                    {
+                                    }
+
+                                    #endregion // Methods
+                                }
+                                """;
+
+        await Verify(testData, Diagnostics(RH0397RegionDescriptionsShouldNotBeMemberOrMembersAnalyzer.DiagnosticId, AnalyzerResources.RH0397MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that endregion descriptions equal to Members are detected case-insensitively
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyEndRegionDescriptionEqualToMembersIsDetectedCaseInsensitively()
+    {
+        const string testData = """
+                                internal class Example
+                                {
+                                    #region Methods
+
+                                    internal void DoWork()
+                                    {
+                                    }
+
+                                    {|#0:#endregion // mEmBeRs|}
+                                }
+                                """;
+
+        await Verify(testData, Diagnostics(RH0397RegionDescriptionsShouldNotBeMemberOrMembersAnalyzer.DiagnosticId, AnalyzerResources.RH0397MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that longer descriptions containing the forbidden words are ignored
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyLongerDescriptionsContainingForbiddenWordsAreIgnored()
+    {
+        const string testData = """
+                                internal class Example
+                                {
+                                    #region Member helpers
+
+                                    internal void DoWork()
+                                    {
+                                    }
+
+                                    #endregion // Members of Example
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    #endregion // Members
+}

--- a/Reihitsu.Analyzer/AnalyzerResources.cs
+++ b/Reihitsu.Analyzer/AnalyzerResources.cs
@@ -1065,6 +1065,16 @@ internal static class AnalyzerResources
     internal static string RH0396Title => GetString(nameof(RH0396Title));
 
     /// <summary>
+    /// Gets the localized string for RH0397MessageFormat
+    /// </summary>
+    internal static string RH0397MessageFormat => GetString(nameof(RH0397MessageFormat));
+
+    /// <summary>
+    /// Gets the localized string for RH0397Title
+    /// </summary>
+    internal static string RH0397Title => GetString(nameof(RH0397Title));
+
+    /// <summary>
     /// Gets the localized string for RH0334MessageFormat
     /// </summary>
     internal static string RH0334MessageFormat => GetString(nameof(RH0334MessageFormat));

--- a/Reihitsu.Analyzer/AnalyzerResources.resx
+++ b/Reihitsu.Analyzer/AnalyzerResources.resx
@@ -1125,6 +1125,12 @@
   <data name="RH0396MessageFormat" xml:space="preserve">
     <value>Replace the using declaration with a using statement block.</value>
   </data>
+  <data name="RH0397Title" xml:space="preserve">
+    <value>Region descriptions should not be Member or Members</value>
+  </data>
+  <data name="RH0397MessageFormat" xml:space="preserve">
+    <value>Use a more descriptive region description than 'Member' or 'Members'.</value>
+  </data>
    <data name="RH0401MessageFormat" xml:space="preserve">
     <value>The \&lt;inheritdoc/&gt; Tag should be used if possible.</value>
   </data>

--- a/Reihitsu.Analyzer/Base/RegionDescriptionAnalyzerBase{TAnalyzer}.cs
+++ b/Reihitsu.Analyzer/Base/RegionDescriptionAnalyzerBase{TAnalyzer}.cs
@@ -1,0 +1,114 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using Reihitsu.Analyzer.Enumerations;
+
+namespace Reihitsu.Analyzer.Base;
+
+/// <summary>
+/// Base class for analyzers that validate region descriptions
+/// </summary>
+/// <typeparam name="TAnalyzer">Type of the analyzer</typeparam>
+public abstract class RegionDescriptionAnalyzerBase<TAnalyzer> : DiagnosticAnalyzerBase<TAnalyzer>
+    where TAnalyzer : DiagnosticAnalyzer
+{
+    #region Constructor
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    /// <param name="diagnosticId">Diagnostic ID</param>
+    /// <param name="category">Category</param>
+    /// <param name="titleResourceName">Resource name of the title</param>
+    /// <param name="messageFormatResourceName">Resource name of the message format</param>
+    private protected RegionDescriptionAnalyzerBase(string diagnosticId, DiagnosticCategory category, string titleResourceName, string messageFormatResourceName)
+        : base(diagnosticId, category, titleResourceName, messageFormatResourceName)
+    {
+    }
+
+    #endregion // Constructor
+
+    #region Methods
+
+    /// <summary>
+    /// Gets the description of an endregion directive
+    /// </summary>
+    /// <param name="directive">Directive</param>
+    /// <returns>Description text</returns>
+    private static string GetEndRegionDescription(EndRegionDirectiveTriviaSyntax directive)
+    {
+        var description = (directive.EndRegionKeyword.TrailingTrivia.ToFullString()
+                           + directive.EndOfDirectiveToken.LeadingTrivia.ToFullString()).Trim();
+
+        if (description.StartsWith("//", StringComparison.Ordinal))
+        {
+            description = description.Substring(2).TrimStart();
+        }
+
+        return description;
+    }
+
+    /// <summary>
+    /// Gets the description of a region directive
+    /// </summary>
+    /// <param name="directive">Directive</param>
+    /// <returns>Description text</returns>
+    private static string GetRegionDescription(RegionDirectiveTriviaSyntax directive)
+    {
+        var messageTrivia = directive.EndOfDirectiveToken.LeadingTrivia.FirstOrDefault(static trivia => trivia.IsKind(SyntaxKind.PreprocessingMessageTrivia));
+
+        return messageTrivia == default
+                   ? string.Empty
+                   : messageTrivia.ToString().Trim();
+    }
+
+    /// <summary>
+    /// Determines whether the specified description violates the rule
+    /// </summary>
+    /// <param name="description">Description to inspect</param>
+    /// <returns><see langword="true"/> if the description violates the rule</returns>
+    protected abstract bool IsInvalidDescription(string description);
+
+    /// <summary>
+    /// Analyzes endregion directives
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnEndRegion(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is EndRegionDirectiveTriviaSyntax node
+            && IsInvalidDescription(GetEndRegionDescription(node)))
+        {
+            context.ReportDiagnostic(CreateDiagnostic(node.GetLocation()));
+        }
+    }
+
+    /// <summary>
+    /// Analyzes region directives
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnRegion(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is RegionDirectiveTriviaSyntax node
+            && IsInvalidDescription(GetRegionDescription(node)))
+        {
+            context.ReportDiagnostic(CreateDiagnostic(node.GetLocation()));
+        }
+    }
+
+    #endregion // Methods
+
+    #region DiagnosticAnalyzer
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        base.Initialize(context);
+
+        context.RegisterSyntaxNodeAction(OnRegion, SyntaxKind.RegionDirectiveTrivia);
+        context.RegisterSyntaxNodeAction(OnEndRegion, SyntaxKind.EndRegionDirectiveTrivia);
+    }
+
+    #endregion // DiagnosticAnalyzer
+}

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0388RegionDescriptionsShouldNotEndWithImplementationAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0388RegionDescriptionsShouldNotEndWithImplementationAnalyzer.cs
@@ -1,6 +1,4 @@
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 using Reihitsu.Analyzer.Base;
@@ -12,7 +10,7 @@ namespace Reihitsu.Analyzer.Rules.Formatting;
 /// Region descriptions should not end with implementation
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class RH0388RegionDescriptionsShouldNotEndWithImplementationAnalyzer : DiagnosticAnalyzerBase<RH0388RegionDescriptionsShouldNotEndWithImplementationAnalyzer>
+public class RH0388RegionDescriptionsShouldNotEndWithImplementationAnalyzer : RegionDescriptionAnalyzerBase<RH0388RegionDescriptionsShouldNotEndWithImplementationAnalyzer>
 {
     #region Constants
 
@@ -60,76 +58,11 @@ public class RH0388RegionDescriptionsShouldNotEndWithImplementationAnalyzer : Di
                || char.IsWhiteSpace(trimmedDescription[trimmedDescription.Length - ForbiddenSuffix.Length - 1]);
     }
 
-    /// <summary>
-    /// Gets the description of an endregion directive
-    /// </summary>
-    /// <param name="directive">Directive</param>
-    /// <returns>Description text</returns>
-    private static string GetEndRegionDescription(EndRegionDirectiveTriviaSyntax directive)
+    /// <inheritdoc/>
+    protected override bool IsInvalidDescription(string description)
     {
-        var description = (directive.EndRegionKeyword.TrailingTrivia.ToFullString()
-                           + directive.EndOfDirectiveToken.LeadingTrivia.ToFullString()).Trim();
-
-        if (description.StartsWith("//", StringComparison.Ordinal))
-        {
-            description = description.Substring(2).TrimStart();
-        }
-
-        return description;
-    }
-
-    /// <summary>
-    /// Gets the description of a region directive
-    /// </summary>
-    /// <param name="directive">Directive</param>
-    /// <returns>Description text</returns>
-    private static string GetRegionDescription(RegionDirectiveTriviaSyntax directive)
-    {
-        var messageTrivia = directive.EndOfDirectiveToken.LeadingTrivia.FirstOrDefault(static trivia => trivia.IsKind(SyntaxKind.PreprocessingMessageTrivia));
-
-        return messageTrivia == default
-                   ? string.Empty
-                   : messageTrivia.ToString().Trim();
-    }
-
-    /// <summary>
-    /// Analyzes endregion directives
-    /// </summary>
-    /// <param name="context">Context</param>
-    private void OnEndRegion(SyntaxNodeAnalysisContext context)
-    {
-        if (context.Node is EndRegionDirectiveTriviaSyntax node
-            && EndsWithForbiddenSuffix(GetEndRegionDescription(node)))
-        {
-            context.ReportDiagnostic(CreateDiagnostic(node.GetLocation()));
-        }
-    }
-
-    /// <summary>
-    /// Analyzes region directives
-    /// </summary>
-    /// <param name="context">Context</param>
-    private void OnRegion(SyntaxNodeAnalysisContext context)
-    {
-        if (context.Node is RegionDirectiveTriviaSyntax node
-            && EndsWithForbiddenSuffix(GetRegionDescription(node)))
-        {
-            context.ReportDiagnostic(CreateDiagnostic(node.GetLocation()));
-        }
+        return EndsWithForbiddenSuffix(description);
     }
 
     #endregion // Methods
-
-    #region DiagnosticAnalyzer
-
-    /// <inheritdoc/>
-    public override void Initialize(AnalysisContext context)
-    {
-        base.Initialize(context);
-
-        context.RegisterSyntaxNodeAction(OnRegion, SyntaxKind.RegionDirectiveTrivia);
-        context.RegisterSyntaxNodeAction(OnEndRegion, SyntaxKind.EndRegionDirectiveTrivia);
-    }
-
-    #endregion // DiagnosticAnalyzer
 }

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0397RegionDescriptionsShouldNotBeMemberOrMembersAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0397RegionDescriptionsShouldNotBeMemberOrMembersAnalyzer.cs
@@ -1,0 +1,123 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Enumerations;
+
+namespace Reihitsu.Analyzer.Rules.Formatting;
+
+/// <summary>
+/// RH0397: Region descriptions should not be Member or Members
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class RH0397RegionDescriptionsShouldNotBeMemberOrMembersAnalyzer : DiagnosticAnalyzerBase<RH0397RegionDescriptionsShouldNotBeMemberOrMembersAnalyzer>
+{
+    #region Constants
+
+    /// <summary>
+    /// Diagnostic ID
+    /// </summary>
+    public const string DiagnosticId = "RH0397";
+
+    #endregion // Constants
+
+    #region Constructor
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public RH0397RegionDescriptionsShouldNotBeMemberOrMembersAnalyzer()
+        : base(DiagnosticId, DiagnosticCategory.Formatting, nameof(AnalyzerResources.RH0397Title), nameof(AnalyzerResources.RH0397MessageFormat))
+    {
+    }
+
+    #endregion // Constructor
+
+    #region Methods
+
+    /// <summary>
+    /// Gets the description of an endregion directive
+    /// </summary>
+    /// <param name="directive">Directive</param>
+    /// <returns>Description text</returns>
+    private static string GetEndRegionDescription(EndRegionDirectiveTriviaSyntax directive)
+    {
+        var description = (directive.EndRegionKeyword.TrailingTrivia.ToFullString()
+                           + directive.EndOfDirectiveToken.LeadingTrivia.ToFullString()).Trim();
+
+        if (description.StartsWith("//", StringComparison.Ordinal))
+        {
+            description = description.Substring(2).TrimStart();
+        }
+
+        return description;
+    }
+
+    /// <summary>
+    /// Gets the description of a region directive
+    /// </summary>
+    /// <param name="directive">Directive</param>
+    /// <returns>Description text</returns>
+    private static string GetRegionDescription(RegionDirectiveTriviaSyntax directive)
+    {
+        var messageTrivia = directive.EndOfDirectiveToken.LeadingTrivia.FirstOrDefault(static trivia => trivia.IsKind(SyntaxKind.PreprocessingMessageTrivia));
+
+        return messageTrivia == default
+                   ? string.Empty
+                   : messageTrivia.ToString().Trim();
+    }
+
+    /// <summary>
+    /// Determines whether the provided description is forbidden
+    /// </summary>
+    /// <param name="description">Description</param>
+    /// <returns><see langword="true"/> if the description is forbidden</returns>
+    private static bool IsForbiddenDescription(string description)
+    {
+        return description.Equals("Member", StringComparison.OrdinalIgnoreCase)
+               || description.Equals("Members", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Analyzes endregion directives
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnEndRegion(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is EndRegionDirectiveTriviaSyntax node
+            && IsForbiddenDescription(GetEndRegionDescription(node)))
+        {
+            context.ReportDiagnostic(CreateDiagnostic(node.GetLocation()));
+        }
+    }
+
+    /// <summary>
+    /// Analyzes region directives
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnRegion(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is RegionDirectiveTriviaSyntax node
+            && IsForbiddenDescription(GetRegionDescription(node)))
+        {
+            context.ReportDiagnostic(CreateDiagnostic(node.GetLocation()));
+        }
+    }
+
+    #endregion // Methods
+
+    #region DiagnosticAnalyzer
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        base.Initialize(context);
+
+        context.RegisterSyntaxNodeAction(OnRegion, SyntaxKind.RegionDirectiveTrivia);
+        context.RegisterSyntaxNodeAction(OnEndRegion, SyntaxKind.EndRegionDirectiveTrivia);
+    }
+
+    #endregion // DiagnosticAnalyzer
+}

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0397RegionDescriptionsShouldNotBeMemberOrMembersAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0397RegionDescriptionsShouldNotBeMemberOrMembersAnalyzer.cs
@@ -1,6 +1,4 @@
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 using Reihitsu.Analyzer.Base;
@@ -12,7 +10,7 @@ namespace Reihitsu.Analyzer.Rules.Formatting;
 /// RH0397: Region descriptions should not be Member or Members
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class RH0397RegionDescriptionsShouldNotBeMemberOrMembersAnalyzer : DiagnosticAnalyzerBase<RH0397RegionDescriptionsShouldNotBeMemberOrMembersAnalyzer>
+public class RH0397RegionDescriptionsShouldNotBeMemberOrMembersAnalyzer : RegionDescriptionAnalyzerBase<RH0397RegionDescriptionsShouldNotBeMemberOrMembersAnalyzer>
 {
     #region Constants
 
@@ -38,38 +36,6 @@ public class RH0397RegionDescriptionsShouldNotBeMemberOrMembersAnalyzer : Diagno
     #region Methods
 
     /// <summary>
-    /// Gets the description of an endregion directive
-    /// </summary>
-    /// <param name="directive">Directive</param>
-    /// <returns>Description text</returns>
-    private static string GetEndRegionDescription(EndRegionDirectiveTriviaSyntax directive)
-    {
-        var description = (directive.EndRegionKeyword.TrailingTrivia.ToFullString()
-                           + directive.EndOfDirectiveToken.LeadingTrivia.ToFullString()).Trim();
-
-        if (description.StartsWith("//", StringComparison.Ordinal))
-        {
-            description = description.Substring(2).TrimStart();
-        }
-
-        return description;
-    }
-
-    /// <summary>
-    /// Gets the description of a region directive
-    /// </summary>
-    /// <param name="directive">Directive</param>
-    /// <returns>Description text</returns>
-    private static string GetRegionDescription(RegionDirectiveTriviaSyntax directive)
-    {
-        var messageTrivia = directive.EndOfDirectiveToken.LeadingTrivia.FirstOrDefault(static trivia => trivia.IsKind(SyntaxKind.PreprocessingMessageTrivia));
-
-        return messageTrivia == default
-                   ? string.Empty
-                   : messageTrivia.ToString().Trim();
-    }
-
-    /// <summary>
     /// Determines whether the provided description is forbidden
     /// </summary>
     /// <param name="description">Description</param>
@@ -80,44 +46,11 @@ public class RH0397RegionDescriptionsShouldNotBeMemberOrMembersAnalyzer : Diagno
                || description.Equals("Members", StringComparison.OrdinalIgnoreCase);
     }
 
-    /// <summary>
-    /// Analyzes endregion directives
-    /// </summary>
-    /// <param name="context">Context</param>
-    private void OnEndRegion(SyntaxNodeAnalysisContext context)
+    /// <inheritdoc/>
+    protected override bool IsInvalidDescription(string description)
     {
-        if (context.Node is EndRegionDirectiveTriviaSyntax node
-            && IsForbiddenDescription(GetEndRegionDescription(node)))
-        {
-            context.ReportDiagnostic(CreateDiagnostic(node.GetLocation()));
-        }
-    }
-
-    /// <summary>
-    /// Analyzes region directives
-    /// </summary>
-    /// <param name="context">Context</param>
-    private void OnRegion(SyntaxNodeAnalysisContext context)
-    {
-        if (context.Node is RegionDirectiveTriviaSyntax node
-            && IsForbiddenDescription(GetRegionDescription(node)))
-        {
-            context.ReportDiagnostic(CreateDiagnostic(node.GetLocation()));
-        }
+        return IsForbiddenDescription(description);
     }
 
     #endregion // Methods
-
-    #region DiagnosticAnalyzer
-
-    /// <inheritdoc/>
-    public override void Initialize(AnalysisContext context)
-    {
-        base.Initialize(context);
-
-        context.RegisterSyntaxNodeAction(OnRegion, SyntaxKind.RegionDirectiveTrivia);
-        context.RegisterSyntaxNodeAction(OnEndRegion, SyntaxKind.EndRegionDirectiveTrivia);
-    }
-
-    #endregion // DiagnosticAnalyzer
 }

--- a/Reihitsu.sln
+++ b/Reihitsu.sln
@@ -176,6 +176,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		documentation\rules\RH0394.md = documentation\rules\RH0394.md
 		documentation\rules\RH0395.md = documentation\rules\RH0395.md
 		documentation\rules\RH0396.md = documentation\rules\RH0396.md
+		documentation\rules\RH0397.md = documentation\rules\RH0397.md
 		documentation\rules\RH0401.md = documentation\rules\RH0401.md
 		documentation\rules\RH0402.md = documentation\rules\RH0402.md
 		documentation\rules\RH0403.md = documentation\rules\RH0403.md

--- a/documentation/rules/RH0397.md
+++ b/documentation/rules/RH0397.md
@@ -1,0 +1,52 @@
+# RH0397 — Region descriptions should not be Member or Members
+
+| Property | Value |
+|----------|-------|
+| **ID** | RH0397 |
+| **Category** | Formatting |
+| **Severity** | Warning |
+| **Code Fix** | ❌ |
+
+## Description
+
+This rule disallows `#region` and `#endregion` descriptions that are only `Member` or `Members`.
+
+## Why is this a problem?
+
+Generic region labels do not explain what the region actually contains. They make it harder to scan a file and understand whether the section contains fields, properties, constructors, methods, or something else.
+
+## How to fix it
+
+Rename the region to describe the grouped code clearly. Use a specific label such as `Fields`, `Properties`, `Constructors`, or `Methods`, and keep the matching `#endregion` text aligned with it.
+
+## Examples
+
+### Violation
+
+```cs
+internal class Example
+{
+    #region Members
+
+    public void Save()
+    {
+    }
+
+    #endregion // Members
+}
+```
+
+### Correction
+
+```cs
+internal class Example
+{
+    #region Methods
+
+    public void Save()
+    {
+    }
+
+    #endregion // Methods
+}
+```


### PR DESCRIPTION
## Summary

Add analyzer rule RH0397 to flag `#region` and `#endregion` descriptions that are exactly `Member` or `Members`.

## Why

Generic region labels do not communicate what the region contains and make files harder to navigate.

## Linked issues

Closes #98

## Review notes

Adds the analyzer, localized strings, focused analyzer tests, rule documentation, and README/solution entries. No code fix is included by design.

## Follow-up work

None
