### PR TITLE
Add RH0503 string interpolation analyzer

### DIFF
--- a/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0328RegionsShouldStartWithAUpperCaseLetterCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0328RegionsShouldStartWithAUpperCaseLetterCodeFixProvider.cs
@@ -99,9 +99,7 @@ public class RH0328RegionsShouldStartWithAUpperCaseLetterCodeFixProvider : CodeF
 
         while (startIndex >= 0)
         {
-            result = result.Substring(0, startIndex)
-                     + newValue
-                     + result.Substring(startIndex + oldValue.Length);
+            result = $"{result.Substring(0, startIndex)}{newValue}{result.Substring(startIndex + oldValue.Length)}";
             startIndex = result.IndexOf(oldValue, startIndex + newValue.Length, StringComparison.Ordinal);
         }
 
@@ -177,9 +175,7 @@ public class RH0328RegionsShouldStartWithAUpperCaseLetterCodeFixProvider : CodeF
                 return false;
             }
 
-            updatedText = text.Substring(0, charIndex)
-                          + char.ToUpperInvariant(text[charIndex])
-                          + text.Substring(charIndex + 1);
+            updatedText = $"{text.Substring(0, charIndex)}{char.ToUpperInvariant(text[charIndex])}{text.Substring(charIndex + 1)}";
             updatedName = updatedText.Substring(charIndex);
 
             return true;

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0337DocumentationLinesMustBeginWithSingleSpaceCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0337DocumentationLinesMustBeginWithSingleSpaceCodeFixProvider.cs
@@ -36,7 +36,7 @@ public class RH0337DocumentationLinesMustBeginWithSingleSpaceCodeFixProvider : C
         var trimmed = lineText.TrimStart();
         var indentation = lineText.Substring(0, lineText.Length - trimmed.Length);
         var suffix = trimmed.StartsWith("///", StringComparison.Ordinal) ? trimmed.Substring(3).TrimStart() : trimmed;
-        var replacement = indentation + "///" + (suffix.Length == 0 ? string.Empty : " " + suffix);
+        var replacement = $"{indentation}///{(suffix.Length == 0 ? string.Empty : $" {suffix}")}";
 
         return document.WithText(sourceText.Replace(TextSpan.FromBounds(line.Start, line.End), replacement));
     }

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0360StatementMustNotBeOnSingleLineCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0360StatementMustNotBeOnSingleLineCodeFixProvider.cs
@@ -50,7 +50,7 @@ public class RH0360StatementMustNotBeOnSingleLineCodeFixProvider : CodeFixProvid
         var indentation = GetIndentation(FormattingTextAnalysisUtilities.GetLineText(sourceText, line));
         var innerIndentation = indentation + "    ";
         var content = sourceText.ToString(TextSpan.FromBounds(block.OpenBraceToken.Span.End, block.CloseBraceToken.SpanStart)).Trim();
-        var replacement = "{" + Environment.NewLine + innerIndentation + content + Environment.NewLine + indentation + "}";
+        var replacement = $"{{{Environment.NewLine}{innerIndentation}{content}{Environment.NewLine}{indentation}}}";
 
         return document.WithText(sourceText.Replace(block.Span, replacement));
     }

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0361ElementMustNotBeOnSingleLineCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0361ElementMustNotBeOnSingleLineCodeFixProvider.cs
@@ -51,8 +51,8 @@ public class RH0361ElementMustNotBeOnSingleLineCodeFixProvider : CodeFixProvider
         var content = sourceText.ToString(TextSpan.FromBounds(declaration.OpenBraceToken.Span.End, declaration.CloseBraceToken.SpanStart)).Trim();
         var memberIndentation = indentation + "    ";
         var replacement = content.Length == 0
-                              ? Environment.NewLine + indentation + "{" + Environment.NewLine + indentation + "}"
-                              : Environment.NewLine + indentation + "{" + Environment.NewLine + memberIndentation + content + Environment.NewLine + indentation + "}";
+                              ? $"{Environment.NewLine}{indentation}{{{Environment.NewLine}{indentation}}}"
+                              : $"{Environment.NewLine}{indentation}{{{Environment.NewLine}{memberIndentation}{content}{Environment.NewLine}{indentation}}}";
         var replacementStart = declaration.OpenBraceToken.SpanStart;
 
         while (replacementStart > declaration.SpanStart

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0362BracesMustNotBeOmittedCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0362BracesMustNotBeOmittedCodeFixProvider.cs
@@ -87,7 +87,7 @@ public class RH0362BracesMustNotBeOmittedCodeFixProvider : CodeFixProvider
         var parentLine = sourceText.Lines.GetLineFromPosition(parentNode?.SpanStart ?? statement.SpanStart);
         var parentIndentation = GetIndentation(FormattingTextAnalysisUtilities.GetLineText(sourceText, parentLine));
         var statementText = sourceText.ToString(statement.Span);
-        var replacement = parentIndentation + "{" + Environment.NewLine + statementIndentation + statementText + Environment.NewLine + parentIndentation + "}";
+        var replacement = $"{parentIndentation}{{{Environment.NewLine}{statementIndentation}{statementText}{Environment.NewLine}{parentIndentation}}}";
         var replacementSpan = TextSpan.FromBounds(statementLine.Start, statement.Span.End);
 
         return document.WithText(sourceText.Replace(replacementSpan, replacement));

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0373BracesMustNotBeOmittedFromMultiLineChildStatementsCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0373BracesMustNotBeOmittedFromMultiLineChildStatementsCodeFixProvider.cs
@@ -87,7 +87,7 @@ public class RH0373BracesMustNotBeOmittedFromMultiLineChildStatementsCodeFixProv
         var parentLine = sourceText.Lines.GetLineFromPosition(parentNode?.SpanStart ?? statement.SpanStart);
         var parentIndentation = GetIndentation(FormattingTextAnalysisUtilities.GetLineText(sourceText, parentLine));
         var statementText = sourceText.ToString(statement.Span);
-        var replacement = parentIndentation + "{" + Environment.NewLine + statementIndentation + statementText + Environment.NewLine + parentIndentation + "}";
+        var replacement = $"{parentIndentation}{{{Environment.NewLine}{statementIndentation}{statementText}{Environment.NewLine}{parentIndentation}}}";
         var replacementSpan = TextSpan.FromBounds(statementLine.Start, statement.Span.End);
 
         return document.WithText(sourceText.Replace(replacementSpan, replacement));

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0374UseBracesConsistentlyCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0374UseBracesConsistentlyCodeFixProvider.cs
@@ -87,7 +87,7 @@ public class RH0374UseBracesConsistentlyCodeFixProvider : CodeFixProvider
         var parentLine = sourceText.Lines.GetLineFromPosition(parentNode?.SpanStart ?? statement.SpanStart);
         var parentIndentation = GetIndentation(FormattingTextAnalysisUtilities.GetLineText(sourceText, parentLine));
         var statementText = sourceText.ToString(statement.Span);
-        var replacement = parentIndentation + "{" + Environment.NewLine + statementIndentation + statementText + Environment.NewLine + parentIndentation + "}";
+        var replacement = $"{parentIndentation}{{{Environment.NewLine}{statementIndentation}{statementText}{Environment.NewLine}{parentIndentation}}}";
         var replacementSpan = TextSpan.FromBounds(statementLine.Start, statement.Span.End);
 
         return document.WithText(sourceText.Replace(replacementSpan, replacement));

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0376CommentsMustBeOnTheirOwnLineCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0376CommentsMustBeOnTheirOwnLineCodeFixProvider.cs
@@ -36,7 +36,7 @@ public class RH0376CommentsMustBeOnTheirOwnLineCodeFixProvider : CodeFixProvider
         var indentation = GetIndentation(FormattingTextAnalysisUtilities.GetLineText(sourceText, affectedLine));
         var commentSpanToReplace = GetCommentSpanToReplace(sourceText, diagnosticSpan);
         var updatedText = sourceText.Replace(commentSpanToReplace, string.Empty);
-        var insertionText = indentation + commentText + Environment.NewLine;
+        var insertionText = $"{indentation}{commentText}{Environment.NewLine}";
 
         return document.WithText(updatedText.Replace(new TextSpan(affectedLine.Start, 0), insertionText));
     }

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0381ParametersMustBeOnSameLineOrSeparateLinesCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Formatting/RH0381ParametersMustBeOnSameLineOrSeparateLinesCodeFixProvider.cs
@@ -51,7 +51,7 @@ public class RH0381ParametersMustBeOnSameLineOrSeparateLinesCodeFixProvider : Co
         var firstParameterLine = sourceText.Lines.GetLineFromPosition(firstParameter.SpanStart);
         var firstParameterColumn = firstParameter.SpanStart - firstParameterLine.Start;
         var alignment = new string(' ', firstParameterColumn);
-        var replacement = "(" + parameters.First() + "," + Environment.NewLine + alignment + string.Join("," + Environment.NewLine + alignment, parameters.Skip(1)) + ")";
+        var replacement = $"({parameters.First()},{Environment.NewLine}{alignment}{string.Join($",{Environment.NewLine}{alignment}", parameters.Skip(1))})";
         var updatedDocument = document.WithText(sourceText.Replace(parameterList.Span, replacement));
         var updatedRoot = await updatedDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
         var updatedParameterList = updatedRoot?.FindToken(parameterList.SpanStart).Parent?.FirstAncestorOrSelf<ParameterListSyntax>();

--- a/Reihitsu.Analyzer.Package/README.MD
+++ b/Reihitsu.Analyzer.Package/README.MD
@@ -239,5 +239,6 @@ The **Formatter** column indicates whether running the Reihitsu formatter can au
 || **Performance**||||
 | [RH0501](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0501.md)| Types used as dictionary keys or in hash sets must implement equality members.| ✔| ❌| ❌|
 | [RH0502](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0502.md)| Types used for equality comparison must implement equality members.| ✔| ❌| ❌|
+| [RH0503](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0503.md)| Use string interpolation instead of string concatenation.| ✔| ❌| ❌|
 || **Analyzer**||||
 | [RH0701](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0701.md)| reihitsu.json configuration must be valid.| ✔| ❌| ❌|

--- a/Reihitsu.Analyzer.Test/Performance/RH0503UseStringInterpolationInsteadOfStringConcatenationAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Performance/RH0503UseStringInterpolationInsteadOfStringConcatenationAnalyzerTests.cs
@@ -1,0 +1,154 @@
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Analyzer.Rules.Performance;
+using Reihitsu.Analyzer.Test.Base;
+
+namespace Reihitsu.Analyzer.Test.Performance;
+
+/// <summary>
+/// Test methods for <see cref="RH0503UseStringInterpolationInsteadOfStringConcatenationAnalyzer"/>
+/// </summary>
+[TestClass]
+public class RH0503UseStringInterpolationInsteadOfStringConcatenationAnalyzerTests : AnalyzerTestsBase<RH0503UseStringInterpolationInsteadOfStringConcatenationAnalyzer>
+{
+    #region Methods
+
+    /// <summary>
+    /// Verifying that non-constant string concatenation chains are reported
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNonConstantStringConcatenationChainIsReported()
+    {
+        const string testData = """
+                                namespace Reihitsu.Analyzer.Test.Performance.Resources;
+
+                                internal class RH0503
+                                {
+                                    public string GetMessage(string userName, int userId, string role)
+                                    {
+                                        return {|#0:"User: " + userName + ", Id: " + userId + ", Role: " + role|};
+                                    }
+                                }
+                                """;
+
+        await Verify(testData, Diagnostics(RH0503UseStringInterpolationInsteadOfStringConcatenationAnalyzer.DiagnosticId, AnalyzerResources.RH0503MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying that compile-time constant string concatenation chains are not reported
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCompileTimeConstantStringConcatenationChainIsIgnored()
+    {
+        const string testData = """
+                                namespace Reihitsu.Analyzer.Test.Performance.Resources;
+
+                                internal class RH0503
+                                {
+                                    public string GetMessage()
+                                    {
+                                        const string prefix = "User";
+                                        const string suffix = "Name";
+
+                                        return prefix + ": " + suffix;
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifying that two-part string concatenations are not reported
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyTwoPartStringConcatenationIsIgnored()
+    {
+        const string testData = """
+                                namespace Reihitsu.Analyzer.Test.Performance.Resources;
+
+                                internal class RH0503
+                                {
+                                    public string GetMessage(string prefix, string name)
+                                    {
+                                        return prefix + name;
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifying that nested add expressions inside a single concatenation chain only report once
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNestedConcatenationChainOnlyReportsOnce()
+    {
+        const string testData = """
+                                namespace Reihitsu.Analyzer.Test.Performance.Resources;
+
+                                internal class RH0503
+                                {
+                                    public string GetMessage(string prefix, string name, string suffix)
+                                    {
+                                        return {|#0:(prefix + name) + suffix|};
+                                    }
+                                }
+                                """;
+
+        await Verify(testData, Diagnostics(RH0503UseStringInterpolationInsteadOfStringConcatenationAnalyzer.DiagnosticId, AnalyzerResources.RH0503MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying that non-string addition expressions are ignored
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNonStringAdditionExpressionIsIgnored()
+    {
+        const string testData = """
+                                namespace Reihitsu.Analyzer.Test.Performance.Resources;
+
+                                internal class RH0503
+                                {
+                                    public int GetValue(int left, int right)
+                                    {
+                                        return left + right;
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifying that constant nested expressions within a reported chain do not prevent reporting
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyStringConcatenationChainWithConstantSubExpressionIsReported()
+    {
+        const string testData = """
+                                namespace Reihitsu.Analyzer.Test.Performance.Resources;
+
+                                internal class RH0503
+                                {
+                                    public string GetMessage(string name)
+                                    {
+                                        return {|#0:"Hello " + (1 + 2) + name|};
+                                    }
+                                }
+                                """;
+
+        await Verify(testData, Diagnostics(RH0503UseStringInterpolationInsteadOfStringConcatenationAnalyzer.DiagnosticId, AnalyzerResources.RH0503MessageFormat));
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Analyzer.Test/SelfHosting/SelfHostingTests.cs
+++ b/Reihitsu.Analyzer.Test/SelfHosting/SelfHostingTests.cs
@@ -532,8 +532,8 @@ public class SelfHostingTests
     /// <returns><see langword="true"/> if the path is inside bin or obj; otherwise, <see langword="false"/></returns>
     private static bool IsInBuildOutputPath(string path)
     {
-        return path.Contains(Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)
-               || path.Contains(Path.DirectorySeparatorChar + "obj" + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+        return path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase)
+               || path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer/AnalyzerResources.cs
+++ b/Reihitsu.Analyzer/AnalyzerResources.cs
@@ -2204,6 +2204,16 @@ internal static class AnalyzerResources
     /// </summary>
     internal static string RH0502Title => GetString(nameof(RH0502Title));
 
+    /// <summary>
+    /// Gets the localized string for RH0503MessageFormat
+    /// </summary>
+    internal static string RH0503MessageFormat => GetString(nameof(RH0503MessageFormat));
+
+    /// <summary>
+    /// Gets the localized string for RH0503Title
+    /// </summary>
+    internal static string RH0503Title => GetString(nameof(RH0503Title));
+
     #endregion // Properties
 
     #region Methods

--- a/Reihitsu.Analyzer/AnalyzerResources.resx
+++ b/Reihitsu.Analyzer/AnalyzerResources.resx
@@ -1431,4 +1431,10 @@
   <data name="RH0502Title" xml:space="preserve">
     <value>Types used for equality comparison must implement equality members</value>
   </data>
+  <data name="RH0503MessageFormat" xml:space="preserve">
+    <value>Use string interpolation instead of string concatenation.</value>
+  </data>
+  <data name="RH0503Title" xml:space="preserve">
+    <value>Use string interpolation instead of string concatenation.</value>
+  </data>
 </root>

--- a/Reihitsu.Analyzer/Base/RegionDescriptionAnalyzerBase{TAnalyzer}.cs
+++ b/Reihitsu.Analyzer/Base/RegionDescriptionAnalyzerBase{TAnalyzer}.cs
@@ -39,8 +39,7 @@ public abstract class RegionDescriptionAnalyzerBase<TAnalyzer> : DiagnosticAnaly
     /// <returns>Description text</returns>
     private static string GetEndRegionDescription(EndRegionDirectiveTriviaSyntax directive)
     {
-        var description = (directive.EndRegionKeyword.TrailingTrivia.ToFullString()
-                           + directive.EndOfDirectiveToken.LeadingTrivia.ToFullString()).Trim();
+        var description = $"{directive.EndRegionKeyword.TrailingTrivia.ToFullString()}{directive.EndOfDirectiveToken.LeadingTrivia.ToFullString()}".Trim();
 
         if (description.StartsWith("//", StringComparison.Ordinal))
         {

--- a/Reihitsu.Analyzer/Rules/Naming/RH0201TypeNameShouldMatchFileNameHelper.cs
+++ b/Reihitsu.Analyzer/Rules/Naming/RH0201TypeNameShouldMatchFileNameHelper.cs
@@ -43,7 +43,7 @@ internal static class RH0201TypeNameShouldMatchFileNameHelper
 
         if (typeParameterList is { Parameters.Count: > 0 })
         {
-            typeName += "{" + string.Join(",", typeParameterList.Parameters.Select(parameter => parameter.Identifier.Text)) + "}";
+            typeName = $"{typeName}{{{string.Join(",", typeParameterList.Parameters.Select(parameter => parameter.Identifier.Text))}}}";
         }
 
         return typeName;
@@ -62,7 +62,7 @@ internal static class RH0201TypeNameShouldMatchFileNameHelper
         var suffix = firstDotIndex >= 0 ? fileNameWithoutExtension.Substring(firstDotIndex) : string.Empty;
         var extension = Path.GetExtension(originalFilePath);
 
-        return GetExpectedFileNameStem(typeDeclaration) + suffix + extension;
+        return $"{GetExpectedFileNameStem(typeDeclaration)}{suffix}{extension}";
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer/Rules/Performance/RH0503UseStringInterpolationInsteadOfStringConcatenationAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Performance/RH0503UseStringInterpolationInsteadOfStringConcatenationAnalyzer.cs
@@ -1,0 +1,195 @@
+using System.Collections.Generic;
+using System.Threading;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Enumerations;
+
+namespace Reihitsu.Analyzer.Rules.Performance;
+
+/// <summary>
+/// RH0503: Use string interpolation instead of string concatenation
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class RH0503UseStringInterpolationInsteadOfStringConcatenationAnalyzer : DiagnosticAnalyzerBase<RH0503UseStringInterpolationInsteadOfStringConcatenationAnalyzer>
+{
+    #region Constants
+
+    /// <summary>
+    /// Diagnostic ID
+    /// </summary>
+    public const string DiagnosticId = "RH0503";
+
+    #endregion // Constants
+
+    #region Constructor
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public RH0503UseStringInterpolationInsteadOfStringConcatenationAnalyzer()
+        : base(DiagnosticId, DiagnosticCategory.Performance, nameof(AnalyzerResources.RH0503Title), nameof(AnalyzerResources.RH0503MessageFormat))
+    {
+    }
+
+    #endregion // Constructor
+
+    #region Methods
+
+    /// <summary>
+    /// Count the individual segments that make up a concatenation chain
+    /// </summary>
+    /// <param name="addExpression">Add expression</param>
+    /// <returns>Number of concatenation chain segments</returns>
+    private static int CountSegments(BinaryExpressionSyntax addExpression)
+    {
+        return EnumerateChainSegments(addExpression).Count();
+    }
+
+    /// <summary>
+    /// Determine whether the chain contains a non-constant segment
+    /// </summary>
+    /// <param name="addExpression">Add expression</param>
+    /// <param name="semanticModel">Semantic model</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns><see langword="true"/> if the chain contains a non-constant segment</returns>
+    private static bool ContainsNonConstantSegment(BinaryExpressionSyntax addExpression, SemanticModel semanticModel, CancellationToken cancellationToken)
+    {
+        foreach (var segment in EnumerateChainSegments(addExpression))
+        {
+            if (semanticModel.GetConstantValue(segment, cancellationToken).HasValue == false)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Enumerate the individual segments that make up a concatenation chain
+    /// </summary>
+    /// <param name="expressionSyntax">Expression syntax</param>
+    /// <returns>Concatenation chain segments</returns>
+    private static IEnumerable<ExpressionSyntax> EnumerateChainSegments(ExpressionSyntax expressionSyntax)
+    {
+        if (expressionSyntax is ParenthesizedExpressionSyntax parenthesizedExpression)
+        {
+            foreach (var segment in EnumerateChainSegments(parenthesizedExpression.Expression))
+            {
+                yield return segment;
+            }
+
+            yield break;
+        }
+
+        if (expressionSyntax is BinaryExpressionSyntax binaryExpression
+            && binaryExpression.IsKind(SyntaxKind.AddExpression))
+        {
+            foreach (var segment in EnumerateChainSegments(binaryExpression.Left))
+            {
+                yield return segment;
+            }
+
+            foreach (var segment in EnumerateChainSegments(binaryExpression.Right))
+            {
+                yield return segment;
+            }
+
+            yield break;
+        }
+
+        yield return expressionSyntax;
+    }
+
+    /// <summary>
+    /// Determine whether the expression is nested inside a larger string concatenation chain
+    /// </summary>
+    /// <param name="addExpression">Add expression</param>
+    /// <param name="semanticModel">Semantic model</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns><see langword="true"/> if the expression is nested inside a larger string concatenation chain</returns>
+    private static bool IsNestedInsideLargerStringConcatenationChain(BinaryExpressionSyntax addExpression, SemanticModel semanticModel, CancellationToken cancellationToken)
+    {
+        ExpressionSyntax currentExpression = addExpression;
+
+        while (currentExpression.Parent is ParenthesizedExpressionSyntax parenthesizedExpression)
+        {
+            currentExpression = parenthesizedExpression;
+        }
+
+        return currentExpression.Parent is BinaryExpressionSyntax parentBinaryExpression
+               && parentBinaryExpression.IsKind(SyntaxKind.AddExpression)
+               && IsStringExpression(parentBinaryExpression, semanticModel, cancellationToken);
+    }
+
+    /// <summary>
+    /// Determine whether the expression resolves to <see cref="string"/>
+    /// </summary>
+    /// <param name="expressionSyntax">Expression syntax</param>
+    /// <param name="semanticModel">Semantic model</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns><see langword="true"/> if the expression resolves to <see cref="string"/></returns>
+    private static bool IsStringExpression(ExpressionSyntax expressionSyntax, SemanticModel semanticModel, CancellationToken cancellationToken)
+    {
+        var typeInfo = semanticModel.GetTypeInfo(expressionSyntax, cancellationToken);
+        var expressionType = typeInfo.ConvertedType ?? typeInfo.Type;
+
+        return expressionType?.SpecialType == SpecialType.System_String;
+    }
+
+    /// <summary>
+    /// Analyze add expressions
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnAddExpression(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not BinaryExpressionSyntax addExpression)
+        {
+            return;
+        }
+
+        if (IsNestedInsideLargerStringConcatenationChain(addExpression, context.SemanticModel, context.CancellationToken))
+        {
+            return;
+        }
+
+        if (IsStringExpression(addExpression, context.SemanticModel, context.CancellationToken) == false)
+        {
+            return;
+        }
+
+        if (CountSegments(addExpression) < 3)
+        {
+            return;
+        }
+
+        if (context.SemanticModel.GetConstantValue(addExpression, context.CancellationToken).HasValue)
+        {
+            return;
+        }
+
+        if (ContainsNonConstantSegment(addExpression, context.SemanticModel, context.CancellationToken))
+        {
+            context.ReportDiagnostic(CreateDiagnostic(addExpression.GetLocation()));
+        }
+    }
+
+    #endregion // Methods
+
+    #region DiagnosticAnalyzer
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        base.Initialize(context);
+
+        context.RegisterSyntaxNodeAction(OnAddExpression, SyntaxKind.AddExpression);
+    }
+
+    #endregion // DiagnosticAnalyzer
+}

--- a/Reihitsu.Formatter.Test/Idempotency/SelfHostingTests.cs
+++ b/Reihitsu.Formatter.Test/Idempotency/SelfHostingTests.cs
@@ -160,8 +160,8 @@ public class SelfHostingTests
             {
                 var relativePath = Path.GetRelativePath(solutionRoot, file);
 
-                if (relativePath.Contains(Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar)
-                    || relativePath.Contains(Path.DirectorySeparatorChar + "obj" + Path.DirectorySeparatorChar))
+                if (relativePath.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}")
+                    || relativePath.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}"))
                 {
                     continue;
                 }

--- a/Reihitsu.Formatter/Pipeline/DocumentationComments/DocumentationCommentFormattingPhase.cs
+++ b/Reihitsu.Formatter/Pipeline/DocumentationComments/DocumentationCommentFormattingPhase.cs
@@ -66,7 +66,7 @@ internal static class DocumentationCommentFormattingPhase
     {
         var contentLines = GetElementContentLines(element, sourceText, documentationPrefix);
 
-        return sourceText.ToString(element.StartTag.Span) + contentLines[0] + sourceText.ToString(element.EndTag.Span);
+        return $"{sourceText.ToString(element.StartTag.Span)}{contentLines[0]}{sourceText.ToString(element.EndTag.Span)}";
     }
 
     /// <summary>
@@ -254,7 +254,7 @@ internal static class DocumentationCommentFormattingPhase
                 var relativeStart = element.Span.Start - documentationCommentTrivia.FullSpan.Start;
                 var relativeEnd = element.Span.End - documentationCommentTrivia.FullSpan.Start;
 
-                normalizedCommentText = normalizedCommentText.Substring(0, relativeStart) + replacementText + normalizedCommentText.Substring(relativeEnd);
+                normalizedCommentText = $"{normalizedCommentText.Substring(0, relativeStart)}{replacementText}{normalizedCommentText.Substring(relativeEnd)}";
                 changed = true;
             }
         }

--- a/Reihitsu.sln
+++ b/Reihitsu.sln
@@ -231,6 +231,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		documentation\rules\RH0451.md = documentation\rules\RH0451.md
 		documentation\rules\RH0501.md = documentation\rules\RH0501.md
 		documentation\rules\RH0502.md = documentation\rules\RH0502.md
+		documentation\rules\RH0503.md = documentation\rules\RH0503.md
 		documentation\rules\RH0601.md = documentation\rules\RH0601.md
 		documentation\rules\RH0602.md = documentation\rules\RH0602.md
 		documentation\rules\RH0603.md = documentation\rules\RH0603.md
@@ -260,6 +261,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Scripts", "Scripts", "{5EEF
 	ProjectSection(SolutionItems) = preProject
 		scripts\install_cli.ps1 = scripts\install_cli.ps1
 	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{0D60025A-7C27-41A2-9512-09633033A1C0}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Analyzer", "Analyzer", "{993F7A87-91E0-4B4F-BC8C-FCA5BA91008B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Formatter", "Formatter", "{1D8454CC-5EF1-4880-A4A5-A319FC9441B0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -369,6 +376,16 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{3CD0BCF3-D255-4CEB-B9F5-F8B9AEAE9400} = {993F7A87-91E0-4B4F-BC8C-FCA5BA91008B}
+		{656A7128-E770-4240-AF0B-F74C127BA307} = {993F7A87-91E0-4B4F-BC8C-FCA5BA91008B}
+		{F84C1FEB-DA12-4DFD-8145-CBB2DF90A783} = {993F7A87-91E0-4B4F-BC8C-FCA5BA91008B}
+		{5B04607B-ED64-4C9D-BF8E-6C18BD15C336} = {0D60025A-7C27-41A2-9512-09633033A1C0}
+		{E0C1F14C-6D72-4719-998B-F076CFCD665C} = {1D8454CC-5EF1-4880-A4A5-A319FC9441B0}
+		{C55DE3AC-3027-4B8B-AE2A-12FDBBB3B908} = {0D60025A-7C27-41A2-9512-09633033A1C0}
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890} = {1D8454CC-5EF1-4880-A4A5-A319FC9441B0}
+		{CEFCDC4D-1738-4B47-8212-CB37FF659773} = {0D60025A-7C27-41A2-9512-09633033A1C0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {137BBE7E-6903-4FD7-9BAC-0E9EB957D647}

--- a/documentation/rules/RH0503.md
+++ b/documentation/rules/RH0503.md
@@ -1,0 +1,34 @@
+# RH0503 — Use string interpolation instead of string concatenation
+
+| Property | Value |
+|----------|-------|
+| **ID** | RH0503 |
+| **Category** | Performance |
+| **Severity** | Warning |
+| **Code Fix** | ❌ |
+
+## Description
+
+Prefer string interpolation over non-constant string concatenation chains with three or more parts.
+
+## Why is this a problem?
+
+Long concatenation chains are harder to read and maintain than a single interpolated string. They can also create unnecessary intermediate strings when the expression is built from runtime values. Short two-part concatenations are ignored by this rule.
+
+## How to fix it
+
+Replace the concatenation chain with an interpolated string and move each runtime value into an interpolation.
+
+## Examples
+
+### Violation
+
+```cs
+var message = "User: " + user.Name + ", Id: " + user.Id + ", Role: " + role;
+```
+
+### Correction
+
+```cs
+var message = $"User: {user.Name}, Id: {user.Id}, Role: {role}";
+```


### PR DESCRIPTION
## Summary

Add RH0503 as a new performance analyzer for non-constant string concatenation chains and wire in its tests, resources, and rule documentation.

## Why

Long string concatenation chains are harder to read and can be replaced with interpolation. This adds analyzer-only guidance for that pattern while avoiding noise from two-part and fully constant concatenations.

## Linked issues

Closes #99

## Review notes

RH0503 is analyzer-only in this first version. It reports only top-level string concatenation chains with at least three parts, ignores fully compile-time-constant chains, and does not flag simple two-part concatenations.

## Follow-up work

None
