### PR TITLE
Fix SonarQube code quality issues

### DIFF
--- a/Reihitsu.Analyzer.Test/Formatting/RH0395BreakStatementsShouldNotBeInsideExplicitSwitchCaseBlocksAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH0395BreakStatementsShouldNotBeInsideExplicitSwitchCaseBlocksAnalyzerTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using System.Threading.Tasks;
 

--- a/Reihitsu.Analyzer.Test/SelfHosting/AnalyzerMetadataDiscovery.cs
+++ b/Reihitsu.Analyzer.Test/SelfHosting/AnalyzerMetadataDiscovery.cs
@@ -19,34 +19,34 @@ namespace Reihitsu.Analyzer.Test.SelfHosting;
 /// </summary>
 internal static class AnalyzerMetadataDiscovery
 {
-    #region Methods
+    #region Fields
+
+    /// <summary>
+    /// Regex that collapses repeated whitespace for rule title normalization
+    /// </summary>
+    private static readonly Regex _whitespaceCollapseRegex = new(@"\s+", RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100));
 
     /// <summary>
     /// Regex for rule rows in the analyzer package README
     /// </summary>
     /// <returns>The package rule row regex</returns>
-    private static Regex PackageRuleRowRegex()
-    {
-        return new Regex(@"^\| \[(RH\d{4}[A-Z]?)\]\([^)]+\)\| (?<description>.*?)\| (?<analyzer>[✔❌])\| (?<codeFix>[✔❌])\| (?<formatter>[✔❌])\|$", RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100));
-    }
+    private static readonly Regex _packageRuleRowRegex = new(@"^\| \[(RH\d{4}[A-Z]?)\]\([^)]+\)\| (?<description>.*?)\| (?<analyzer>[✔❌])\| (?<codeFix>[✔❌])\| (?<formatter>[✔❌])\|$", RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100));
 
     /// <summary>
     /// Regex for rule document title headings
     /// </summary>
     /// <returns>The rule documentation title regex</returns>
-    private static Regex RuleDocumentationTitleRegex()
-    {
-        return new Regex(@"^# (?<diagnosticId>RH\d{4}[A-Z]?) [—-] (?<title>.+?)\s*$", RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100));
-    }
+    private static readonly Regex _ruleDocumentationTitleRegex = new(@"^# (?<diagnosticId>RH\d{4}[A-Z]?) [—-] (?<title>.+?)\s*$", RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100));
 
     /// <summary>
     /// Regex for diagnostic IDs encoded in formatter test class names
     /// </summary>
     /// <returns>The formatter test class diagnostic ID regex</returns>
-    private static Regex FormatterTestClassDiagnosticIdRegex()
-    {
-        return new Regex(@"^(RH\d{4})", RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100));
-    }
+    private static readonly Regex _formatterTestClassDiagnosticIdRegex = new(@"^(RH\d{4})", RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100));
+
+    #endregion // Fields
+
+    #region Methods
 
     /// <summary>
     /// Discovers all shipped analyzers
@@ -126,7 +126,7 @@ internal static class AnalyzerMetadataDiscovery
         var packageReadmePath = Path.Combine(FindRepositoryRoot(), "Reihitsu.Analyzer.Package", "README.MD");
 
         return File.ReadLines(packageReadmePath)
-                   .Select(line => PackageRuleRowRegex().Match(line))
+                   .Select(line => _packageRuleRowRegex.Match(line))
                    .Where(match => match.Success)
                    .Select(match => new PackageReadmeRuleMetadata(match.Groups[1].Value,
                                                                   match.Groups["description"].Value.Trim(),
@@ -166,9 +166,9 @@ internal static class AnalyzerMetadataDiscovery
 
         normalizedValue = Regex.Replace(normalizedValue, @"<(?<name>[A-Za-z][A-Za-z0-9]*)\s*/>", "<${name}>", RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100));
 
-        return Regex.Replace(normalizedValue, @"\s+", " ")
-                    .Trim()
-                    .TrimEnd('.');
+        return _whitespaceCollapseRegex.Replace(normalizedValue, " ")
+                                       .Trim()
+                                       .TrimEnd('.');
     }
 
     /// <summary>
@@ -211,7 +211,7 @@ internal static class AnalyzerMetadataDiscovery
     /// <returns>Diagnostic ID covered by the formatter test class</returns>
     private static string ParseDiagnosticIdFromFormatterTestClass(Type formatterTestClass)
     {
-        var match = FormatterTestClassDiagnosticIdRegex().Match(formatterTestClass.Name);
+        var match = _formatterTestClassDiagnosticIdRegex.Match(formatterTestClass.Name);
 
         return match.Success
                    ? match.Groups[1].Value
@@ -227,7 +227,7 @@ internal static class AnalyzerMetadataDiscovery
     {
         var firstLine = File.ReadLines(path).FirstOrDefault()
                             ?? throw new InvalidOperationException($"Rule documentation '{path}' is empty.");
-        var match = RuleDocumentationTitleRegex().Match(firstLine);
+        var match = _ruleDocumentationTitleRegex.Match(firstLine);
 
         if (match.Success is false)
         {

--- a/Reihitsu.Analyzer/Core/FormattingTextAnalysisUtilities.cs
+++ b/Reihitsu.Analyzer/Core/FormattingTextAnalysisUtilities.cs
@@ -71,15 +71,15 @@ internal static class FormattingTextAnalysisUtilities
     {
         var stringLineIndices = new HashSet<int>();
 
-        foreach (var literalExpression in root.DescendantNodes().OfType<LiteralExpressionSyntax>())
+        foreach (var literalExpression in root.DescendantNodes()
+                                              .OfType<LiteralExpressionSyntax>()
+                                              .Where(IsTrackedStringLiteral))
         {
-            if (IsTrackedStringLiteral(literalExpression))
-            {
-                AddIntersectingLineIndices(stringLineIndices, sourceText, literalExpression.FullSpan);
-            }
+            AddIntersectingLineIndices(stringLineIndices, sourceText, literalExpression.FullSpan);
         }
 
-        foreach (var interpolatedString in root.DescendantNodes().OfType<InterpolatedStringExpressionSyntax>())
+        foreach (var interpolatedString in root.DescendantNodes()
+                                               .OfType<InterpolatedStringExpressionSyntax>())
         {
             AddIntersectingLineIndices(stringLineIndices, sourceText, interpolatedString.FullSpan);
         }

--- a/Reihitsu.Analyzer/Data/ConfigurationManager.cs
+++ b/Reihitsu.Analyzer/Data/ConfigurationManager.cs
@@ -315,7 +315,7 @@ internal static class ConfigurationManager
         {
             var lines = normalizedText.Split('\n');
 
-            return lines.All(currentLine => currentLine.StartsWith("//", StringComparison.Ordinal));
+            return Array.TrueForAll(lines, currentLine => currentLine.StartsWith("//", StringComparison.Ordinal));
         }
 
         return normalizedText.StartsWith("/*", StringComparison.Ordinal)

--- a/Reihitsu.Analyzer/Data/CopyrightHeaderTemplateResolver.cs
+++ b/Reihitsu.Analyzer/Data/CopyrightHeaderTemplateResolver.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;

--- a/Reihitsu.Analyzer/Rules/Analyzer/RH0701ConfigurationFileMustBeValidAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Analyzer/RH0701ConfigurationFileMustBeValidAnalyzer.cs
@@ -1,5 +1,4 @@
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
 

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0452FileMustStartWithConfiguredXmlStyleCopyrightHeaderAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0452FileMustStartWithConfiguredXmlStyleCopyrightHeaderAnalyzer.cs
@@ -1,5 +1,4 @@
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
 

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0345OpeningGenericBracketsMustBeSpacedCorrectlyAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0345OpeningGenericBracketsMustBeSpacedCorrectlyAnalyzer.cs
@@ -46,9 +46,11 @@ public class RH0345OpeningGenericBracketsMustBeSpacedCorrectlyAnalyzer : Diagnos
         var root = context.Tree.GetRoot(context.CancellationToken);
         var sourceText = context.Tree.GetText(context.CancellationToken);
 
-        foreach (var token in root.DescendantNodes().OfType<TypeArgumentListSyntax>().Select(node => node.LessThanToken))
+        foreach (var tokenStart in root.DescendantNodes()
+                                       .OfType<TypeArgumentListSyntax>()
+                                       .Select(node => node.LessThanToken.SpanStart))
         {
-            var start = token.SpanStart;
+            var start = tokenStart;
 
             while (start > 0
                    && (sourceText[start - 1] == ' ' || sourceText[start - 1] == '\t'))
@@ -56,9 +58,9 @@ public class RH0345OpeningGenericBracketsMustBeSpacedCorrectlyAnalyzer : Diagnos
                 start--;
             }
 
-            if (start < token.SpanStart)
+            if (start < tokenStart)
             {
-                context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, TextSpan.FromBounds(start, token.SpanStart))));
+                context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, TextSpan.FromBounds(start, tokenStart))));
             }
         }
     }

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0346ClosingGenericBracketsMustBeSpacedCorrectlyAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0346ClosingGenericBracketsMustBeSpacedCorrectlyAnalyzer.cs
@@ -46,9 +46,11 @@ public class RH0346ClosingGenericBracketsMustBeSpacedCorrectlyAnalyzer : Diagnos
         var root = context.Tree.GetRoot(context.CancellationToken);
         var sourceText = context.Tree.GetText(context.CancellationToken);
 
-        foreach (var token in root.DescendantNodes().OfType<TypeArgumentListSyntax>().Select(node => node.GreaterThanToken))
+        foreach (var tokenStart in root.DescendantNodes()
+                                       .OfType<TypeArgumentListSyntax>()
+                                       .Select(node => node.GreaterThanToken.SpanStart))
         {
-            var start = token.SpanStart;
+            var start = tokenStart;
 
             while (start > 0
                    && (sourceText[start - 1] == ' ' || sourceText[start - 1] == '\t'))
@@ -56,9 +58,9 @@ public class RH0346ClosingGenericBracketsMustBeSpacedCorrectlyAnalyzer : Diagnos
                 start--;
             }
 
-            if (start < token.SpanStart)
+            if (start < tokenStart)
             {
-                context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, TextSpan.FromBounds(start, token.SpanStart))));
+                context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, TextSpan.FromBounds(start, tokenStart))));
             }
         }
     }

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0348ClosingAttributeBracketsMustBeSpacedCorrectlyAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0348ClosingAttributeBracketsMustBeSpacedCorrectlyAnalyzer.cs
@@ -46,9 +46,11 @@ public class RH0348ClosingAttributeBracketsMustBeSpacedCorrectlyAnalyzer : Diagn
         var root = context.Tree.GetRoot(context.CancellationToken);
         var sourceText = context.Tree.GetText(context.CancellationToken);
 
-        foreach (var token in root.DescendantNodes().OfType<AttributeListSyntax>().Select(node => node.CloseBracketToken))
+        foreach (var tokenStart in root.DescendantNodes()
+                                       .OfType<AttributeListSyntax>()
+                                       .Select(node => node.CloseBracketToken.SpanStart))
         {
-            var start = token.SpanStart;
+            var start = tokenStart;
 
             while (start > 0
                    && (sourceText[start - 1] == ' ' || sourceText[start - 1] == '\t'))
@@ -56,9 +58,9 @@ public class RH0348ClosingAttributeBracketsMustBeSpacedCorrectlyAnalyzer : Diagn
                 start--;
             }
 
-            if (start < token.SpanStart)
+            if (start < tokenStart)
             {
-                context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, TextSpan.FromBounds(start, token.SpanStart))));
+                context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, TextSpan.FromBounds(start, tokenStart))));
             }
         }
     }

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0349NullableTypeSymbolsMustNotBePrecededBySpaceAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0349NullableTypeSymbolsMustNotBePrecededBySpaceAnalyzer.cs
@@ -46,9 +46,11 @@ public class RH0349NullableTypeSymbolsMustNotBePrecededBySpaceAnalyzer : Diagnos
         var root = context.Tree.GetRoot(context.CancellationToken);
         var sourceText = context.Tree.GetText(context.CancellationToken);
 
-        foreach (var token in root.DescendantNodes().OfType<NullableTypeSyntax>().Select(node => node.QuestionToken))
+        foreach (var tokenStart in root.DescendantNodes()
+                                       .OfType<NullableTypeSyntax>()
+                                       .Select(node => node.QuestionToken.SpanStart))
         {
-            var start = token.SpanStart;
+            var start = tokenStart;
 
             while (start > 0
                    && (sourceText[start - 1] == ' ' || sourceText[start - 1] == '\t'))
@@ -56,9 +58,9 @@ public class RH0349NullableTypeSymbolsMustNotBePrecededBySpaceAnalyzer : Diagnos
                 start--;
             }
 
-            if (start < token.SpanStart)
+            if (start < tokenStart)
             {
-                context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, TextSpan.FromBounds(start, token.SpanStart))));
+                context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, TextSpan.FromBounds(start, tokenStart))));
             }
         }
     }

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0362BracesMustNotBeOmittedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0362BracesMustNotBeOmittedAnalyzer.cs
@@ -44,7 +44,10 @@ public class RH0362BracesMustNotBeOmittedAnalyzer : DiagnosticAnalyzerBase<RH036
     {
         var root = context.Tree.GetRoot(context.CancellationToken);
 
-        foreach (var statement in root.DescendantNodes().OfType<IfStatementSyntax>().Select(statement => statement.Statement))
+        foreach (var statement in root.DescendantNodes()
+                                      .OfType<IfStatementSyntax>()
+                                      .Select(statement => statement.Statement)
+                                      .Where(statement => statement is BlockSyntax == false))
         {
             if (statement is BlockSyntax == false)
             {

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0384GenericTypeConstraintsShouldBeOnTheirOwnLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0384GenericTypeConstraintsShouldBeOnTheirOwnLineAnalyzer.cs
@@ -55,18 +55,19 @@ public class RH0384GenericTypeConstraintsShouldBeOnTheirOwnLineAnalyzer : Diagno
             return;
         }
 
-        var expectedColumn = declaration.GetFirstToken().GetLocation().GetLineSpan().StartLinePosition.Character + IndentationSize;
+        var expectedColumn = declaration.GetFirstToken().GetLocation().GetLineSpan().StartLinePosition.Character
+                             + IndentationSize;
 
-        foreach (var constraintClause in constraintClauses)
+        foreach (var whereKeyword in constraintClauses.Select(constraintClause => constraintClause.WhereKeyword))
         {
-            var whereLineSpan = constraintClause.WhereKeyword.GetLocation().GetLineSpan();
-            var previousToken = constraintClause.WhereKeyword.GetPreviousToken();
+            var previousToken = whereKeyword.GetPreviousToken();
 
             if (previousToken.RawKind == 0)
             {
                 continue;
             }
 
+            var whereLineSpan = whereKeyword.GetLocation().GetLineSpan();
             var previousLineSpan = previousToken.GetLocation().GetLineSpan();
             var isOnOwnLine = whereLineSpan.StartLinePosition.Line > previousLineSpan.EndLinePosition.Line;
             var hasExpectedIndentation = whereLineSpan.StartLinePosition.Character == expectedColumn;
@@ -74,7 +75,7 @@ public class RH0384GenericTypeConstraintsShouldBeOnTheirOwnLineAnalyzer : Diagno
             if (isOnOwnLine == false
                 || hasExpectedIndentation == false)
             {
-                context.ReportDiagnostic(CreateDiagnostic(constraintClause.WhereKeyword.GetLocation()));
+                context.ReportDiagnostic(CreateDiagnostic(whereKeyword.GetLocation()));
 
                 break;
             }

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0385CodeMustNotContainMixedLineEndingsAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0385CodeMustNotContainMixedLineEndingsAnalyzer.cs
@@ -45,7 +45,7 @@ public class RH0385CodeMustNotContainMixedLineEndingsAnalyzer : DiagnosticAnalyz
     /// <param name="endOfLineTrivia">End-of-line trivia in source order</param>
     /// <param name="counts">Line-ending counts</param>
     /// <returns>The predominant line ending</returns>
-    private string GetPredominantLineEnding(List<SyntaxTrivia> endOfLineTrivia, IReadOnlyDictionary<string, int> counts)
+    private static string GetPredominantLineEnding(List<SyntaxTrivia> endOfLineTrivia, IReadOnlyDictionary<string, int> counts)
     {
         var predominantCount = counts.Values.Max();
 

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0387ATypesShouldBeOrganizedWithRegionsForMultipleKindsAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0387ATypesShouldBeOrganizedWithRegionsForMultipleKindsAnalyzer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0387ATypesShouldBeOrganizedWithRegionsForMultipleKindsAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0387ATypesShouldBeOrganizedWithRegionsForMultipleKindsAnalyzer.cs
@@ -1,6 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
-
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -48,7 +46,7 @@ public class RH0387ATypesShouldBeOrganizedWithRegionsForMultipleKindsAnalyzer : 
         }
 
         return regions.Count == 0
-               || relevantMembers.Any(memberDeclaration => IsWithinRegion(memberDeclaration, regions) == false);
+               || Array.Exists(relevantMembers, memberDeclaration => IsWithinRegion(memberDeclaration, regions) == false);
     }
 
     #endregion // Methods

--- a/Reihitsu.Analyzer/Rules/Formatting/RH0387TypesShouldBeOrganizedWithRegionsAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Formatting/RH0387TypesShouldBeOrganizedWithRegionsAnalyzer.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -43,7 +42,7 @@ public class RH0387TypesShouldBeOrganizedWithRegionsAnalyzer : TypesOrganizedWit
     protected override bool ShouldReport(MemberDeclarationSyntax[] relevantMembers, IReadOnlyList<(SyntaxTrivia Region, SyntaxTrivia EndRegion)> regions)
     {
         return regions.Count == 0
-               || relevantMembers.Any(memberDeclaration => IsWithinRegion(memberDeclaration, regions) == false);
+               || Array.Exists(relevantMembers, memberDeclaration => IsWithinRegion(memberDeclaration, regions) == false);
     }
 
     #endregion // Methods

--- a/Reihitsu.Analyzer/Rules/Ordering/RH0613UsingStaticDirectivesMustBePlacedAtCorrectPositionAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Ordering/RH0613UsingStaticDirectivesMustBePlacedAtCorrectPositionAnalyzer.cs
@@ -96,6 +96,21 @@ public class RH0613UsingStaticDirectivesMustBePlacedAtCorrectPositionAnalyzer : 
     }
 
     /// <summary>
+    /// Gets all static using directives that violate their required ordering
+    /// </summary>
+    /// <param name="directives">Using directives</param>
+    /// <returns>Violating directives</returns>
+    private static HashSet<UsingDirectiveSyntax> GetViolatingDirectives(IReadOnlyList<UsingDirectiveSyntax> directives)
+    {
+        var violations = new HashSet<UsingDirectiveSyntax>();
+
+        AddViolationsAfterAlias(directives, violations);
+        AddViolationsBeforeRegularUsings(directives, violations);
+
+        return violations;
+    }
+
+    /// <summary>
     /// Analyze the using directive scope
     /// </summary>
     /// <param name="context">Context</param>
@@ -112,21 +127,6 @@ public class RH0613UsingStaticDirectivesMustBePlacedAtCorrectPositionAnalyzer : 
                 context.ReportDiagnostic(CreateDiagnostic(UsingDirectiveOrderingUtilities.GetDiagnosticLocation(usingDirective)));
             }
         }
-    }
-
-    /// <summary>
-    /// Gets all static using directives that violate their required ordering
-    /// </summary>
-    /// <param name="directives">Using directives</param>
-    /// <returns>Violating directives</returns>
-    private HashSet<UsingDirectiveSyntax> GetViolatingDirectives(IReadOnlyList<UsingDirectiveSyntax> directives)
-    {
-        var violations = new HashSet<UsingDirectiveSyntax>();
-
-        AddViolationsAfterAlias(directives, violations);
-        AddViolationsBeforeRegularUsings(directives, violations);
-
-        return violations;
     }
 
     #endregion // Methods

--- a/Reihitsu.Formatter/Pipeline/BlankLines/BlankLineTokenCleanupRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/BlankLines/BlankLineTokenCleanupRewriter.cs
@@ -226,7 +226,7 @@ internal sealed class BlankLineTokenCleanupRewriter : BlankLineSubphaseRewriter
                                                         out List<SyntaxTrivia> indentationTrivia)
     {
         var eolIndex = lastDocumentationCommentIndex + 1;
-        indentationTrivia = new List<SyntaxTrivia>();
+        indentationTrivia = [];
         removeUntil = eolIndex;
 
         if (eolIndex >= trivia.Count || trivia[eolIndex].IsKind(SyntaxKind.EndOfLineTrivia) == false)

--- a/Reihitsu.Formatter/Pipeline/BlankLines/BlankLineTriviaBoundaryRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/BlankLines/BlankLineTriviaBoundaryRewriter.cs
@@ -72,44 +72,31 @@ internal sealed class BlankLineTriviaBoundaryRewriter : BlankLineSubphaseRewrite
     }
 
     /// <summary>
-    /// Ensures exactly one blank line exists before the first comment in the specified token's leading trivia
+    /// Finds the first comment trivia index in the leading trivia list
     /// </summary>
-    /// <param name="token">The token whose leading trivia should be checked</param>
-    /// <returns>The token with a single blank line before the first comment</returns>
-    private SyntaxToken EnsureBlankLineBeforeFirstComment(SyntaxToken token)
+    /// <param name="trivia">The trivia list to inspect</param>
+    /// <returns>The zero-based trivia index or -1 if no comment exists</returns>
+    private static int FindFirstCommentIndex(SyntaxTriviaList trivia)
     {
-        var trivia = token.LeadingTrivia;
-        var commentIndex = -1;
-
         for (var triviaIndex = 0; triviaIndex < trivia.Count; triviaIndex++)
         {
             if (IsCommentTrivia(trivia[triviaIndex]))
             {
-                commentIndex = triviaIndex;
-
-                break;
+                return triviaIndex;
             }
         }
 
-        if (commentIndex < 0)
-        {
-            return token;
-        }
+        return -1;
+    }
 
-        var previousTokenLine = token.GetPreviousToken();
-
-        if (previousTokenLine != default && previousTokenLine.IsKind(SyntaxKind.None) == false)
-        {
-            var previousLine = previousTokenLine.GetLocation().GetLineSpan().EndLinePosition.Line;
-            var commentLine = trivia[commentIndex].GetLocation().GetLineSpan().StartLinePosition.Line;
-            var blankLineCountByLine = commentLine - previousLine - 1;
-
-            if (blankLineCountByLine == 1)
-            {
-                return token;
-            }
-        }
-
+    /// <summary>
+    /// Finds the start index of the line that contains the specified trivia index
+    /// </summary>
+    /// <param name="trivia">The trivia list to inspect</param>
+    /// <param name="commentIndex">The trivia index that points at the comment</param>
+    /// <returns>The first trivia index on the comment line</returns>
+    private static int FindLineStartIndex(SyntaxTriviaList trivia, int commentIndex)
+    {
         var lineStartIndex = commentIndex;
 
         while (lineStartIndex > 0 && trivia[lineStartIndex - 1].IsKind(SyntaxKind.WhitespaceTrivia))
@@ -117,6 +104,17 @@ internal sealed class BlankLineTriviaBoundaryRewriter : BlankLineSubphaseRewrite
             lineStartIndex--;
         }
 
+        return lineStartIndex;
+    }
+
+    /// <summary>
+    /// Finds the first trivia index after preceding blank-line trivia and indentation trivia
+    /// </summary>
+    /// <param name="trivia">The trivia list to inspect</param>
+    /// <param name="lineStartIndex">The first trivia index on the comment line</param>
+    /// <returns>The first trivia index belonging to the removable gap</returns>
+    private static int FindGapStartIndex(SyntaxTriviaList trivia, int lineStartIndex)
+    {
         var gapStartIndex = lineStartIndex;
 
         while (gapStartIndex > 0
@@ -126,6 +124,18 @@ internal sealed class BlankLineTriviaBoundaryRewriter : BlankLineSubphaseRewrite
             gapStartIndex--;
         }
 
+        return gapStartIndex;
+    }
+
+    /// <summary>
+    /// Counts blank lines in the trivia span before the comment line
+    /// </summary>
+    /// <param name="trivia">The trivia list to inspect</param>
+    /// <param name="gapStartIndex">The first trivia index belonging to the removable gap</param>
+    /// <param name="lineStartIndex">The first trivia index on the comment line</param>
+    /// <returns>The number of blank lines found in the gap</returns>
+    private static int CountLocalBlankLines(SyntaxTriviaList trivia, int gapStartIndex, int lineStartIndex)
+    {
         var localBlankLineCount = 0;
         var localSawLineBreak = false;
         var localAtLineStart = true;
@@ -150,6 +160,41 @@ internal sealed class BlankLineTriviaBoundaryRewriter : BlankLineSubphaseRewrite
             }
         }
 
+        return localBlankLineCount;
+    }
+
+    /// <summary>
+    /// Ensures exactly one blank line exists before the first comment in the specified token's leading trivia
+    /// </summary>
+    /// <param name="token">The token whose leading trivia should be checked</param>
+    /// <returns>The token with a single blank line before the first comment</returns>
+    private SyntaxToken EnsureBlankLineBeforeFirstComment(SyntaxToken token)
+    {
+        var trivia = token.LeadingTrivia;
+        var commentIndex = FindFirstCommentIndex(trivia);
+
+        if (commentIndex < 0)
+        {
+            return token;
+        }
+
+        var previousTokenLine = token.GetPreviousToken();
+
+        if (previousTokenLine != default && previousTokenLine.IsKind(SyntaxKind.None) == false)
+        {
+            var previousLine = previousTokenLine.GetLocation().GetLineSpan().EndLinePosition.Line;
+            var commentLine = trivia[commentIndex].GetLocation().GetLineSpan().StartLinePosition.Line;
+            var blankLineCountByLine = commentLine - previousLine - 1;
+
+            if (blankLineCountByLine == 1)
+            {
+                return token;
+            }
+        }
+
+        var lineStartIndex = FindLineStartIndex(trivia, commentIndex);
+        var gapStartIndex = FindGapStartIndex(trivia, lineStartIndex);
+        var localBlankLineCount = CountLocalBlankLines(trivia, gapStartIndex, lineStartIndex);
         var blankLineCount = CountBlankLinesBeforeLeadingTriviaIndex(token, commentIndex);
 
         if (blankLineCount == 1 || (localBlankLineCount == 0 && HasBlankLineBeforeIndex(trivia, commentIndex)))


### PR DESCRIPTION
## Summary

Clean up SonarQube-reported analyzer and formatter code smells, including simpler collection usage, static helper cleanup, and blank-line trivia refactoring.

## Why

Reduce maintainability warnings while keeping formatting and self-hosting behavior unchanged.

## Linked issues

None.

## Review notes

Blank-line trivia handling was refactored conservatively to preserve trivia order and spacing.

## Follow-up work

None.
