### PR TITLE
Add RH0701 analyzer diagnostics for invalid reihitsu.json

### DIFF
--- a/Reihitsu.Analyzer.Package/README.MD
+++ b/Reihitsu.Analyzer.Package/README.MD
@@ -1,6 +1,6 @@
 # Reihitsu.Analyzer
 
-A Roslyn-based C# analyzer package that enforces coding rules across multiple categories: Clarity, Design, Naming, Formatting, Documentation, Ordering, and Performance.
+A Roslyn-based C# analyzer package that enforces coding rules across multiple categories: Clarity, Design, Naming, Formatting, Documentation, Ordering, Performance, and Analyzer.
 
 ## Installation
 
@@ -239,3 +239,5 @@ The **Formatter** column indicates whether running the Reihitsu formatter can au
 || **Performance**||||
 | [RH0501](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0501.md)| Types used as dictionary keys or in hash sets must implement equality members.| ✔| ❌| ❌|
 | [RH0502](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0502.md)| Types used for equality comparison must implement equality members.| ✔| ❌| ❌|
+|| **Analyzer**||||
+| [RH0701](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0701.md)| reihitsu.json configuration must be valid.| ✔| ❌| ❌|

--- a/Reihitsu.Analyzer.Test/Analyzer/RH0701ConfigurationFileMustBeValidAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Analyzer/RH0701ConfigurationFileMustBeValidAnalyzerTests.cs
@@ -1,0 +1,238 @@
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Analyzer.Rules.Analyzer;
+using Reihitsu.Analyzer.Test.Base;
+
+namespace Reihitsu.Analyzer.Test.Analyzer;
+
+/// <summary>
+/// Tests for <see cref="RH0701ConfigurationFileMustBeValidAnalyzer"/>
+/// </summary>
+[TestClass]
+public class RH0701ConfigurationFileMustBeValidAnalyzerTests : AnalyzerTestsBase<RH0701ConfigurationFileMustBeValidAnalyzer>
+{
+    #region Constants
+
+    /// <summary>
+    /// Test code
+    /// </summary>
+    private const string TestCode = """
+                                    namespace TestNamespace
+                                    {
+                                    }
+                                    """;
+
+    #endregion // Constants
+
+    #region Tests
+
+    /// <summary>
+    /// Valid configuration
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task ValidConfiguration()
+    {
+        await Verify(TestCode,
+                     test =>
+                     {
+                         const string configuration = """
+                                                      {
+                                                         "Naming":{
+                                                            "AllowedNamespaceDeclarations":[
+                                                               "TestNamespace"
+                                                            ]
+                                                         }
+                                                      }
+                                                      """;
+
+                         test.TestState.AdditionalFiles.Add(("reihitsu.json", configuration));
+                     });
+    }
+
+    /// <summary>
+    /// Empty configuration
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task EmptyConfiguration()
+    {
+        await Verify(TestCode,
+                     test => test.TestState.AdditionalFiles.Add(("reihitsu.json", string.Empty)),
+                     InvalidConfiguration("The configuration file must not be empty or whitespace-only.", 1, 1));
+    }
+
+    /// <summary>
+    /// Whitespace configuration
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task WhitespaceConfiguration()
+    {
+        await Verify(TestCode,
+                     test => test.TestState.AdditionalFiles.Add(("reihitsu.json", "   ")),
+                     InvalidConfiguration("The configuration file must not be empty or whitespace-only.", 1, 1));
+    }
+
+    /// <summary>
+    /// Invalid JSON
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task InvalidJson()
+    {
+        await Verify(TestCode,
+                     test =>
+                     {
+                         const string configuration = """
+                                                      {
+                                                         "Naming":{
+                                                            "AllowedNamespaceDeclarations":[
+                                                               "TestNamespace"
+                                                         }
+                                                      }
+                                                      """;
+
+                         test.TestState.AdditionalFiles.Add(("reihitsu.json", configuration));
+                     },
+                     InvalidConfiguration("The configuration file contains invalid JSON syntax.", 5, 4));
+    }
+
+    /// <summary>
+    /// Unknown top level section
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task UnknownTopLevelSection()
+    {
+        await Verify(TestCode,
+                     test =>
+                     {
+                         const string configuration = """
+                                                      {
+                                                         "Unknown":{
+                                                         }
+                                                      }
+                                                      """;
+
+                         test.TestState.AdditionalFiles.Add(("reihitsu.json", configuration));
+                     },
+                     InvalidConfiguration("Unknown configuration section 'Unknown'.", 2, 5));
+    }
+
+    /// <summary>
+    /// Unknown naming property
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task UnknownNamingProperty()
+    {
+        await Verify(TestCode,
+                     test =>
+                     {
+                         const string configuration = """
+                                                      {
+                                                         "Naming":{
+                                                            "Unknown":[
+                                                            ]
+                                                         }
+                                                      }
+                                                      """;
+
+                         test.TestState.AdditionalFiles.Add(("reihitsu.json", configuration));
+                     },
+                     InvalidConfiguration("Unknown configuration setting 'Naming.Unknown'.", 3, 8));
+    }
+
+    /// <summary>
+    /// Naming section must be object
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task NamingSectionMustBeObject()
+    {
+        await Verify(TestCode,
+                     test =>
+                     {
+                         const string configuration = """
+                                                      {
+                                                         "Naming":[
+                                                         ]
+                                                      }
+                                                      """;
+
+                         test.TestState.AdditionalFiles.Add(("reihitsu.json", configuration));
+                     },
+                     InvalidConfiguration("The 'Naming' section must be a JSON object.", 2, 13));
+    }
+
+    /// <summary>
+    /// Allowed namespace declarations must be array
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task AllowedNamespaceDeclarationsMustBeArray()
+    {
+        await Verify(TestCode,
+                     test =>
+                     {
+                         const string configuration = """
+                                                      {
+                                                         "Naming":{
+                                                            "AllowedNamespaceDeclarations":"TestNamespace"
+                                                         }
+                                                      }
+                                                      """;
+
+                         test.TestState.AdditionalFiles.Add(("reihitsu.json", configuration));
+                     },
+                     InvalidConfiguration("The 'Naming.AllowedNamespaceDeclarations' setting must be a JSON array.", 3, 39));
+    }
+
+    /// <summary>
+    /// Allowed namespace declarations entries must be strings
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task AllowedNamespaceDeclarationsEntriesMustBeStrings()
+    {
+        await Verify(TestCode,
+                     test =>
+                     {
+                         const string configuration = """
+                                                      {
+                                                         "Naming":{
+                                                            "AllowedNamespaceDeclarations":[
+                                                               1
+                                                            ]
+                                                         }
+                                                      }
+                                                      """;
+
+                         test.TestState.AdditionalFiles.Add(("reihitsu.json", configuration));
+                     },
+                     InvalidConfiguration("Entries in 'Naming.AllowedNamespaceDeclarations' must be strings.", 4, 10));
+    }
+
+    #endregion // Tests
+
+    #region Methods
+
+    /// <summary>
+    /// Invalid configuration diagnostic
+    /// </summary>
+    /// <param name="message">Message</param>
+    /// <param name="line">Line</param>
+    /// <param name="column">Column</param>
+    /// <returns>Diagnostic</returns>
+    private static DiagnosticResult InvalidConfiguration(string message, int line, int column)
+    {
+        return Diagnostic(RH0701ConfigurationFileMustBeValidAnalyzer.DiagnosticId).WithLocation("reihitsu.json", line, column)
+                                                                                  .WithMessage(string.Format(AnalyzerResources.RH0701MessageFormat, message));
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Analyzer/AnalyzerResources.cs
+++ b/Reihitsu.Analyzer/AnalyzerResources.cs
@@ -1665,6 +1665,16 @@ internal static class AnalyzerResources
     internal static string RH0614MessageFormat => GetString(nameof(RH0614MessageFormat));
 
     /// <summary>
+    /// Gets the localized string for RH0701Title
+    /// </summary>
+    internal static string RH0701Title => GetString(nameof(RH0701Title));
+
+    /// <summary>
+    /// Gets the localized string for RH0701MessageFormat
+    /// </summary>
+    internal static string RH0701MessageFormat => GetString(nameof(RH0701MessageFormat));
+
+    /// <summary>
     /// Gets the localized string for RH0402MessageFormat
     /// </summary>
     internal static string RH0402MessageFormat => GetString(nameof(RH0402MessageFormat));

--- a/Reihitsu.Analyzer/AnalyzerResources.resx
+++ b/Reihitsu.Analyzer/AnalyzerResources.resx
@@ -1089,6 +1089,12 @@
   <data name="RH0614MessageFormat" xml:space="preserve">
     <value>Using static directives must be ordered alphabetically.</value>
   </data>
+  <data name="RH0701Title" xml:space="preserve">
+    <value>reihitsu.json configuration must be valid</value>
+  </data>
+  <data name="RH0701MessageFormat" xml:space="preserve">
+    <value>The reihitsu.json configuration is invalid: {0}</value>
+  </data>
   <data name="RH0390Title" xml:space="preserve">
     <value>Using directives should be organized into groups</value>
   </data>

--- a/Reihitsu.Analyzer/Base/DiagnosticAnalyzerBase{TAnalyzer}.cs
+++ b/Reihitsu.Analyzer/Base/DiagnosticAnalyzerBase{TAnalyzer}.cs
@@ -75,6 +75,17 @@ public class DiagnosticAnalyzerBase<TAnalyzer> : DiagnosticAnalyzer
     /// <summary>
     /// Create diagnostic
     /// </summary>
+    /// <param name="location">Location</param>
+    /// <param name="messageArgs">Message arguments</param>
+    /// <returns>Created <see cref="Diagnostic"/> object</returns>
+    protected Diagnostic CreateDiagnostic(Location location, params object[] messageArgs)
+    {
+        return Diagnostic.Create(_rule, location, messageArgs);
+    }
+
+    /// <summary>
+    /// Create diagnostic
+    /// </summary>
     /// <param name="locations">Locations</param>
     /// <returns>Created <see cref="Diagnostic"/> object</returns>
     protected Diagnostic CreateDiagnostic(ImmutableArray<Location> locations)

--- a/Reihitsu.Analyzer/Data/ConfigurationLoadResult.cs
+++ b/Reihitsu.Analyzer/Data/ConfigurationLoadResult.cs
@@ -1,0 +1,36 @@
+using System.Collections.Immutable;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Reihitsu.Analyzer.Data;
+
+/// <summary>
+/// Result of loading the analyzer configuration
+/// </summary>
+internal class ConfigurationLoadResult
+{
+    #region Properties
+
+    /// <summary>
+    /// Loaded configuration
+    /// </summary>
+    public Configuration Configuration { get; set; }
+
+    /// <summary>
+    /// Configuration validation errors
+    /// </summary>
+    public ImmutableArray<ConfigurationValidationError> Errors { get; set; } = [];
+
+    /// <summary>
+    /// Configuration file
+    /// </summary>
+    public AdditionalText File { get; set; }
+
+    /// <summary>
+    /// Configuration text
+    /// </summary>
+    public SourceText Text { get; set; }
+
+    #endregion // Properties
+}

--- a/Reihitsu.Analyzer/Data/ConfigurationManager.cs
+++ b/Reihitsu.Analyzer/Data/ConfigurationManager.cs
@@ -1,7 +1,10 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text;
 using System.Text.Json;
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Reihitsu.Analyzer.Data;
 
@@ -10,61 +13,330 @@ namespace Reihitsu.Analyzer.Data;
 /// </summary>
 internal static class ConfigurationManager
 {
+    #region Constants
+
+    /// <summary>
+    /// Configuration file name
+    /// </summary>
+    private const string ConfigurationFileName = "reihitsu.json";
+
+    #endregion // Constants
+
     #region Methods
 
     /// <summary>
-    /// Try to get configuration
+    /// Gets the configuration
     /// </summary>
     /// <param name="additionalFiles">Additional files</param>
-    /// <param name="configuration">Configuration</param>
-    /// <returns>Is a configuration available?</returns>
-    public static bool TryGetConfiguration(ImmutableArray<AdditionalText> additionalFiles, out Configuration configuration)
+    /// <returns>Configuration load result</returns>
+    public static ConfigurationLoadResult GetConfiguration(ImmutableArray<AdditionalText> additionalFiles)
     {
-        configuration = null;
-
-        var file = additionalFiles.FirstOrDefault(file => file.Path.EndsWith("reihitsu.json"));
+        var file = additionalFiles.FirstOrDefault(currentFile => currentFile.Path.EndsWith(ConfigurationFileName, StringComparison.OrdinalIgnoreCase));
 
         if (file == null)
         {
-            return false;
+            return new ConfigurationLoadResult();
         }
 
-        var text = file.GetText()?.ToString();
+        var text = file.GetText();
+        var result = new ConfigurationLoadResult
+                     {
+                         File = file,
+                         Text = text
+                     };
 
-        if (string.IsNullOrWhiteSpace(text))
+        if (text == null)
         {
-            return false;
+            result.Errors = [CreateValidationError("The configuration file could not be read.")];
+
+            return result;
+        }
+
+        if (string.IsNullOrWhiteSpace(text.ToString()))
+        {
+            result.Errors = [CreateValidationError("The configuration file must not be empty or whitespace-only.")];
+
+            return result;
         }
 
         try
         {
-            using (var jsonDocument = JsonDocument.Parse(text))
+            result.Configuration = ParseConfiguration(text, out var errors);
+            result.Errors = [.. errors];
+        }
+        catch (JsonException exception)
+        {
+            result.Errors = [CreateValidationError("The configuration file contains invalid JSON syntax.", GetExceptionSpan(text, exception))];
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Parse configuration
+    /// </summary>
+    /// <param name="text">Text</param>
+    /// <param name="errors">Errors</param>
+    /// <returns>Configuration</returns>
+    private static Configuration ParseConfiguration(SourceText text, out List<ConfigurationValidationError> errors)
+    {
+        var configuration = new Configuration();
+
+        errors = [];
+
+        var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(text.ToString()));
+
+        if (reader.Read() == false)
+        {
+            errors.Add(CreateValidationError("The configuration file must not be empty or whitespace-only."));
+
+            return configuration;
+        }
+
+        if (reader.TokenType != JsonTokenType.StartObject)
+        {
+            errors.Add(CreateValidationError("The configuration root must be a JSON object.", GetCurrentValueSpan(ref reader)));
+
+            return configuration;
+        }
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
             {
-                configuration = new Configuration();
+                break;
+            }
 
-                if (jsonDocument.RootElement.TryGetProperty(nameof(Configuration.Naming), out var namingElement))
-                {
-                    configuration.Naming = new ConfigurationCategoryNaming();
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                continue;
+            }
 
-                    if (namingElement.TryGetProperty(nameof(ConfigurationCategoryNaming.AllowedNamespaceDeclarations), out var allowedNamespaceDeclarationsElement)
-                        && allowedNamespaceDeclarationsElement.ValueKind == JsonValueKind.Array)
+            var propertyName = reader.GetString();
+            var propertySpan = GetPropertyNameSpan(ref reader);
+
+            reader.Read();
+
+            switch (propertyName)
+            {
+                case nameof(Configuration.Naming):
                     {
-                        configuration.Naming.AllowedNamespaceDeclarations = allowedNamespaceDeclarationsElement.EnumerateArray()
-                                                                                                               .Where(item => item.ValueKind == JsonValueKind.String)
-                                                                                                               .Select(item => item.GetString())
-                                                                                                               .ToList();
+                        ParseNaming(ref reader, configuration, errors);
                     }
-                }
+                    break;
 
-                return true;
+                default:
+                    {
+                        errors.Add(CreateValidationError($"Unknown configuration section '{propertyName}'.", propertySpan));
+
+                        SkipValue(ref reader);
+                    }
+                    break;
             }
         }
-        catch (JsonException)
+
+        return configuration;
+    }
+
+    /// <summary>
+    /// Parse naming category
+    /// </summary>
+    /// <param name="reader">Reader</param>
+    /// <param name="configuration">Configuration</param>
+    /// <param name="errors">Errors</param>
+    private static void ParseNaming(ref Utf8JsonReader reader, Configuration configuration, List<ConfigurationValidationError> errors)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
         {
-            configuration = null;
+            errors.Add(CreateValidationError("The 'Naming' section must be a JSON object.", GetCurrentValueSpan(ref reader)));
+
+            SkipValue(ref reader);
+
+            return;
         }
 
-        return false;
+        configuration.Naming ??= new ConfigurationCategoryNaming();
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                break;
+            }
+
+            if (reader.TokenType != JsonTokenType.PropertyName)
+            {
+                continue;
+            }
+
+            var propertyName = reader.GetString();
+            var propertySpan = GetPropertyNameSpan(ref reader);
+
+            reader.Read();
+
+            switch (propertyName)
+            {
+                case nameof(ConfigurationCategoryNaming.AllowedNamespaceDeclarations):
+                    {
+                        ParseAllowedNamespaceDeclarations(ref reader, configuration.Naming, errors);
+                    }
+                    break;
+
+                default:
+                    {
+                        errors.Add(CreateValidationError($"Unknown configuration setting 'Naming.{propertyName}'.", propertySpan));
+                        SkipValue(ref reader);
+                    }
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Parse allowed namespace declarations
+    /// </summary>
+    /// <param name="reader">Reader</param>
+    /// <param name="namingConfiguration">Naming configuration</param>
+    /// <param name="errors">Errors</param>
+    private static void ParseAllowedNamespaceDeclarations(ref Utf8JsonReader reader, ConfigurationCategoryNaming namingConfiguration, List<ConfigurationValidationError> errors)
+    {
+        if (reader.TokenType != JsonTokenType.StartArray)
+        {
+            errors.Add(CreateValidationError("The 'Naming.AllowedNamespaceDeclarations' setting must be a JSON array.", GetCurrentValueSpan(ref reader)));
+
+            SkipValue(ref reader);
+
+            return;
+        }
+
+        var allowedNamespaceDeclarations = new List<string>();
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndArray)
+            {
+                break;
+            }
+
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                allowedNamespaceDeclarations.Add(reader.GetString());
+            }
+            else
+            {
+                errors.Add(CreateValidationError("Entries in 'Naming.AllowedNamespaceDeclarations' must be strings.", GetCurrentValueSpan(ref reader)));
+
+                SkipValue(ref reader);
+            }
+        }
+
+        namingConfiguration.AllowedNamespaceDeclarations = allowedNamespaceDeclarations;
+    }
+
+    /// <summary>
+    /// Skip current value
+    /// </summary>
+    /// <param name="reader">Reader</param>
+    private static void SkipValue(ref Utf8JsonReader reader)
+    {
+        if (reader.TokenType != JsonTokenType.StartArray
+            && reader.TokenType != JsonTokenType.StartObject)
+        {
+            return;
+        }
+
+        JsonDocument.ParseValue(ref reader).Dispose();
+    }
+
+    /// <summary>
+    /// Create validation error
+    /// </summary>
+    /// <param name="message">Message</param>
+    /// <returns>Validation error</returns>
+    private static ConfigurationValidationError CreateValidationError(string message)
+    {
+        return CreateValidationError(message, new TextSpan(0, 0));
+    }
+
+    /// <summary>
+    /// Create validation error
+    /// </summary>
+    /// <param name="message">Message</param>
+    /// <param name="span">Span</param>
+    /// <returns>Validation error</returns>
+    private static ConfigurationValidationError CreateValidationError(string message, TextSpan span)
+    {
+        return new ConfigurationValidationError
+               {
+                   Message = message,
+                   Span = span
+               };
+    }
+
+    /// <summary>
+    /// Gets the current property name span
+    /// </summary>
+    /// <param name="reader">Reader</param>
+    /// <returns>Text span</returns>
+    private static TextSpan GetPropertyNameSpan(ref Utf8JsonReader reader)
+    {
+        var start = (int)reader.TokenStartIndex + 1;
+        var length = reader.ValueSpan.Length;
+
+        return new TextSpan(start, length);
+    }
+
+    /// <summary>
+    /// Gets the current value span
+    /// </summary>
+    /// <param name="reader">Reader</param>
+    /// <returns>Text span</returns>
+    private static TextSpan GetCurrentValueSpan(ref Utf8JsonReader reader)
+    {
+        var start = (int)reader.TokenStartIndex;
+
+        if (reader.TokenType is JsonTokenType.StartArray or JsonTokenType.StartObject)
+        {
+            var clonedReader = reader;
+
+            JsonDocument.ParseValue(ref clonedReader).Dispose();
+
+            return TextSpan.FromBounds(start, (int)clonedReader.BytesConsumed);
+        }
+
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            var valueStart = start + 1;
+            var valueLength = reader.ValueSpan.Length;
+
+            return new TextSpan(valueStart, valueLength);
+        }
+
+        var length = reader.ValueSpan.Length;
+
+        if (length == 0)
+        {
+            length = 1;
+        }
+
+        return new TextSpan(start, length);
+    }
+
+    /// <summary>
+    /// Gets the exception span
+    /// </summary>
+    /// <param name="text">Text</param>
+    /// <param name="exception">Exception</param>
+    /// <returns>Span</returns>
+    private static TextSpan GetExceptionSpan(SourceText text, JsonException exception)
+    {
+        var line = exception.LineNumber.GetValueOrDefault();
+        var column = exception.BytePositionInLine.GetValueOrDefault();
+        var lineIndex = (int)Math.Min(line, text.Lines.Count - 1);
+        var lineStart = text.Lines[lineIndex].Start;
+        var position = lineStart + (int)column;
+
+        return new TextSpan(Math.Min(position, text.Length), 0);
     }
 
     #endregion // Methods

--- a/Reihitsu.Analyzer/Data/ConfigurationValidationError.cs
+++ b/Reihitsu.Analyzer/Data/ConfigurationValidationError.cs
@@ -1,0 +1,23 @@
+using Microsoft.CodeAnalysis.Text;
+
+namespace Reihitsu.Analyzer.Data;
+
+/// <summary>
+/// Configuration validation error
+/// </summary>
+internal class ConfigurationValidationError
+{
+    #region Properties
+
+    /// <summary>
+    /// Message
+    /// </summary>
+    public string Message { get; set; }
+
+    /// <summary>
+    /// Span
+    /// </summary>
+    public TextSpan Span { get; set; }
+
+    #endregion // Properties
+}

--- a/Reihitsu.Analyzer/Enumerations/DiagnosticCategory.cs
+++ b/Reihitsu.Analyzer/Enumerations/DiagnosticCategory.cs
@@ -39,4 +39,9 @@ internal enum DiagnosticCategory
     /// Ordering
     /// </summary>
     Ordering = 6,
+
+    /// <summary>
+    /// Analyzer
+    /// </summary>
+    Analyzer = 7,
 }

--- a/Reihitsu.Analyzer/Rules/Analyzer/RH0701ConfigurationFileMustBeValidAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Analyzer/RH0701ConfigurationFileMustBeValidAnalyzer.cs
@@ -1,0 +1,109 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+
+using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Data;
+using Reihitsu.Analyzer.Enumerations;
+
+namespace Reihitsu.Analyzer.Rules.Analyzer;
+
+/// <summary>
+/// RH0701: reihitsu.json configuration must be valid
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class RH0701ConfigurationFileMustBeValidAnalyzer : DiagnosticAnalyzerBase<RH0701ConfigurationFileMustBeValidAnalyzer>
+{
+    #region Fields
+
+    /// <summary>
+    /// Diagnostic ID
+    /// </summary>
+    public const string DiagnosticId = "RH0701";
+
+    #endregion // Fields
+
+    #region Constructor
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public RH0701ConfigurationFileMustBeValidAnalyzer()
+        : base(DiagnosticId, DiagnosticCategory.Analyzer, nameof(AnalyzerResources.RH0701Title), nameof(AnalyzerResources.RH0701MessageFormat))
+    {
+    }
+
+    #endregion // Constructor
+
+    #region Methods
+
+    /// <summary>
+    /// Create location
+    /// </summary>
+    /// <param name="configuration">Configuration</param>
+    /// <param name="error">Error</param>
+    /// <returns>Location</returns>
+    private static Location CreateLocation(ConfigurationLoadResult configuration, ConfigurationValidationError error)
+    {
+        var span = ClampSpan(configuration.Text, error.Span);
+        var lineSpan = configuration.Text == null
+                           ? new LinePositionSpan(new LinePosition(0, 0), new LinePosition(0, 0))
+                           : configuration.Text.Lines.GetLinePositionSpan(span);
+
+        return Location.Create(configuration.File.Path, span, lineSpan);
+    }
+
+    /// <summary>
+    /// Clamp span
+    /// </summary>
+    /// <param name="text">Text</param>
+    /// <param name="span">Span</param>
+    /// <returns>Clamped span</returns>
+    private static TextSpan ClampSpan(SourceText text, TextSpan span)
+    {
+        if (text == null)
+        {
+            return new TextSpan(0, 0);
+        }
+
+        var start = Math.Min(span.Start, text.Length);
+        var end = Math.Min(span.End, text.Length);
+
+        return TextSpan.FromBounds(start, end);
+    }
+
+    /// <summary>
+    /// Analyze compilation
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnCompilation(CompilationAnalysisContext context)
+    {
+        var configuration = ConfigurationManager.GetConfiguration(context.Options.AdditionalFiles);
+
+        if (configuration.File == null
+            || configuration.Errors.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        foreach (var error in configuration.Errors)
+        {
+            context.ReportDiagnostic(CreateDiagnostic(CreateLocation(configuration, error), error.Message));
+        }
+    }
+
+    #endregion // Methods
+
+    #region DiagnosticAnalyzer
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        base.Initialize(context);
+
+        context.RegisterCompilationAction(OnCompilation);
+    }
+
+    #endregion // DiagnosticAnalyzer
+}

--- a/Reihitsu.Analyzer/Rules/Naming/RH0227NamespaceNotAllowedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Naming/RH0227NamespaceNotAllowedAnalyzer.cs
@@ -44,8 +44,9 @@ public class RH0227NamespaceNotAllowedAnalyzer : DiagnosticAnalyzerBase<RH0227Na
     /// <param name="context">Context</param>
     private void OnCompilationStart(CompilationStartAnalysisContext context)
     {
-        if (ConfigurationManager.TryGetConfiguration(context.Options.AdditionalFiles, out var configuration)
-            && configuration?.Naming?.AllowedNamespaceDeclarations?.Count > 0)
+        var configuration = ConfigurationManager.GetConfiguration(context.Options.AdditionalFiles).Configuration;
+
+        if (configuration?.Naming?.AllowedNamespaceDeclarations?.Count > 0)
         {
             context.RegisterSyntaxNodeAction(analysisContext => OnNamespaceDeclarationSyntax(configuration, analysisContext), SyntaxKind.NamespaceDeclaration, SyntaxKind.FileScopedNamespaceDeclaration);
         }

--- a/Reihitsu.sln
+++ b/Reihitsu.sln
@@ -245,6 +245,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		documentation\rules\RH0612.md = documentation\rules\RH0612.md
 		documentation\rules\RH0613.md = documentation\rules\RH0613.md
 		documentation\rules\RH0614.md = documentation\rules\RH0614.md
+		documentation\rules\RH0701.md = documentation\rules\RH0701.md
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Reihitsu.Formatter", "Reihitsu.Formatter\Reihitsu.Formatter.csproj", "{E0C1F14C-6D72-4719-998B-F076CFCD665C}"

--- a/documentation/rules/RH0701.md
+++ b/documentation/rules/RH0701.md
@@ -1,0 +1,46 @@
+# RH0701 — reihitsu.json configuration must be valid
+
+| Property | Value |
+|----------|-------|
+| **ID** | RH0701 |
+| **Category** | Analyzer |
+| **Severity** | Warning |
+| **Code Fix** | ❌ |
+
+## Description
+
+This rule reports invalid `reihitsu.json` files. The configuration must use valid JSON and only supported sections, properties, and value types.
+
+## Why is this a problem?
+
+Invalid analyzer configuration is easy to miss. When the file cannot be read or contains unsupported content, rules that depend on it may stop working as intended.
+
+## How to fix it
+
+Open `reihitsu.json` and correct the reported problem. Make sure the file contains valid JSON, only known configuration sections and properties, and values in the expected shape.
+
+## Examples
+
+### Violation
+
+```cs
+// reihitsu.json
+{
+  "Naming": {
+    "AllowedNamespaceDeclarations": "MyCompany.Project"
+  }
+}
+```
+
+### Correction
+
+```cs
+// reihitsu.json
+{
+  "Naming": {
+    "AllowedNamespaceDeclarations": [
+      "MyCompany.Project"
+    ]
+  }
+}
+```


### PR DESCRIPTION
Closes #104

## Summary

- add RH0701 as the first rule in the new Analyzer category and RH07xx range
- report invalid or unreadable `reihitsu.json` with dedicated diagnostics instead of silently ignoring failures
- refactor shared configuration loading so RH0227 and future config-driven rules can reuse validated configuration results
- add focused analyzer tests and rule documentation for the new behavior
