### PR TITLE
Add front-page README showcase example

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -24,6 +24,83 @@ dotnet tool install -g Reihitsu.Cli
 reihitsu-format src/
 ```
 
+## Showcase
+The following is a code snippet that complies with the rules of the analyzer and formatter.
+
+```csharp
+/// <summary>
+/// Builds report instances from a list of customer orders
+/// </summary>
+internal sealed class ReportBuilder
+{
+    #region Fields
+
+    /// <summary>
+    /// The orders that can are used to build the report
+    /// </summary>
+    private readonly IReadOnlyList<Order> _orders;
+
+    #endregion // Fields
+
+    #region Constructor
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReportBuilder"/> class
+    /// </summary>
+    /// <param name="orders">The orders that can be used to build reports</param>
+    public ReportBuilder(IReadOnlyList<Order> orders)
+    {
+        _orders = orders ?? throw new ArgumentNullException(nameof(orders));
+    }
+
+    #endregion // Constructor
+
+    #region Methods
+
+    /// <summary>
+    /// Builds a report for a specific customer
+    /// </summary>
+    /// <param name="customerId">The customer identifier to filter for</param>
+    /// <param name="createdOn">The date assigned to the generated report</param>
+    /// <param name="includeInactive">A value indicating whether inactive orders should be included</param>
+    /// <returns>The generated report</returns>
+    public Report Build(string customerId, DateOnly createdOn, bool includeInactive)
+    {
+        var items = _orders.Where(order => order.CustomerId == customerId)
+                           .Where(order => includeInactive || order.IsActive)
+                           .Select(order => new ReportItem
+                                            {
+                                                Id = order.Id,
+                                                Lines = order.Lines
+                                                             .Select(line => new ReportLine
+                                                                             {
+                                                                                 Name = line.Name,
+                                                                                 Total = line.UnitPrice
+                                                                                         * line.Quantity
+                                                                             })
+                                                             .ToArray()
+                                            })
+                           .OrderBy(item => item.Id)
+                           .ToArray();
+
+        return new Report(customerId,
+                          createdOn,
+                          items,
+                          new ReportOptions
+                          {
+                              IncludeTotals = true,
+                              UseShortDates = false,
+                              Labels = [
+                                           "stable",
+                                           "demo"
+                                       ]
+                          });
+    }
+
+    #endregion // Methods
+}
+```
+
 ## License
 
 This project is licensed under the terms of the [LICENSE](LICENSE) file.


### PR DESCRIPTION
## Summary

Add a front-page README showcase with a formatter- and analyzer-compliant C# example.

## Why

The repository front page did not show what Reihitsu-formatted code looks like, which made the formatter harder to evaluate at a glance.

## Linked issues

Closes #96

## Review notes

The showcase is intentionally compact but broad: it includes XML comments, regions, fluent LINQ chains, object creation, and indentation/alignment behavior.

## Follow-up work

None
