### PR TITLE
Fix multiline argument wrapping in formatter

### DIFF
--- a/Reihitsu.Formatter.Test/Regression/FullPipeline/ArgumentFormattingFullPipelineTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/FullPipeline/ArgumentFormattingFullPipelineTests.cs
@@ -378,6 +378,228 @@ public class ArgumentFormattingFullPipelineTests : FormatterTestsBase
     }
 
     /// <summary>
+    /// Verifies that outer arguments fully split when an expression-lambda body becomes
+    /// multi-line because it wraps a multi-member anonymous object
+    /// </summary>
+    [TestMethod]
+    public void FormatsArgumentsWhenLambdaContainsMultiMemberAnonymousObject()
+    {
+        const string input = """
+                             internal class LambdaAnonymousObjectArgumentTestData
+                             {
+                                 void Method()
+                                 {
+                                     PrimaryKey("first", value => new { value.Alpha, value.Beta }, "third");
+                                 }
+
+                                 void PrimaryKey(string first, object second, string third) { }
+                             }
+                             """;
+
+        const string expected = """
+                                internal class LambdaAnonymousObjectArgumentTestData
+                                {
+                                    void Method()
+                                    {
+                                        PrimaryKey("first",
+                                                   value => new
+                                                            {
+                                                                value.Alpha,
+                                                                value.Beta
+                                                            },
+                                                   "third");
+                                    }
+
+                                    void PrimaryKey(string first, object second, string third)
+                                    {
+                                    }
+                                }
+                                """;
+
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that outer arguments fully split when an expression-lambda body becomes
+    /// multi-line because it wraps an object initializer
+    /// </summary>
+    [TestMethod]
+    public void FormatsArgumentsWhenLambdaContainsMultiMemberObjectInitializer()
+    {
+        const string input = """
+                             using System;
+
+                             internal class LambdaObjectInitializerArgumentTestData
+                             {
+                                 void Method()
+                                 {
+                                     Create("first", value => new Settings { Alpha = 1, Beta = 2 }, "third");
+                                 }
+
+                                 void Create(string first, Func<int, Settings> second, string third) { }
+                             }
+
+                             internal class Settings
+                             {
+                                 internal int Alpha { get; set; }
+
+                                 internal int Beta { get; set; }
+                             }
+                             """;
+
+        const string expected = """
+                                using System;
+
+                                internal class LambdaObjectInitializerArgumentTestData
+                                {
+                                    void Method()
+                                    {
+                                        Create("first",
+                                               value => new Settings
+                                                        {
+                                                            Alpha = 1,
+                                                            Beta = 2
+                                                        },
+                                               "third");
+                                    }
+
+                                    void Create(string first, Func<int, Settings> second, string third)
+                                    {
+                                    }
+                                }
+
+                                internal class Settings
+                                {
+                                    internal int Alpha { get; set; }
+
+                                    internal int Beta { get; set; }
+                                }
+                                """;
+
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that outer arguments fully split when an expression-lambda body invocation
+    /// becomes multi-line after its nested anonymous object is rewritten
+    /// </summary>
+    [TestMethod]
+    public void FormatsArgumentsWhenLambdaBodyInvocationBecomesMultiLine()
+    {
+        const string input = """
+                             internal class LambdaInvocationArgumentTestData
+                             {
+                                 void Method()
+                                 {
+                                     Call("first", value => Project(new { Alpha = 1, Beta = 2 }), "third");
+                                 }
+
+                                 string Project(object value) => value.ToString();
+
+                                 void Call(string first, object second, string third) { }
+                             }
+                             """;
+
+        const string expected = """
+                                internal class LambdaInvocationArgumentTestData
+                                {
+                                    void Method()
+                                    {
+                                        Call("first",
+                                             value => Project(new
+                                                              {
+                                                                  Alpha = 1,
+                                                                  Beta = 2
+                                                              }),
+                                             "third");
+                                    }
+
+                                    string Project(object value)
+                                    {
+                                        return value.ToString();
+                                    }
+
+                                    void Call(string first, object second, string third)
+                                    {
+                                    }
+                                }
+                                """;
+
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a statement-lambda used as the second argument makes the outer
+    /// argument list multi-line and formats the lambda block body correctly
+    /// </summary>
+    [TestMethod]
+    public void FormatsStatementLambdaAsSecondArgumentAndSplitsOuterArguments()
+    {
+        const string input = """
+                             internal class StatementLambdaSecondArgumentTestData
+                             {
+                                 void Method()
+                                 {
+                                     var changed = Apply(entry => entry.Key == currentKey, entry => { entry.State = nextState; entry.Payload = nextPayload; });
+                                 }
+
+                                 bool Apply(System.Func<Entry, bool> predicate, System.Action<Entry> action)
+                                 {
+                                     return true;
+                                 }
+
+                                 string currentKey;
+                                 string nextPayload;
+                                 int nextState;
+
+                                 internal class Entry
+                                 {
+                                     internal string Key { get; set; }
+
+                                     internal int State { get; set; }
+
+                                     internal string Payload { get; set; }
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                internal class StatementLambdaSecondArgumentTestData
+                                {
+                                    void Method()
+                                    {
+                                        var changed = Apply(entry => entry.Key == currentKey,
+                                                            entry =>
+                                                            {
+                                                                entry.State = nextState;
+                                                                entry.Payload = nextPayload;
+                                                            });
+                                    }
+
+                                    bool Apply(System.Func<Entry, bool> predicate, System.Action<Entry> action)
+                                    {
+                                        return true;
+                                    }
+
+                                    string currentKey;
+                                    string nextPayload;
+                                    int nextState;
+
+                                    internal class Entry
+                                    {
+                                        internal string Key { get; set; }
+
+                                        internal int State { get; set; }
+
+                                        internal string Payload { get; set; }
+                                    }
+                                }
+                                """;
+
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
     /// Verifies that method chains with mixed-line arguments are formatted correctly
     /// </summary>
     [TestMethod]

--- a/Reihitsu.Formatter.Test/Regression/FullPipeline/BlankLineBeforeStatementFullPipelineTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/FullPipeline/BlankLineBeforeStatementFullPipelineTests.cs
@@ -417,17 +417,18 @@ public class BlankLineBeforeStatementFullPipelineTests
 
                                           public int[] StatementLambdaInLinq()
                                           {
-                                              var values = System.Linq.Enumerable.Select(new[] { 1, 2 }, x =>
-                                                                                                         {
-                                                                                                             var y = x;
+                                              var values = System.Linq.Enumerable.Select(new[] { 1, 2 },
+                                                                                         x =>
+                                                                                         {
+                                                                                             var y = x;
 
-                                                                                                             if (y > 1)
-                                                                                                             {
-                                                                                                                 y++;
-                                                                                                             }
+                                                                                             if (y > 1)
+                                                                                             {
+                                                                                                 y++;
+                                                                                             }
 
-                                                                                                             return y;
-                                                                                                         });
+                                                                                             return y;
+                                                                                         });
 
                                               return System.Linq.Enumerable.ToArray(values);
                                           }

--- a/Reihitsu.Formatter.Test/Regression/Indentation/CollectionExpressionAlignmentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Indentation/CollectionExpressionAlignmentTests.cs
@@ -464,12 +464,13 @@ public class CollectionExpressionAlignmentTests : FormatterTestsBase
                                                            
                                                                               using (var dbFactory = RepositoryFactory.CreateInstance())
                                                                               {
-                                                                                  dbFactory.GetRepository<ScheduleRepository>()
-                                                                                           .Refresh(obj => obj.Id == data.Id, obj =>
-                                                                                                                              {
-                                                                                                                                  obj.Type = data.Type;
-                                                                                                                                  obj.AdditionalData = data.AdditionalData;
-                                                                                                                              });
+                                                                                      dbFactory.GetRepository<ScheduleRepository>()
+                                                                                               .Refresh(obj => obj.Id == data.Id,
+                                                                                                        obj =>
+                                                                                                        {
+                                                                                                            obj.Type = data.Type;
+                                                                                                            obj.AdditionalData = data.AdditionalData;
+                                                                                                        });
                                                                               }
                                                            
                                                                               return true;
@@ -500,11 +501,12 @@ public class CollectionExpressionAlignmentTests : FormatterTestsBase
                                                                                  using (var dbFactory = RepositoryFactory.CreateInstance())
                                                                                  {
                                                                                      dbFactory.GetRepository<ScheduleRepository>()
-                                                                                              .Refresh(obj => obj.Id == data.Id, obj =>
-                                                                                                                                 {
-                                                                                                                                     obj.Type = data.Type;
-                                                                                                                                     obj.AdditionalData = data.AdditionalData;
-                                                                                                                                 });
+                                                                                              .Refresh(obj => obj.Id == data.Id,
+                                                                                                       obj =>
+                                                                                                       {
+                                                                                                           obj.Type = data.Type;
+                                                                                                           obj.AdditionalData = data.AdditionalData;
+                                                                                                       });
                                                                                  }
 
                                                                                  return true;

--- a/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
@@ -307,11 +307,12 @@ public class MethodChainAlignmentTests : FormatterTestsBase
                              """;
 
         const string expected = """
-                                var response = manager.Apply(entry => entry.Key == currentKey, entry =>
-                                                                                               {
-                                                                                                   entry.State = nextState;
-                                                                                                   entry.Payload = nextPayload;
-                                                                                               });
+                                var response = manager.Apply(entry => entry.Key == currentKey,
+                                                             entry =>
+                                                             {
+                                                                 entry.State = nextState;
+                                                                 entry.Payload = nextPayload;
+                                                             });
                                 """;
 
         // Act & Assert

--- a/Reihitsu.Formatter.Test/Regression/Indentation/ObjectInitializerAlignmentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Indentation/ObjectInitializerAlignmentTests.cs
@@ -702,19 +702,20 @@ public class ObjectInitializerAlignmentTests : FormatterTestsBase
                                 {
                                     void M(string content)
                                     {
-                                        var result = Deserialize(content, new Settings
-                                                                          {
-                                                                              Items = {
-                                                                                          new Converter()
-                                                                                      },
-                                                                              Handler = (sender, args) =>
-                                                                                        {
-                                                                                            if (args.Path == "test")
-                                                                                            {
-                                                                                                args.Handled = true;
-                                                                                            }
-                                                                                        }
-                                                                          });
+                                        var result = Deserialize(content,
+                                                                 new Settings
+                                                                 {
+                                                                     Items = {
+                                                                                 new Converter()
+                                                                             },
+                                                                     Handler = (sender, args) =>
+                                                                               {
+                                                                                   if (args.Path == "test")
+                                                                                   {
+                                                                                       args.Handled = true;
+                                                                                   }
+                                                                               }
+                                                                 });
                                     }
 
                                     static T Deserialize<T>(string content, Settings settings)
@@ -816,19 +817,20 @@ public class ObjectInitializerAlignmentTests : FormatterTestsBase
                                 {
                                     void M(string payload)
                                     {
-                                        var config = DataParser.Parse<ImportResult>(payload, new ParserOptions
-                                                                                             {
-                                                                                                 Validators = {
-                                                                                                                  new SchemaValidator()
-                                                                                                              },
-                                                                                                 OnError = (_, context) =>
-                                                                                                           {
-                                                                                                               if (context.FieldName == "identifier")
-                                                                                                               {
-                                                                                                                   context.IsHandled = true;
-                                                                                                               }
-                                                                                                           }
-                                                                                             });
+                                        var config = DataParser.Parse<ImportResult>(payload,
+                                                                                    new ParserOptions
+                                                                                    {
+                                                                                        Validators = {
+                                                                                                         new SchemaValidator()
+                                                                                                     },
+                                                                                        OnError = (_, context) =>
+                                                                                                  {
+                                                                                                      if (context.FieldName == "identifier")
+                                                                                                      {
+                                                                                                          context.IsHandled = true;
+                                                                                                      }
+                                                                                                  }
+                                                                                    });
                                     }
 
                                     static T Parse<T>(string payload, ParserOptions options)

--- a/Reihitsu.Formatter.Test/Unit/LineBreaks/LineBreakRewriterTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/LineBreaks/LineBreakRewriterTests.cs
@@ -1130,6 +1130,131 @@ public class LineBreakRewriterTests
     }
 
     /// <summary>
+    /// Verifies that the outer argument list is split when a lambda argument wraps a
+    /// multi-member anonymous object that the initializer rewriter already expanded to multiple lines
+    /// </summary>
+    [TestMethod]
+    public void SplitsOuterArgumentsWhenLambdaContainsMultiMemberAnonymousObject()
+    {
+        // Arrange — single-line call; the initializer rewriter expands the anonymous object
+        //           to multiple lines first, making the outer invocation multi-line;
+        //           the list rewriter must then also split the outer arguments
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     table.PrimaryKey("PK_TableName", x => new { x.Column1, x.Column2 });
+                                 }
+                             }
+                             """;
+
+        // Act
+        var result = ExecuteLineBreakPhase(input);
+
+        // Assert — the comma after "PK_TableName" must be followed by a line break
+        Assert.DoesNotContain("\"PK_TableName\", x =>", result, "When a lambda argument wraps a multi-member anonymous object, the outer argument list must be split.");
+    }
+
+    /// <summary>
+    /// Verifies that the outer argument list is split when a lambda argument wraps an
+    /// object initializer that the initializer rewriter expanded to multiple lines
+    /// </summary>
+    [TestMethod]
+    public void SplitsOuterArgumentsWhenLambdaContainsMultiMemberObjectInitializer()
+    {
+        // Arrange — single-line call; the initializer rewriter expands the object initializer
+        //           to multiple lines first, making the lambda body multi-line;
+        //           the list rewriter must then also split the outer arguments
+        const string input = """
+                             using System;
+
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     Create("prefix", value => new Settings { Alpha = 1, Beta = 2 }, "suffix");
+                                 }
+                             }
+
+                             class Settings
+                             {
+                                 public int Alpha { get; set; }
+
+                                 public int Beta { get; set; }
+                             }
+                             """;
+
+        // Act
+        var result = ExecuteLineBreakPhase(input);
+
+        // Assert — the comma after "prefix" must be followed by a line break
+        Assert.DoesNotContain("\"prefix\", value =>", result, "When a lambda argument wraps a multi-member object initializer, the outer argument list must be split.");
+    }
+
+    /// <summary>
+    /// Verifies that the outer argument list is split when a lambda argument wraps an
+    /// invocation whose nested initializer becomes multi-line after child rewrites
+    /// </summary>
+    [TestMethod]
+    public void SplitsOuterArgumentsWhenLambdaBodyInvocationBecomesMultiLine()
+    {
+        // Arrange — the nested anonymous object becomes multi-line first, causing the
+        //           lambda expression body invocation to become multi-line as well;
+        //           the list rewriter must then split the outer arguments
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     Call("first", value => Project(new { Alpha = 1, Beta = 2 }), "third");
+                                 }
+
+                                 object Project(object value)
+                                 {
+                                     return value;
+                                 }
+                             }
+                             """;
+
+        // Act
+        var result = ExecuteLineBreakPhase(input);
+
+        // Assert — the comma after "first" must be followed by a line break
+        Assert.DoesNotContain("\"first\", value =>", result, "When a lambda body invocation becomes multi-line, the outer argument list must be split.");
+    }
+
+    /// <summary>
+    /// Verifies that the outer argument list is split when a statement-lambda body becomes
+    /// multi-line as the second argument
+    /// </summary>
+    [TestMethod]
+    public void SplitsOuterArgumentsWhenStatementLambdaBodyBecomesMultiLine()
+    {
+        // Arrange — the statement lambda body is already multi-line, so the list rewriter
+        //           must treat the whole argument as multi-line and split the outer arguments
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     Apply(entry => entry.Key == currentKey, entry =>
+                                                                            {
+                                                                                entry.State = nextState;
+                                                                                entry.Payload = nextPayload;
+                                                                            });
+                                 }
+                             }
+                             """;
+
+        // Act
+        var result = ExecuteLineBreakPhase(input);
+
+        // Assert — the comma after the first lambda argument must be followed by a line break
+        Assert.DoesNotContain("currentKey, entry =>", result, "When a statement lambda argument is multi-line, the outer argument list must be split.");
+    }
+
+    /// <summary>
     /// Executes the <see cref="LineBreakPhase"/> on the given C# source text using the platform end-of-line sequence
     /// </summary>
     /// <param name="input">The C# source text to format</param>
@@ -1145,7 +1270,8 @@ public class LineBreakRewriterTests
     /// <param name="input">The C# source text to format</param>
     /// <param name="endOfLine">The end-of-line sequence for the formatting context</param>
     /// <returns>The formatted source text</returns>
-    private string ExecuteLineBreakPhase(string input, string endOfLine)
+    private string ExecuteLineBreakPhase(string input,
+                                         string endOfLine)
     {
         var tree = CSharpSyntaxTree.ParseText(input, cancellationToken: TestContext.CancellationToken);
         var context = new FormattingContext(endOfLine);

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/LineBreakListRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/LineBreakListRewriter.cs
@@ -354,25 +354,7 @@ internal sealed class LineBreakListRewriter : LineBreakRewriter
         foreach (var element in list)
         {
             if (LineBreakTriviaUtilities.HasLeadingEndOfLine(element.GetFirstToken())
-                || ContainsNestedMultiLineInvocation(element))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /// <summary>
-    /// Determines whether a syntax node contains a nested multi-line invocation
-    /// </summary>
-    /// <param name="element">The syntax node to inspect</param>
-    /// <returns><see langword="true"/> if a nested invocation already spans multiple lines; otherwise, <see langword="false"/></returns>
-    private static bool ContainsNestedMultiLineInvocation(SyntaxNode element)
-    {
-        foreach (var descendant in element.DescendantNodes())
-        {
-            if (descendant is InvocationExpressionSyntax invocation && IsMultiLine(invocation))
+                || IsMultiLine(element))
             {
                 return true;
             }


### PR DESCRIPTION
## Summary

Make the line-break list rewriter split outer argument lists whenever any argument becomes multiline, and add regression coverage for lambda, initializer, and nested invocation cases.

## Why

The formatter missed cases where a child rewrite made an argument multiline but the surrounding argument list stayed inline. That left formatter output inconsistent and hid additional regressions around statement lambdas and multiline initializer arguments.

## Linked issues

None

## Review notes

This changes the formatter rule generically: once any argument in a separated argument list is multiline, the outer list is wrapped too. Several existing regression expectations were updated to reflect the stricter and now consistent behavior.

## Follow-up work

None
