### PR TITLE
Ensure documentation analyzers honor DocumentationMode

### DIFF
--- a/Reihitsu.Analyzer/Base/DocumentationModeAnalysisContextExtensions.cs
+++ b/Reihitsu.Analyzer/Base/DocumentationModeAnalysisContextExtensions.cs
@@ -1,0 +1,59 @@
+using System.Collections.Immutable;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Reihitsu.Analyzer.Base;
+
+/// <summary>
+/// Analysis context extensions related to documentation mode
+/// </summary>
+internal static class DocumentationModeAnalysisContextExtensions
+{
+    #region Methods
+
+    /// <summary>
+    /// Registers a syntax node action that runs only when documentation mode is not <see cref="DocumentationMode.None"/>
+    /// </summary>
+    /// <param name="context">Analysis context</param>
+    /// <param name="action">Action</param>
+    /// <param name="syntaxKinds">Syntax kinds</param>
+    internal static void RegisterSyntaxNodeActionWithDocumentationModeCheck(this AnalysisContext context, Action<SyntaxNodeAnalysisContext> action, params SyntaxKind[] syntaxKinds)
+    {
+        context.RegisterSyntaxNodeAction(currentContext =>
+                                         {
+                                             if (currentContext.Node.SyntaxTree.Options is CSharpParseOptions parseOptions
+                                                 && parseOptions.DocumentationMode == DocumentationMode.None)
+                                             {
+                                                 return;
+                                             }
+
+                                             action(currentContext);
+                                         },
+                                         syntaxKinds);
+    }
+
+    /// <summary>
+    /// Registers a syntax node action that runs only when documentation mode is not <see cref="DocumentationMode.None"/>
+    /// </summary>
+    /// <param name="context">Analysis context</param>
+    /// <param name="action">Action</param>
+    /// <param name="syntaxKinds">Syntax kinds</param>
+    internal static void RegisterSyntaxNodeActionWithDocumentationModeCheck(this AnalysisContext context, Action<SyntaxNodeAnalysisContext> action, ImmutableArray<SyntaxKind> syntaxKinds)
+    {
+        context.RegisterSyntaxNodeAction(currentContext =>
+                                         {
+                                             if (currentContext.Node.SyntaxTree.Options is CSharpParseOptions parseOptions
+                                                 && parseOptions.DocumentationMode == DocumentationMode.None)
+                                             {
+                                                 return;
+                                             }
+
+                                             action(currentContext);
+                                         },
+                                         syntaxKinds);
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Analyzer/Core/SplitElementDocumentationAnalyzerBase{TAnalyzer}.cs
+++ b/Reihitsu.Analyzer/Core/SplitElementDocumentationAnalyzerBase{TAnalyzer}.cs
@@ -77,7 +77,7 @@ public abstract class SplitElementDocumentationAnalyzerBase<TAnalyzer> : Diagnos
     {
         base.Initialize(context);
 
-        context.RegisterSyntaxNodeAction(OnDeclaration, _syntaxKinds);
+        context.RegisterSyntaxNodeActionWithDocumentationModeCheck(OnDeclaration, _syntaxKinds);
     }
 
     #endregion // DiagnosticAnalyzer

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0401InheritdocShouldBeUsedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0401InheritdocShouldBeUsedAnalyzer.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -79,10 +79,10 @@ public class RH0401InheritdocShouldBeUsedAnalyzer : DiagnosticAnalyzerBase<RH040
     {
         base.Initialize(context);
 
-        context.RegisterSyntaxNodeAction(OnSingleLineDocumentationCommentTrivia, SyntaxKind.MethodDeclaration);
-        context.RegisterSyntaxNodeAction(OnSingleLineDocumentationCommentTrivia, SyntaxKind.PropertyDeclaration);
-        context.RegisterSyntaxNodeAction(OnSingleLineDocumentationCommentTrivia, SyntaxKind.EventDeclaration);
-        context.RegisterSyntaxNodeAction(OnSingleLineDocumentationCommentTrivia, SyntaxKind.IndexerDeclaration);
+        context.RegisterSyntaxNodeActionWithDocumentationModeCheck(OnSingleLineDocumentationCommentTrivia, SyntaxKind.MethodDeclaration);
+        context.RegisterSyntaxNodeActionWithDocumentationModeCheck(OnSingleLineDocumentationCommentTrivia, SyntaxKind.PropertyDeclaration);
+        context.RegisterSyntaxNodeActionWithDocumentationModeCheck(OnSingleLineDocumentationCommentTrivia, SyntaxKind.EventDeclaration);
+        context.RegisterSyntaxNodeActionWithDocumentationModeCheck(OnSingleLineDocumentationCommentTrivia, SyntaxKind.IndexerDeclaration);
     }
 
     #endregion // DiagnosticAnalyzer

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0414NonPrivateEnumMembersMustBeDocumentedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0414NonPrivateEnumMembersMustBeDocumentedAnalyzer.cs
@@ -63,7 +63,7 @@ public class RH0414NonPrivateEnumMembersMustBeDocumentedAnalyzer : DiagnosticAna
     {
         base.Initialize(context);
 
-        context.RegisterSyntaxNodeAction(OnDeclaration, SyntaxKind.EnumMemberDeclaration);
+        context.RegisterSyntaxNodeActionWithDocumentationModeCheck(OnDeclaration, SyntaxKind.EnumMemberDeclaration);
     }
 
     #endregion // DiagnosticAnalyzer

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0415PrivateEnumMembersMustBeDocumentedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0415PrivateEnumMembersMustBeDocumentedAnalyzer.cs
@@ -63,7 +63,7 @@ public class RH0415PrivateEnumMembersMustBeDocumentedAnalyzer : DiagnosticAnalyz
     {
         base.Initialize(context);
 
-        context.RegisterSyntaxNodeAction(OnDeclaration, SyntaxKind.EnumMemberDeclaration);
+        context.RegisterSyntaxNodeActionWithDocumentationModeCheck(OnDeclaration, SyntaxKind.EnumMemberDeclaration);
     }
 
     #endregion // DiagnosticAnalyzer

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0431ElementDocumentationMustHaveSummaryTextAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0431ElementDocumentationMustHaveSummaryTextAnalyzer.cs
@@ -99,7 +99,7 @@ public class RH0431ElementDocumentationMustHaveSummaryTextAnalyzer : DiagnosticA
     {
         base.Initialize(context);
 
-        context.RegisterSyntaxNodeAction(OnDeclaration, DocumentationAnalysisUtilities.SummaryDocumentationKinds);
+        context.RegisterSyntaxNodeActionWithDocumentationModeCheck(OnDeclaration, DocumentationAnalysisUtilities.SummaryDocumentationKinds);
     }
 
     #endregion // DiagnosticAnalyzer

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0432ValueTagMustNotBeUsedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0432ValueTagMustNotBeUsedAnalyzer.cs
@@ -43,7 +43,7 @@ public class RH0432ValueTagMustNotBeUsedAnalyzer : DiagnosticAnalyzerBase<RH0432
     {
         base.Initialize(context);
 
-        context.RegisterSyntaxNodeAction(OnDeclaration, SyntaxKind.PropertyDeclaration, SyntaxKind.IndexerDeclaration);
+        context.RegisterSyntaxNodeActionWithDocumentationModeCheck(OnDeclaration, SyntaxKind.PropertyDeclaration, SyntaxKind.IndexerDeclaration);
     }
 
     #endregion // DiagnosticAnalyzer

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0433ElementParametersMustBeDocumentedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0433ElementParametersMustBeDocumentedAnalyzer.cs
@@ -87,7 +87,7 @@ public class RH0433ElementParametersMustBeDocumentedAnalyzer : DiagnosticAnalyze
     {
         base.Initialize(context);
 
-        context.RegisterSyntaxNodeAction(OnDeclaration, DocumentationAnalysisUtilities.ParameterOwnerKinds);
+        context.RegisterSyntaxNodeActionWithDocumentationModeCheck(OnDeclaration, DocumentationAnalysisUtilities.ParameterOwnerKinds);
     }
 
     #endregion // DiagnosticAnalyzer

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0434ElementParameterDocumentationMustMatchElementParametersAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0434ElementParameterDocumentationMustMatchElementParametersAnalyzer.cs
@@ -97,7 +97,7 @@ public class RH0434ElementParameterDocumentationMustMatchElementParametersAnalyz
     {
         base.Initialize(context);
 
-        context.RegisterSyntaxNodeAction(OnDeclaration, DocumentationAnalysisUtilities.ParameterOwnerKinds);
+        context.RegisterSyntaxNodeActionWithDocumentationModeCheck(OnDeclaration, DocumentationAnalysisUtilities.ParameterOwnerKinds);
     }
 
     #endregion // DiagnosticAnalyzer

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0435ElementParameterDocumentationMustDeclareParameterNameAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0435ElementParameterDocumentationMustDeclareParameterNameAnalyzer.cs
@@ -71,7 +71,7 @@ public class RH0435ElementParameterDocumentationMustDeclareParameterNameAnalyzer
     {
         base.Initialize(context);
 
-        context.RegisterSyntaxNodeAction(OnDeclaration, DocumentationAnalysisUtilities.ParameterOwnerKinds);
+        context.RegisterSyntaxNodeActionWithDocumentationModeCheck(OnDeclaration, DocumentationAnalysisUtilities.ParameterOwnerKinds);
     }
 
     #endregion // DiagnosticAnalyzer

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0436ElementParameterDocumentationMustHaveTextAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0436ElementParameterDocumentationMustHaveTextAnalyzer.cs
@@ -71,7 +71,7 @@ public class RH0436ElementParameterDocumentationMustHaveTextAnalyzer : Diagnosti
     {
         base.Initialize(context);
 
-        context.RegisterSyntaxNodeAction(OnDeclaration, DocumentationAnalysisUtilities.ParameterOwnerKinds);
+        context.RegisterSyntaxNodeActionWithDocumentationModeCheck(OnDeclaration, DocumentationAnalysisUtilities.ParameterOwnerKinds);
     }
 
     #endregion // DiagnosticAnalyzer

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0437ElementReturnValueMustBeDocumentedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0437ElementReturnValueMustBeDocumentedAnalyzer.cs
@@ -77,7 +77,7 @@ public class RH0437ElementReturnValueMustBeDocumentedAnalyzer : DiagnosticAnalyz
     {
         base.Initialize(context);
 
-        context.RegisterSyntaxNodeAction(OnDeclaration, DocumentationAnalysisUtilities.ReturnValueOwnerKinds);
+        context.RegisterSyntaxNodeActionWithDocumentationModeCheck(OnDeclaration, DocumentationAnalysisUtilities.ReturnValueOwnerKinds);
     }
 
     #endregion // DiagnosticAnalyzer

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0438ElementReturnValueDocumentationMustHaveTextAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0438ElementReturnValueDocumentationMustHaveTextAnalyzer.cs
@@ -75,7 +75,7 @@ public class RH0438ElementReturnValueDocumentationMustHaveTextAnalyzer : Diagnos
     {
         base.Initialize(context);
 
-        context.RegisterSyntaxNodeAction(OnDeclaration, DocumentationAnalysisUtilities.ReturnValueOwnerKinds);
+        context.RegisterSyntaxNodeActionWithDocumentationModeCheck(OnDeclaration, DocumentationAnalysisUtilities.ReturnValueOwnerKinds);
     }
 
     #endregion // DiagnosticAnalyzer

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0439VoidReturnValueMustNotBeDocumentedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0439VoidReturnValueMustNotBeDocumentedAnalyzer.cs
@@ -75,7 +75,7 @@ public class RH0439VoidReturnValueMustNotBeDocumentedAnalyzer : DiagnosticAnalyz
     {
         base.Initialize(context);
 
-        context.RegisterSyntaxNodeAction(OnDeclaration, DocumentationAnalysisUtilities.ReturnValueOwnerKinds);
+        context.RegisterSyntaxNodeActionWithDocumentationModeCheck(OnDeclaration, DocumentationAnalysisUtilities.ReturnValueOwnerKinds);
     }
 
     #endregion // DiagnosticAnalyzer

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0440GenericTypeParametersMustBeDocumentedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0440GenericTypeParametersMustBeDocumentedAnalyzer.cs
@@ -87,7 +87,7 @@ public class RH0440GenericTypeParametersMustBeDocumentedAnalyzer : DiagnosticAna
     {
         base.Initialize(context);
 
-        context.RegisterSyntaxNodeAction(OnDeclaration, DocumentationAnalysisUtilities.TypeParameterOwnerKinds);
+        context.RegisterSyntaxNodeActionWithDocumentationModeCheck(OnDeclaration, DocumentationAnalysisUtilities.TypeParameterOwnerKinds);
     }
 
     #endregion // DiagnosticAnalyzer

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0441GenericTypeParameterDocumentationMustMatchTypeParametersAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0441GenericTypeParameterDocumentationMustMatchTypeParametersAnalyzer.cs
@@ -97,7 +97,7 @@ public class RH0441GenericTypeParameterDocumentationMustMatchTypeParametersAnaly
     {
         base.Initialize(context);
 
-        context.RegisterSyntaxNodeAction(OnDeclaration, DocumentationAnalysisUtilities.TypeParameterOwnerKinds);
+        context.RegisterSyntaxNodeActionWithDocumentationModeCheck(OnDeclaration, DocumentationAnalysisUtilities.TypeParameterOwnerKinds);
     }
 
     #endregion // DiagnosticAnalyzer

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0442GenericTypeParameterDocumentationMustDeclareParameterNameAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0442GenericTypeParameterDocumentationMustDeclareParameterNameAnalyzer.cs
@@ -72,7 +72,7 @@ public class RH0442GenericTypeParameterDocumentationMustDeclareParameterNameAnal
     {
         base.Initialize(context);
 
-        context.RegisterSyntaxNodeAction(OnDeclaration, DocumentationAnalysisUtilities.TypeParameterOwnerKinds);
+        context.RegisterSyntaxNodeActionWithDocumentationModeCheck(OnDeclaration, DocumentationAnalysisUtilities.TypeParameterOwnerKinds);
     }
 
     #endregion // DiagnosticAnalyzer

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0443GenericTypeParameterDocumentationMustHaveTextAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0443GenericTypeParameterDocumentationMustHaveTextAnalyzer.cs
@@ -72,7 +72,7 @@ public class RH0443GenericTypeParameterDocumentationMustHaveTextAnalyzer : Diagn
     {
         base.Initialize(context);
 
-        context.RegisterSyntaxNodeAction(OnDeclaration, DocumentationAnalysisUtilities.TypeParameterOwnerKinds);
+        context.RegisterSyntaxNodeActionWithDocumentationModeCheck(OnDeclaration, DocumentationAnalysisUtilities.TypeParameterOwnerKinds);
     }
 
     #endregion // DiagnosticAnalyzer

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0444SingleLineCommentsMustNotUseDocumentationStyleSlashesAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0444SingleLineCommentsMustNotUseDocumentationStyleSlashesAnalyzer.cs
@@ -73,7 +73,7 @@ public class RH0444SingleLineCommentsMustNotUseDocumentationStyleSlashesAnalyzer
     {
         base.Initialize(context);
 
-        context.RegisterSyntaxNodeAction(OnDocumentationCommentTrivia, SyntaxKind.SingleLineDocumentationCommentTrivia);
+        context.RegisterSyntaxNodeActionWithDocumentationModeCheck(OnDocumentationCommentTrivia, SyntaxKind.SingleLineDocumentationCommentTrivia);
     }
 
     #endregion // DiagnosticAnalyzer

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0445InheritdocMustBeUsedWithInheritingClassAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0445InheritdocMustBeUsedWithInheritingClassAnalyzer.cs
@@ -89,7 +89,7 @@ public class RH0445InheritdocMustBeUsedWithInheritingClassAnalyzer : DiagnosticA
     {
         base.Initialize(context);
 
-        context.RegisterSyntaxNodeAction(OnDeclaration, DocumentationAnalysisUtilities.DocumentableDeclarationKinds);
+        context.RegisterSyntaxNodeActionWithDocumentationModeCheck(OnDeclaration, DocumentationAnalysisUtilities.DocumentableDeclarationKinds);
     }
 
     #endregion // DiagnosticAnalyzer

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0446DoNotUsePlaceholderElementsAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0446DoNotUsePlaceholderElementsAnalyzer.cs
@@ -62,7 +62,7 @@ public class RH0446DoNotUsePlaceholderElementsAnalyzer : DiagnosticAnalyzerBase<
     {
         base.Initialize(context);
 
-        context.RegisterSyntaxNodeAction(OnXmlElement, SyntaxKind.XmlElement, SyntaxKind.XmlEmptyElement);
+        context.RegisterSyntaxNodeActionWithDocumentationModeCheck(OnXmlElement, SyntaxKind.XmlElement, SyntaxKind.XmlEmptyElement);
     }
 
     #endregion // DiagnosticAnalyzer

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0447XmlDocumentationElementsMustBeOnSeparateLinesAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0447XmlDocumentationElementsMustBeOnSeparateLinesAnalyzer.cs
@@ -126,7 +126,7 @@ public class RH0447XmlDocumentationElementsMustBeOnSeparateLinesAnalyzer : Diagn
     {
         base.Initialize(context);
 
-        context.RegisterSyntaxNodeAction(OnDocumentationCommentTrivia, SyntaxKind.SingleLineDocumentationCommentTrivia);
+        context.RegisterSyntaxNodeActionWithDocumentationModeCheck(OnDocumentationCommentTrivia, SyntaxKind.SingleLineDocumentationCommentTrivia);
     }
 
     #endregion // DiagnosticAnalyzer

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0448SummaryElementMustSpanAtLeastThreeLinesAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0448SummaryElementMustSpanAtLeastThreeLinesAnalyzer.cs
@@ -79,7 +79,7 @@ public class RH0448SummaryElementMustSpanAtLeastThreeLinesAnalyzer : DiagnosticA
     {
         base.Initialize(context);
 
-        context.RegisterSyntaxNodeAction(OnDocumentationCommentTrivia, SyntaxKind.SingleLineDocumentationCommentTrivia);
+        context.RegisterSyntaxNodeActionWithDocumentationModeCheck(OnDocumentationCommentTrivia, SyntaxKind.SingleLineDocumentationCommentTrivia);
     }
 
     #endregion // DiagnosticAnalyzer

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0449XmlDocumentationElementTextMustNotEndWithPeriodAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0449XmlDocumentationElementTextMustNotEndWithPeriodAnalyzer.cs
@@ -175,7 +175,7 @@ public class RH0449XmlDocumentationElementTextMustNotEndWithPeriodAnalyzer : Dia
     {
         base.Initialize(context);
 
-        context.RegisterSyntaxNodeAction(OnXmlElement, SyntaxKind.XmlElement);
+        context.RegisterSyntaxNodeActionWithDocumentationModeCheck(OnXmlElement, SyntaxKind.XmlElement);
     }
 
     #endregion // DiagnosticAnalyzer

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0450TextAfterOpeningXmlTagMustBeOnSameLineAsClosingTagAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0450TextAfterOpeningXmlTagMustBeOnSameLineAsClosingTagAnalyzer.cs
@@ -149,7 +149,7 @@ public class RH0450TextAfterOpeningXmlTagMustBeOnSameLineAsClosingTagAnalyzer : 
     {
         base.Initialize(context);
 
-        context.RegisterSyntaxNodeAction(OnXmlElement, SyntaxKind.XmlElement);
+        context.RegisterSyntaxNodeActionWithDocumentationModeCheck(OnXmlElement, SyntaxKind.XmlElement);
     }
 
     #endregion // DiagnosticAnalyzer

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0451NoContentShouldAppearAfterClosingXmlTagsAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0451NoContentShouldAppearAfterClosingXmlTagsAnalyzer.cs
@@ -144,7 +144,7 @@ public class RH0451NoContentShouldAppearAfterClosingXmlTagsAnalyzer : Diagnostic
     {
         base.Initialize(context);
 
-        context.RegisterSyntaxNodeAction(OnDocumentationCommentTrivia, SyntaxKind.SingleLineDocumentationCommentTrivia);
+        context.RegisterSyntaxNodeActionWithDocumentationModeCheck(OnDocumentationCommentTrivia, SyntaxKind.SingleLineDocumentationCommentTrivia);
     }
 
     #endregion // DiagnosticAnalyzer

--- a/Reihitsu.Analyzer/Rules/Documentation/RH0452FileMustStartWithConfiguredXmlStyleCopyrightHeaderAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH0452FileMustStartWithConfiguredXmlStyleCopyrightHeaderAnalyzer.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
 
@@ -63,6 +64,12 @@ public class RH0452FileMustStartWithConfiguredXmlStyleCopyrightHeaderAnalyzer : 
     /// <param name="context">Context</param>
     private void OnSyntaxTree(ConfigurationCategoryCopyright configuration, SyntaxTreeAnalysisContext context)
     {
+        if (context.Tree.Options is CSharpParseOptions parseOptions
+            && parseOptions.DocumentationMode == DocumentationMode.None)
+        {
+            return;
+        }
+
         var sourceText = context.Tree.GetText(context.CancellationToken);
         var expectedHeader = CopyrightHeaderTemplateResolver.ResolveHeader(configuration, context.Tree.FilePath);
 


### PR DESCRIPTION
## Summary

Add a shared documentation-mode guard helper and apply it across documentation analyzers so syntax-node actions are skipped when parse options use `DocumentationMode.None`.

## Why

Documentation analyzers should not run when documentation parsing is disabled. Centralizing this check avoids duplicated logic and keeps behavior consistent across affected rules.

## Linked issues

None.

## Review notes

This change introduces `DocumentationModeAnalysisContextExtensions` and switches analyzer registrations to `RegisterSyntaxNodeActionWithDocumentationModeCheck(...)`, including the split element documentation base analyzer.

## Follow-up work

None.
