### PR TITLE
Add RH0228 single-letter identifier analyzer

### DIFF
--- a/Reihitsu.Analyzer.Package/README.MD
+++ b/Reihitsu.Analyzer.Package/README.MD
@@ -70,6 +70,7 @@ The **Formatter** column indicates whether running the Reihitsu formatter can au
 | [RH0225](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0225.md)| File scoped namespace declarations should be in PascalCase.| ✔| ❌| ❌|
 | [RH0226](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0226.md)| Namespace declarations should be in PascalCase.| ✔| ❌| ❌|
 | [RH0227](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0227.md)| The given namespace is not allowed.| ✔| ❌| ❌|
+| [RH0228](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0228.md)| Single-letter identifiers should not be used.| ✔| ❌| ❌|
 || **Formatting**||||
 | [RH0301](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0301.md)| #region and #endregion descriptions should match.| ✔| ✔| ✔|
 | [RH0302](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0302.md)| Object initializer should be formatted correctly.| ✔| ✔| ✔|

--- a/Reihitsu.Analyzer.Test/Naming/RH0228SingleLetterIdentifiersShouldNotBeUsedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Naming/RH0228SingleLetterIdentifiersShouldNotBeUsedAnalyzerTests.cs
@@ -1,0 +1,225 @@
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Analyzer.Rules.Naming;
+using Reihitsu.Analyzer.Test.Base;
+
+namespace Reihitsu.Analyzer.Test.Naming;
+
+/// <summary>
+/// Test methods for <see cref="RH0228SingleLetterIdentifiersShouldNotBeUsedAnalyzer"/>
+/// </summary>
+[TestClass]
+public class RH0228SingleLetterIdentifiersShouldNotBeUsedAnalyzerTests : AnalyzerTestsBase<RH0228SingleLetterIdentifiersShouldNotBeUsedAnalyzer>
+{
+    #region Tests
+
+    /// <summary>
+    /// Verifies diagnostics are reported for single-letter method parameters and local variables
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticsForSingleLetterMethodParameterAndLocalVariables()
+    {
+        const string testCode = """
+                                using System.Collections.Generic;
+
+                                namespace Reihitsu.Analyzer.Test.Naming.Resources;
+
+                                public class TestClass
+                                {
+                                    public void Process(List<int> items, int {|#0:x|})
+                                    {
+                                        for (int {|#1:i|} = 0; i < items.Count; i++)
+                                        {
+                                            var {|#2:y|} = items[i] + x;
+                                        }
+                                    }
+                                }
+                                """;
+
+        await Verify(testCode, Diagnostics(RH0228SingleLetterIdentifiersShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH0228MessageFormat, 3));
+    }
+
+    /// <summary>
+    /// Verifies diagnostics are reported for a catch variable
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticsForCatchVariable()
+    {
+        const string testCode = """
+                                using System;
+
+                                namespace Reihitsu.Analyzer.Test.Naming.Resources;
+
+                                public class TestClass
+                                {
+                                    public void Process()
+                                    {
+                                        try
+                                        {
+                                            throw new Exception();
+                                        }
+                                        catch (Exception {|#0:e|})
+                                        {
+                                        }
+                                    }
+                                }
+                                """;
+
+        await Verify(testCode, Diagnostics(RH0228SingleLetterIdentifiersShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH0228MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies diagnostics are reported for deconstruction variables
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticsForDeconstructionVariables()
+    {
+        const string testCode = """
+                                namespace Reihitsu.Analyzer.Test.Naming.Resources;
+
+                                public class TestClass
+                                {
+                                    public void Process()
+                                    {
+                                        var ({|#0:x|}, {|#1:y|}) = GetCoordinates();
+                                    }
+
+                                    private static (int Left, int Top) GetCoordinates()
+                                    {
+                                        return (1, 2);
+                                    }
+                                }
+                                """;
+
+        await Verify(testCode, Diagnostics(RH0228SingleLetterIdentifiersShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH0228MessageFormat, 2));
+    }
+
+    /// <summary>
+    /// Verifies no diagnostics are reported for descriptive local identifiers
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForDescriptiveIdentifiers()
+    {
+        const string testCode = """
+                                using System.Collections.Generic;
+
+                                namespace Reihitsu.Analyzer.Test.Naming.Resources;
+
+                                public class TestClass
+                                {
+                                    public void Process(List<int> items, int offset)
+                                    {
+                                        for (int index = 0; index < items.Count; index++)
+                                        {
+                                            var item = items[index] + offset;
+                                        }
+                                    }
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
+    /// <summary>
+    /// Verifies no diagnostics are reported for discards
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForDiscards()
+    {
+        const string testCode = """
+                                namespace Reihitsu.Analyzer.Test.Naming.Resources;
+
+                                public class TestClass
+                                {
+                                    public void Process(int _)
+                                    {
+                                        (_, var item) = GetCoordinates();
+                                    }
+
+                                    private static (int Left, int Top) GetCoordinates()
+                                    {
+                                        return (1, 2);
+                                    }
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
+    /// <summary>
+    /// Verifies no diagnostics are reported for override parameters
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForOverrideParameters()
+    {
+        const string testCode = """
+                                namespace Reihitsu.Analyzer.Test.Naming.Resources;
+
+                                public abstract class TestBase
+                                {
+                                    public abstract void Process(int item);
+                                }
+
+                                public class TestClass : TestBase
+                                {
+                                    public override void Process(int x)
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
+    /// <summary>
+    /// Verifies no diagnostics are reported for explicit interface implementation parameters
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForExplicitInterfaceImplementationParameters()
+    {
+        const string testCode = """
+                                namespace Reihitsu.Analyzer.Test.Naming.Resources;
+
+                                public interface ITestHandler
+                                {
+                                    void Process(int item);
+                                }
+
+                                public class TestClass : ITestHandler
+                                {
+                                    void ITestHandler.Process(int x)
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
+    /// <summary>
+    /// Verifies no diagnostics are reported for record primary constructor parameters
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForRecordPrimaryConstructorParameters()
+    {
+        const string testCode = """
+                                namespace Reihitsu.Analyzer.Test.Naming.Resources;
+
+                                public record TestRecord(int x);
+                                """;
+
+        await Verify(testCode);
+    }
+
+    #endregion // Tests
+}

--- a/Reihitsu.Analyzer/AnalyzerResources.cs
+++ b/Reihitsu.Analyzer/AnalyzerResources.cs
@@ -545,6 +545,16 @@ internal static class AnalyzerResources
     internal static string RH0227MessageFormat => GetString(nameof(RH0227MessageFormat));
 
     /// <summary>
+    /// Gets the localized string for RH0228Title
+    /// </summary>
+    internal static string RH0228Title => GetString(nameof(RH0228Title));
+
+    /// <summary>
+    /// Gets the localized string for RH0228MessageFormat
+    /// </summary>
+    internal static string RH0228MessageFormat => GetString(nameof(RH0228MessageFormat));
+
+    /// <summary>
     /// Gets the localized string for RH0301MessageFormat
     /// </summary>
     internal static string RH0301MessageFormat => GetString(nameof(RH0301MessageFormat));

--- a/Reihitsu.Analyzer/AnalyzerResources.resx
+++ b/Reihitsu.Analyzer/AnalyzerResources.resx
@@ -435,6 +435,12 @@
   <data name="RH0227MessageFormat" xml:space="preserve">
     <value>The given namespace is not allowed (see reihitsu.json)</value>
   </data>
+  <data name="RH0228Title" xml:space="preserve">
+    <value>Single-letter identifiers should not be used</value>
+  </data>
+  <data name="RH0228MessageFormat" xml:space="preserve">
+    <value>Single-letter identifiers should not be used</value>
+  </data>
   <data name="RH0301MessageFormat" xml:space="preserve">
     <value>The description of the #region and #endregion should match.</value>
   </data>

--- a/Reihitsu.Analyzer/Core/CasingUtilities.cs
+++ b/Reihitsu.Analyzer/Core/CasingUtilities.cs
@@ -144,9 +144,9 @@ public static class CasingUtilities
         if (isCamelCase)
         {
             // All other characters must be letters or digits
-            foreach (var c in input.Slice(1))
+            foreach (var character in input.Slice(1))
             {
-                if (char.IsLetterOrDigit(c) == false)
+                if (char.IsLetterOrDigit(character) == false)
                 {
                     isCamelCase = false;
 

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0324MethodChainsShouldBeAlignedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0324MethodChainsShouldBeAlignedAnalyzer.cs
@@ -228,23 +228,23 @@ public class RH0324MethodChainsShouldBeAlignedAnalyzer : DiagnosticAnalyzerBase<
 
         var referenceColumn = GetColumn(chainLinks[0]);
 
-        for (var i = 1; i < chainLinks.Count; i++)
+        for (var linkIndex = 1; linkIndex < chainLinks.Count; linkIndex++)
         {
-            var linkLine = GetLine(chainLinks[i]);
-            var linkColumn = GetColumn(chainLinks[i]);
+            var linkLine = GetLine(chainLinks[linkIndex]);
+            var linkColumn = GetColumn(chainLinks[linkIndex]);
 
             if (linkLine == firstLine)
             {
-                if (chainLinks.Skip(i + 1).Any(subsequentLink => GetLine(subsequentLink) != firstLine))
+                if (chainLinks.Skip(linkIndex + 1).Any(subsequentLink => GetLine(subsequentLink) != firstLine))
                 {
-                    context.ReportDiagnostic(CreateDiagnostic(chainLinks[i].GetLocation()));
+                    context.ReportDiagnostic(CreateDiagnostic(chainLinks[linkIndex].GetLocation()));
                 }
             }
             else
             {
                 if (linkColumn != referenceColumn)
                 {
-                    context.ReportDiagnostic(CreateDiagnostic(chainLinks[i].GetLocation()));
+                    context.ReportDiagnostic(CreateDiagnostic(chainLinks[linkIndex].GetLocation()));
                 }
             }
         }

--- a/Reihitsu.Analyzer/Rules/Naming/RH0228SingleLetterIdentifiersShouldNotBeUsedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Naming/RH0228SingleLetterIdentifiersShouldNotBeUsedAnalyzer.cs
@@ -1,0 +1,207 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Enumerations;
+
+namespace Reihitsu.Analyzer.Rules.Naming;
+
+/// <summary>
+/// Analyzer for single-letter identifiers
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class RH0228SingleLetterIdentifiersShouldNotBeUsedAnalyzer : DiagnosticAnalyzerBase<RH0228SingleLetterIdentifiersShouldNotBeUsedAnalyzer>
+{
+    #region Fields
+
+    /// <summary>
+    /// Diagnostic ID
+    /// </summary>
+    public const string DiagnosticId = "RH0228";
+
+    #endregion // Fields
+
+    #region Constructor
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public RH0228SingleLetterIdentifiersShouldNotBeUsedAnalyzer()
+        : base(DiagnosticId, DiagnosticCategory.Naming, nameof(AnalyzerResources.RH0228Title), nameof(AnalyzerResources.RH0228MessageFormat))
+    {
+    }
+
+    #endregion // Constructor
+
+    #region Methods
+
+    /// <summary>
+    /// Checks whether a parameter symbol should be analyzed
+    /// </summary>
+    /// <param name="parameterSymbol">Parameter symbol</param>
+    /// <returns>True if the symbol should be analyzed, otherwise false</returns>
+    private static bool ShouldAnalyze(IParameterSymbol parameterSymbol)
+    {
+        if (HasSingleLetterName(parameterSymbol.Name) == false)
+        {
+            return false;
+        }
+
+        if (IsFrameworkMandatedSignature(parameterSymbol))
+        {
+            return false;
+        }
+
+        return IsRecordPrimaryConstructorParameter(parameterSymbol) == false;
+    }
+
+    /// <summary>
+    /// Checks whether a local symbol should be analyzed
+    /// </summary>
+    /// <param name="localSymbol">Local symbol</param>
+    /// <returns>True if the symbol should be analyzed, otherwise false</returns>
+    private static bool ShouldAnalyze(ILocalSymbol localSymbol)
+    {
+        return HasSingleLetterName(localSymbol.Name);
+    }
+
+    /// <summary>
+    /// Checks whether an identifier uses a single-letter name
+    /// </summary>
+    /// <param name="name">Identifier name</param>
+    /// <returns>True if the identifier uses a single-letter name, otherwise false</returns>
+    private static bool HasSingleLetterName(string name)
+    {
+        return name.Length == 1
+               && name != "_";
+    }
+
+    /// <summary>
+    /// Checks whether the parameter belongs to a signature that is not practical to rename
+    /// </summary>
+    /// <param name="parameterSymbol">Parameter symbol</param>
+    /// <returns>True if the signature should be excluded, otherwise false</returns>
+    private static bool IsFrameworkMandatedSignature(IParameterSymbol parameterSymbol)
+    {
+        if (parameterSymbol.ContainingSymbol is IMethodSymbol methodSymbol)
+        {
+            return methodSymbol.MethodKind == MethodKind.AnonymousFunction
+                   || methodSymbol.IsOverride
+                   || methodSymbol.ExplicitInterfaceImplementations.Length > 0;
+        }
+
+        if (parameterSymbol.ContainingSymbol is IPropertySymbol propertySymbol)
+        {
+            return propertySymbol.IsOverride
+                   || propertySymbol.ExplicitInterfaceImplementations.Length > 0;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Checks whether a parameter belongs to a record primary constructor
+    /// </summary>
+    /// <param name="parameterSymbol">Parameter symbol</param>
+    /// <returns>True if the parameter belongs to a record primary constructor, otherwise false</returns>
+    private static bool IsRecordPrimaryConstructorParameter(IParameterSymbol parameterSymbol)
+    {
+        foreach (var syntaxReference in parameterSymbol.DeclaringSyntaxReferences)
+        {
+            if (syntaxReference.GetSyntax() is ParameterSyntax { Parent: ParameterListSyntax { Parent: RecordDeclarationSyntax } })
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Analyzes a catch declaration
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnCatchDeclaration(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is CatchDeclarationSyntax { Identifier.ValueText: var identifierName, Identifier.RawKind: not 0 } catchDeclaration
+            && HasSingleLetterName(identifierName))
+        {
+            context.ReportDiagnostic(CreateDiagnostic(catchDeclaration.Identifier.GetLocation()));
+        }
+    }
+
+    /// <summary>
+    /// Analyzes a foreach statement
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnForEachStatement(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is ForEachStatementSyntax { Identifier.ValueText: var identifierName } forEachStatement
+            && HasSingleLetterName(identifierName))
+        {
+            context.ReportDiagnostic(CreateDiagnostic(forEachStatement.Identifier.GetLocation()));
+        }
+    }
+
+    /// <summary>
+    /// Analyzes a parameter
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnParameter(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is ParameterSyntax parameter
+            && context.SemanticModel.GetDeclaredSymbol(parameter, context.CancellationToken) is IParameterSymbol parameterSymbol
+            && ShouldAnalyze(parameterSymbol))
+        {
+            context.ReportDiagnostic(CreateDiagnostic(parameter.Identifier.GetLocation()));
+        }
+    }
+
+    /// <summary>
+    /// Analyzes a single variable designation
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnSingleVariableDesignation(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is SingleVariableDesignationSyntax { Identifier.ValueText: var identifierName } designation
+            && context.SemanticModel.GetDeclaredSymbol(designation, context.CancellationToken) is ILocalSymbol
+            && HasSingleLetterName(identifierName))
+        {
+            context.ReportDiagnostic(CreateDiagnostic(designation.Identifier.GetLocation()));
+        }
+    }
+
+    /// <summary>
+    /// Analyzes a variable declarator
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnVariableDeclarator(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is VariableDeclaratorSyntax variableDeclarator
+            && context.SemanticModel.GetDeclaredSymbol(variableDeclarator, context.CancellationToken) is ILocalSymbol localSymbol
+            && ShouldAnalyze(localSymbol))
+        {
+            context.ReportDiagnostic(CreateDiagnostic(variableDeclarator.Identifier.GetLocation()));
+        }
+    }
+
+    #endregion // Methods
+
+    #region DiagnosticAnalyzer
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        base.Initialize(context);
+
+        context.RegisterSyntaxNodeAction(OnCatchDeclaration, SyntaxKind.CatchDeclaration);
+        context.RegisterSyntaxNodeAction(OnForEachStatement, SyntaxKind.ForEachStatement);
+        context.RegisterSyntaxNodeAction(OnParameter, SyntaxKind.Parameter);
+        context.RegisterSyntaxNodeAction(OnSingleVariableDesignation, SyntaxKind.SingleVariableDesignation);
+        context.RegisterSyntaxNodeAction(OnVariableDeclarator, SyntaxKind.VariableDeclarator);
+    }
+
+    #endregion // DiagnosticAnalyzer
+}

--- a/Reihitsu.Cli.Test/Unit/Diff/DiffGeneratorTests.cs
+++ b/Reihitsu.Cli.Test/Unit/Diff/DiffGeneratorTests.cs
@@ -89,10 +89,10 @@ public class DiffGeneratorTests
         formattedLines.Add("new1");
 
         // 10 identical lines in between (more than 2 × ContextLines)
-        for (var i = 1; i <= 10; i++)
+        for (var lineIndex = 1; lineIndex <= 10; lineIndex++)
         {
-            originalLines.Add($"same{i}");
-            formattedLines.Add($"same{i}");
+            originalLines.Add($"same{lineIndex}");
+            formattedLines.Add($"same{lineIndex}");
         }
 
         // Second change at line 11

--- a/Reihitsu.Cli.Test/Unit/Diff/HunkBuilderTests.cs
+++ b/Reihitsu.Cli.Test/Unit/Diff/HunkBuilderTests.cs
@@ -65,9 +65,9 @@ public class HunkBuilderTests
                          };
 
         // Add enough Equal operations to separate hunks (> 2 × ContextLines)
-        for (var i = 1; i <= 8; i++)
+        for (var operationIndex = 1; operationIndex <= 8; operationIndex++)
         {
-            operations.Add(new EditOperation(EditKind.Equal, i, i));
+            operations.Add(new EditOperation(EditKind.Equal, operationIndex, operationIndex));
         }
 
         // Second change
@@ -109,9 +109,9 @@ public class HunkBuilderTests
         var operations = new List<EditOperation>();
 
         // 5 equal lines before the change
-        for (var i = 0; i < 5; i++)
+        for (var operationIndex = 0; operationIndex < 5; operationIndex++)
         {
-            operations.Add(new EditOperation(EditKind.Equal, i, i));
+            operations.Add(new EditOperation(EditKind.Equal, operationIndex, operationIndex));
         }
 
         // One change
@@ -119,9 +119,9 @@ public class HunkBuilderTests
         operations.Add(new EditOperation(EditKind.Insert, -1, 5));
 
         // 5 equal lines after the change
-        for (var i = 6; i < 11; i++)
+        for (var operationIndex = 6; operationIndex < 11; operationIndex++)
         {
-            operations.Add(new EditOperation(EditKind.Equal, i, i));
+            operations.Add(new EditOperation(EditKind.Equal, operationIndex, operationIndex));
         }
 
         var hunks = HunkBuilder.Build(operations, 11, 11);

--- a/Reihitsu.Formatter.Test/Idempotency/SelfHostingTests.cs
+++ b/Reihitsu.Formatter.Test/Idempotency/SelfHostingTests.cs
@@ -199,10 +199,10 @@ public class SelfHostingTests
 
         var maxLines = Math.Max(originalLines.Length, formattedLines.Length);
 
-        for (var i = 0; i < maxLines; i++)
+        for (var lineIndex = 0; lineIndex < maxLines; lineIndex++)
         {
-            var origLine = i < originalLines.Length ? originalLines[i] : "<EOF>";
-            var fmtLine = i < formattedLines.Length ? formattedLines[i] : "<EOF>";
+            var origLine = lineIndex < originalLines.Length ? originalLines[lineIndex] : "<EOF>";
+            var fmtLine = lineIndex < formattedLines.Length ? formattedLines[lineIndex] : "<EOF>";
 
             if (origLine != fmtLine)
             {
@@ -210,7 +210,7 @@ public class SelfHostingTests
 
                 if (changedLineCount <= 10)
                 {
-                    sb.AppendLine($"  Line {i + 1}:");
+                    sb.AppendLine($"  Line {lineIndex + 1}:");
                     sb.AppendLine($"    - {origLine.TrimEnd().Replace("\r", "\\r")}");
                     sb.AppendLine($"    + {fmtLine.TrimEnd().Replace("\r", "\\r")}");
                 }

--- a/Reihitsu.Formatter.Test/Unit/Indentation/TokenLayoutTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/Indentation/TokenLayoutTests.cs
@@ -61,11 +61,11 @@ public class TokenLayoutTests
     public void EqualityWithSameValuesReturnsTrue()
     {
         // Arrange
-        var a = new TokenLayout(4, "align");
-        var b = new TokenLayout(4, "align");
+        var firstLayout = new TokenLayout(4, "align");
+        var secondLayout = new TokenLayout(4, "align");
 
         // Act & Assert
-        Assert.AreEqual(a, b);
+        Assert.AreEqual(firstLayout, secondLayout);
     }
 
     /// <summary>
@@ -75,11 +75,11 @@ public class TokenLayoutTests
     public void InequalityWithDifferentValuesReturnsTrue()
     {
         // Arrange
-        var a = new TokenLayout(4, "align");
-        var b = new TokenLayout(8, "block");
+        var firstLayout = new TokenLayout(4, "align");
+        var secondLayout = new TokenLayout(8, "block");
 
         // Act & Assert
-        Assert.AreNotEqual(a, b);
+        Assert.AreNotEqual(firstLayout, secondLayout);
     }
 
     #endregion // Methods

--- a/Reihitsu.Formatter/Pipeline/BlankLines/BlankLineCollapser.cs
+++ b/Reihitsu.Formatter/Pipeline/BlankLines/BlankLineCollapser.cs
@@ -24,11 +24,11 @@ internal sealed class BlankLineCollapser : CSharpSyntaxRewriter
         var lines = new List<List<SyntaxTrivia>>();
         var currentLine = new List<SyntaxTrivia>();
 
-        foreach (var t in trivia)
+        foreach (var triviaItem in trivia)
         {
-            currentLine.Add(t);
+            currentLine.Add(triviaItem);
 
-            if (t.IsKind(SyntaxKind.EndOfLineTrivia))
+            if (triviaItem.IsKind(SyntaxKind.EndOfLineTrivia))
             {
                 lines.Add(currentLine);
                 currentLine = [];
@@ -94,9 +94,9 @@ internal sealed class BlankLineCollapser : CSharpSyntaxRewriter
     {
         var hasEndOfLine = false;
 
-        foreach (var t in line)
+        foreach (var triviaItem in line)
         {
-            var kind = t.Kind();
+            var kind = triviaItem.Kind();
 
             if (kind == SyntaxKind.EndOfLineTrivia)
             {

--- a/Reihitsu.Formatter/Pipeline/Indentation/IndentationRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/Indentation/IndentationRewriter.cs
@@ -76,20 +76,20 @@ internal static class IndentationRewriter
 
         for (var triviaIndex = 0; triviaIndex < trivia.Count; triviaIndex++)
         {
-            var t = trivia[triviaIndex];
+            var triviaItem = trivia[triviaIndex];
 
-            if (t.IsKind(SyntaxKind.EndOfLineTrivia))
+            if (triviaItem.IsKind(SyntaxKind.EndOfLineTrivia))
             {
-                result.Add(t);
+                result.Add(triviaItem);
                 currentLine++;
                 atLineStart = true;
 
                 continue;
             }
 
-            if (atLineStart && t.IsKind(SyntaxKind.WhitespaceTrivia))
+            if (atLineStart && triviaItem.IsKind(SyntaxKind.WhitespaceTrivia))
             {
-                var text = t.ToFullString();
+                var text = triviaItem.ToFullString();
                 var hasBom = text.Length > 0 && text[0] == '\uFEFF';
 
                 if (StartsWithNonRegionDirective(trivia, triviaIndex + 1))
@@ -102,7 +102,7 @@ internal static class IndentationRewriter
                     continue;
                 }
 
-                AddLineStartWhitespace(result, t, hasBom, currentLine, model);
+                AddLineStartWhitespace(result, triviaItem, hasBom, currentLine, model);
 
                 atLineStart = false;
 
@@ -111,7 +111,7 @@ internal static class IndentationRewriter
 
             if (atLineStart)
             {
-                if (IsNonRegionDirectiveTrivia(t) == false)
+                if (IsNonRegionDirectiveTrivia(triviaItem) == false)
                 {
                     AddLayoutWhitespaceIfConfigured(result, currentLine, model);
                 }
@@ -119,10 +119,10 @@ internal static class IndentationRewriter
                 atLineStart = false;
             }
 
-            result.Add(t);
+            result.Add(triviaItem);
 
             // Directive trivia contains an embedded end-of-line; advance to the next line
-            if (t.HasStructure && t.GetStructure() is DirectiveTriviaSyntax)
+            if (triviaItem.HasStructure && triviaItem.GetStructure() is DirectiveTriviaSyntax)
             {
                 currentLine++;
                 atLineStart = true;

--- a/Reihitsu.sln
+++ b/Reihitsu.sln
@@ -80,6 +80,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		documentation\rules\RH0225.md = documentation\rules\RH0225.md
 		documentation\rules\RH0226.md = documentation\rules\RH0226.md
 		documentation\rules\RH0227.md = documentation\rules\RH0227.md
+		documentation\rules\RH0228.md = documentation\rules\RH0228.md
 		documentation\rules\RH0301.md = documentation\rules\RH0301.md
 		documentation\rules\RH0302.md = documentation\rules\RH0302.md
 		documentation\rules\RH0303.md = documentation\rules\RH0303.md

--- a/documentation/rules/RH0228.md
+++ b/documentation/rules/RH0228.md
@@ -1,0 +1,42 @@
+# RH0228 — Single-letter identifiers should not be used
+
+| Property | Value |
+|----------|-------|
+| **ID** | RH0228 |
+| **Category** | Naming |
+| **Severity** | Warning |
+| **Code Fix** | ❌ |
+
+## Description
+
+Requires descriptive names for short-lived identifiers such as local variables and parameters instead of single-letter names.
+
+## Why is this a problem?
+
+Single-letter identifiers hide intent. Names like `i`, `j`, and `x` force readers to infer meaning from surrounding code instead of understanding it directly from the identifier.
+
+## How to fix it
+
+Rename the identifier so that it describes its role, value, or purpose. Prefer names such as `index`, `item`, `count`, or `offset`.
+
+## Examples
+
+### Violation
+
+```cs
+for (int i = 0; i < items.Count; i++)
+{
+    var x = items[i];
+    Process(x);
+}
+```
+
+### Correction
+
+```cs
+for (int index = 0; index < items.Count; index++)
+{
+    var item = items[index];
+    Process(item);
+}
+```


### PR DESCRIPTION
## Summary

Adds the RH0228 naming analyzer to report single-letter identifiers for short-lived locals and parameters, with focused tests and rule documentation.

## Why

Single-letter names like `i`, `x`, and `e` hide intent and make code harder to review and maintain. This adds the analyzer requested in #110 and documents the intended exclusions for cases where renaming is not practical.

## Linked issues

Closes #110

## Review notes

- Reports single-letter local variables, `for`/`foreach` variables, catch variables, deconstruction variables, and regular parameters.
- Skips discards (`_`), override members, explicit interface implementations, anonymous-function parameters, and record primary-constructor parameters.
- No code fix is included because choosing a descriptive replacement requires human judgment.

## Follow-up work

None
