### PR TITLE
Format auto-properties onto one line

### DIFF
--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH0389IndentationMustUseFourSpacesPerScopeLevelFormatterTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH0389IndentationMustUseFourSpacesPerScopeLevelFormatterTests.cs
@@ -25,19 +25,13 @@ public class RH0389IndentationMustUseFourSpacesPerScopeLevelFormatterTests : For
         const string input = """
                              internal class Example
                              {
-                               internal bool Value
-                                 {
-                                     get;
-                                 }
+                               internal bool Value { get; }
                              }
                              """;
         const string fixedData = """
                                  internal class Example
                                  {
-                                     internal bool Value
-                                     {
-                                         get;
-                                     }
+                                     internal bool Value { get; }
                                  }
                                  """;
 

--- a/Reihitsu.Analyzer.Test/Formatting/RH0389IndentationMustUseFourSpacesPerScopeLevelAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH0389IndentationMustUseFourSpacesPerScopeLevelAnalyzerTests.cs
@@ -77,19 +77,13 @@ public class RH0389IndentationMustUseFourSpacesPerScopeLevelAnalyzerTests : Anal
         const string testData = """
                                 internal class Example
                                 {
-                                  {|#0:internal|} bool Value
-                                    {
-                                        get;
-                                    }
+                                  {|#0:internal|} bool Value { get; }
                                 }
                                 """;
         const string fixedData = """
                                  internal class Example
                                  {
-                                     internal bool Value
-                                     {
-                                         get;
-                                     }
+                                     internal bool Value { get; }
                                  }
                                  """;
 

--- a/Reihitsu.Formatter.Test/Unit/LineBreaks/LineBreakRewriterTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/LineBreaks/LineBreakRewriterTests.cs
@@ -253,6 +253,101 @@ public class LineBreakRewriterTests
     }
 
     /// <summary>
+    /// Verifies that a multi-line auto-property with only <c>get;</c> collapses to one line
+    /// </summary>
+    [TestMethod]
+    public void CollapsesGetOnlyAutoPropertyToSingleLine()
+    {
+        // Arrange
+        const string input = """
+                             class Foo
+                             {
+                                 public int Prop
+                                 { get; }
+                             }
+                             """;
+
+        // Act
+        var result = ExecuteLineBreakPhase(input);
+
+        // Assert
+        Assert.Contains("public int Prop { get; }", result, "Get-only auto-property should be on one line.");
+        Assert.DoesNotContain($"Prop{Environment.NewLine}                                 {{ get; }}", result, "Get-only auto-property should not remain split across lines.");
+    }
+
+    /// <summary>
+    /// Verifies that a multi-line auto-property with <c>get;</c>/<c>set;</c> collapses to one line
+    /// </summary>
+    [TestMethod]
+    public void CollapsesGetSetAutoPropertyToSingleLine()
+    {
+        // Arrange
+        const string input = """
+                             class Foo
+                             {
+                                 public int Prop
+                                 { get; set; }
+                             }
+                             """;
+
+        // Act
+        var result = ExecuteLineBreakPhase(input);
+
+        // Assert
+        Assert.Contains("public int Prop { get; set; }", result, "Get/set auto-property should be on one line.");
+        Assert.DoesNotContain($"Prop{Environment.NewLine}                                 {{ get; set; }}", result, "Get/set auto-property should not remain split across lines.");
+    }
+
+    /// <summary>
+    /// Verifies that properties with bodied accessors are not collapsed to one line
+    /// </summary>
+    [TestMethod]
+    public void DoesNotCollapsePropertyWithAccessorBody()
+    {
+        // Arrange
+        const string input = """
+                             class Foo
+                             {
+                                 public int Prop
+                                 {
+                                     get
+                                     {
+                                         return 1;
+                                     }
+                                 }
+                             }
+                             """;
+
+        // Act
+        var result = ExecuteLineBreakPhase(input);
+
+        // Assert
+        Assert.DoesNotContain("public int Prop { get; }", result, "Properties with accessor bodies must not be treated as auto-properties.");
+        Assert.Contains("return 1;", result, "Accessor body should be preserved.");
+    }
+
+    /// <summary>
+    /// Verifies that expression-bodied properties are not converted into accessor-list auto-properties
+    /// </summary>
+    [TestMethod]
+    public void DoesNotRewriteExpressionBodiedPropertyAsAccessorList()
+    {
+        // Arrange
+        const string input = """
+                             class Foo
+                             {
+                                 public int Prop => 1;
+                             }
+                             """;
+
+        // Act
+        var result = ExecuteLineBreakPhase(input);
+
+        // Assert
+        Assert.AreEqual(input, result, "Expression-bodied properties should remain expression-bodied.");
+    }
+
+    /// <summary>
     /// Verifies that switch expression arms are handled without errors
     /// </summary>
     [TestMethod]

--- a/Reihitsu.Formatter/Pipeline/BlankLines/BlankLineSubphaseRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/BlankLines/BlankLineSubphaseRewriter.cs
@@ -14,8 +14,7 @@ internal abstract class BlankLineSubphaseRewriter : CSharpSyntaxRewriter
     /// <summary>
     /// Formatting context of the current blank-line subphase
     /// </summary>
-    protected FormattingContext Context
-    { get; }
+    protected FormattingContext Context { get; }
 
     /// <summary>
     /// Cancellation token of the current blank-line subphase

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/LineBreakDeclarationRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/LineBreakDeclarationRewriter.cs
@@ -82,6 +82,67 @@ internal sealed class LineBreakDeclarationRewriter : LineBreakRewriter
     }
 
     /// <summary>
+    /// Collapses a multi-line auto-property accessor list to a single line
+    /// </summary>
+    /// <param name="node">The property declaration with an auto-property accessor list</param>
+    /// <returns>The property declaration with a single-line accessor list</returns>
+    private static PropertyDeclarationSyntax CollapseAutoPropertyAccessorList(PropertyDeclarationSyntax node)
+    {
+        if (node?.AccessorList == null || IsAutoPropertyAccessorList(node.AccessorList) == false)
+        {
+            return node;
+        }
+
+        if (node.AccessorList.DescendantTrivia(descendIntoTrivia: true)
+                             .Any(static trivia => trivia.IsDirective || trivia.IsKind(SyntaxKind.SingleLineCommentTrivia) || trivia.IsKind(SyntaxKind.MultiLineCommentTrivia)))
+        {
+            return node;
+        }
+
+        var updatedNode = CollapseTokenToSameLine(node, node.AccessorList.OpenBraceToken);
+
+        foreach (var accessor in updatedNode.AccessorList.Accessors)
+        {
+            updatedNode = CollapseTokenToSameLine(updatedNode, accessor.Keyword);
+
+            if (accessor.SemicolonToken.IsMissing == false)
+            {
+                updatedNode = CollapseTokenToSameLine(updatedNode, accessor.SemicolonToken);
+            }
+        }
+
+        updatedNode = CollapseTokenToSameLine(updatedNode, updatedNode.AccessorList.CloseBraceToken);
+
+        var accessorList = updatedNode.AccessorList;
+        var previousToken = accessorList.OpenBraceToken.GetPreviousToken();
+        var replacementMap = new Dictionary<SyntaxToken, SyntaxToken>
+                             {
+                                 [accessorList.OpenBraceToken] = accessorList.OpenBraceToken.WithLeadingTrivia(SyntaxFactory.TriviaList())
+                                                                                            .WithTrailingTrivia(SyntaxFactory.Space),
+                                 [accessorList.CloseBraceToken] = accessorList.CloseBraceToken.WithLeadingTrivia(SyntaxFactory.TriviaList()),
+                             };
+
+        if (previousToken != default && previousToken.IsKind(SyntaxKind.None) == false)
+        {
+            replacementMap[previousToken] = previousToken.WithTrailingTrivia(SyntaxFactory.Space);
+        }
+
+        foreach (var accessor in accessorList.Accessors)
+        {
+            replacementMap[accessor.Keyword] = accessor.Keyword.WithLeadingTrivia(SyntaxFactory.TriviaList())
+                                                               .WithTrailingTrivia(SyntaxFactory.TriviaList());
+
+            if (accessor.SemicolonToken.IsMissing == false)
+            {
+                replacementMap[accessor.SemicolonToken] = accessor.SemicolonToken.WithLeadingTrivia(SyntaxFactory.TriviaList())
+                                                                                 .WithTrailingTrivia(SyntaxFactory.Space);
+            }
+        }
+
+        return updatedNode.ReplaceTokens(replacementMap.Keys, (original, _) => replacementMap[original]);
+    }
+
+    /// <summary>
     /// Gets the constraint clauses from a syntax node if it supports them
     /// </summary>
     /// <param name="node">The syntax node to inspect</param>
@@ -512,11 +573,18 @@ internal sealed class LineBreakDeclarationRewriter : LineBreakRewriter
             node = CollapseExpressionBodiedProperty(node);
         }
 
-        if (node.AccessorList != null && IsAutoPropertyAccessorList(node.AccessorList) == false)
+        if (node.AccessorList != null)
         {
-            node = NormalizeGapBeforeToken(node, node.AccessorList.OpenBraceToken, blankLineCount: 0);
-            node = EnsureFirstContentOnNewLine(node, node.AccessorList.OpenBraceToken);
-            node = NormalizeGapBeforeToken(node, node.AccessorList.CloseBraceToken, blankLineCount: 0);
+            if (IsAutoPropertyAccessorList(node.AccessorList))
+            {
+                node = CollapseAutoPropertyAccessorList(node);
+            }
+            else
+            {
+                node = NormalizeGapBeforeToken(node, node.AccessorList.OpenBraceToken, blankLineCount: 0);
+                node = EnsureFirstContentOnNewLine(node, node.AccessorList.OpenBraceToken);
+                node = NormalizeGapBeforeToken(node, node.AccessorList.CloseBraceToken, blankLineCount: 0);
+            }
         }
 
         return node;


### PR DESCRIPTION
## Summary

Format auto-properties so their accessor list stays on one line (for example, `public int Prop { get; set; }`) instead of multiline accessor braces.

## Why

This keeps trivial auto-properties compact and consistent with the requested formatter style.

## Linked issues

None

## Review notes

The behavior is implemented in the existing line-break declaration rewriter and covered with positive and negative formatter tests.

## Follow-up work

None
