### PR TITLE
Add RH0702 analyzer for documentation project configuration

### DIFF
--- a/Reihitsu.Analyzer.Package/README.MD
+++ b/Reihitsu.Analyzer.Package/README.MD
@@ -244,3 +244,4 @@ The **Formatter** column indicates whether running the Reihitsu formatter can au
 | [RH0503](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0503.md)| Use string interpolation instead of string concatenation.| ✔| ❌| ❌|
 || **Analyzer**||||
 | [RH0701](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0701.md)| reihitsu.json configuration must be valid.| ✔| ❌| ❌|
+| [RH0702](https://github.com/thoenissen/Reihitsu/blob/main/documentation/rules/RH0702.md)| Documentation rules are currently not active for this project.| ✔| ❌| ❌|

--- a/Reihitsu.Analyzer.Test/Analyzer/RH0702DocumentationModeMustNotBeNoneAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Analyzer/RH0702DocumentationModeMustNotBeNoneAnalyzerTests.cs
@@ -1,0 +1,126 @@
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Analyzer.Rules.Analyzer;
+using Reihitsu.Analyzer.Test.Base;
+
+namespace Reihitsu.Analyzer.Test.Analyzer;
+
+/// <summary>
+/// Tests for <see cref="RH0702DocumentationModeMustNotBeNoneAnalyzer"/>
+/// </summary>
+[TestClass]
+public class RH0702DocumentationModeMustNotBeNoneAnalyzerTests : AnalyzerTestsBase<RH0702DocumentationModeMustNotBeNoneAnalyzer>
+{
+    #region Tests
+
+    /// <summary>
+    /// Documentation mode none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task DocumentationModeNone()
+    {
+        const string source = """
+                              {|#0:namespace|} TestNamespace;
+                              """;
+
+        await Verify(source,
+                     test => test.SolutionTransforms.Add(ApplyDocumentationModeNone),
+                     Diagnostic(RH0702DocumentationModeMustNotBeNoneAnalyzer.DiagnosticId).WithLocation(0, DiagnosticLocationOptions.InterpretAsMarkupKey)
+                                                                                          .WithMessage(AnalyzerResources.RH0702MessageFormat));
+    }
+
+    /// <summary>
+    /// Documentation mode parse
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task DocumentationModeParse()
+    {
+        const string source = """
+                              namespace TestNamespace;
+                              """;
+
+        await Verify(source,
+                     test => test.SolutionTransforms.Add(ApplyDocumentationModeParse));
+    }
+
+    /// <summary>
+    /// Diagnostic is reported only once per project
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task DiagnosticOnlyOncePerProject()
+    {
+        await Verify("""
+                     namespace PlaceholderNamespace;
+                     """,
+                     test =>
+                     {
+                         test.TestState.Sources.Clear();
+                         test.TestState.Sources.Add(("/0/Test0.cs",
+                                                     """
+                                                     {|#0:namespace|} FirstNamespace;
+                                                     """));
+                         test.TestState.Sources.Add(("/0/Test1.cs",
+                                                     """
+                                                     {|#1:namespace|} SecondNamespace;
+                                                     """));
+                         test.SolutionTransforms.Add(ApplyDocumentationModeNone);
+                     },
+                     Diagnostic(RH0702DocumentationModeMustNotBeNoneAnalyzer.DiagnosticId).WithLocation(0, DiagnosticLocationOptions.InterpretAsMarkupKey)
+                                                                                          .WithMessage(AnalyzerResources.RH0702MessageFormat));
+    }
+
+    #endregion // Tests
+
+    #region Methods
+
+    /// <summary>
+    /// Apply documentation mode none
+    /// </summary>
+    /// <param name="solution">Solution</param>
+    /// <param name="projectId">Project ID</param>
+    /// <returns>Solution</returns>
+    private static Solution ApplyDocumentationModeNone(Solution solution, ProjectId projectId)
+    {
+        return ApplyDocumentationMode(solution, projectId, DocumentationMode.None);
+    }
+
+    /// <summary>
+    /// Apply documentation mode parse
+    /// </summary>
+    /// <param name="solution">Solution</param>
+    /// <param name="projectId">Project ID</param>
+    /// <returns>Solution</returns>
+    private static Solution ApplyDocumentationModeParse(Solution solution, ProjectId projectId)
+    {
+        return ApplyDocumentationMode(solution, projectId, DocumentationMode.Parse);
+    }
+
+    /// <summary>
+    /// Apply documentation mode
+    /// </summary>
+    /// <param name="solution">Solution</param>
+    /// <param name="projectId">Project ID</param>
+    /// <param name="documentationMode">Documentation mode</param>
+    /// <returns>Solution</returns>
+    private static Solution ApplyDocumentationMode(Solution solution, ProjectId projectId, DocumentationMode documentationMode)
+    {
+        var project = solution.GetProject(projectId);
+
+        if (project?.ParseOptions is CSharpParseOptions parseOptions)
+        {
+            solution = solution.WithProjectParseOptions(projectId, parseOptions.WithDocumentationMode(documentationMode));
+        }
+
+        return solution;
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Analyzer/AnalyzerResources.cs
+++ b/Reihitsu.Analyzer/AnalyzerResources.cs
@@ -1685,6 +1685,16 @@ internal static class AnalyzerResources
     internal static string RH0701MessageFormat => GetString(nameof(RH0701MessageFormat));
 
     /// <summary>
+    /// Gets the localized string for RH0702Title
+    /// </summary>
+    internal static string RH0702Title => GetString(nameof(RH0702Title));
+
+    /// <summary>
+    /// Gets the localized string for RH0702MessageFormat
+    /// </summary>
+    internal static string RH0702MessageFormat => GetString(nameof(RH0702MessageFormat));
+
+    /// <summary>
     /// Gets the localized string for RH0452Title
     /// </summary>
     internal static string RH0452Title => GetString(nameof(RH0452Title));

--- a/Reihitsu.Analyzer/AnalyzerResources.resx
+++ b/Reihitsu.Analyzer/AnalyzerResources.resx
@@ -1101,6 +1101,12 @@
   <data name="RH0701MessageFormat" xml:space="preserve">
     <value>The reihitsu.json configuration is invalid: {0}</value>
   </data>
+  <data name="RH0702Title" xml:space="preserve">
+    <value>Documentation rules are not active for this project</value>
+  </data>
+  <data name="RH0702MessageFormat" xml:space="preserve">
+    <value>Documentation-category rules are currently not active for this project configuration. Set &lt;GenerateDocumentationFile&gt;true&lt;/GenerateDocumentationFile&gt; in the project file to enable them.</value>
+  </data>
   <data name="RH0452Title" xml:space="preserve">
     <value>Files must start with configured copyright header</value>
   </data>

--- a/Reihitsu.Analyzer/Rules/Analyzer/RH0702DocumentationModeMustNotBeNoneAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Analyzer/RH0702DocumentationModeMustNotBeNoneAnalyzer.cs
@@ -1,0 +1,90 @@
+using System.Threading;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+
+using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Enumerations;
+
+namespace Reihitsu.Analyzer.Rules.Analyzer;
+
+/// <summary>
+/// RH0702: DocumentationMode must not be None for documentation rules
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class RH0702DocumentationModeMustNotBeNoneAnalyzer : DiagnosticAnalyzerBase<RH0702DocumentationModeMustNotBeNoneAnalyzer>
+{
+    #region Fields
+
+    /// <summary>
+    /// Diagnostic ID
+    /// </summary>
+    public const string DiagnosticId = "RH0702";
+
+    #endregion // Fields
+
+    #region Constructor
+
+    /// <summary>
+    /// Constructor
+    /// </summary>
+    public RH0702DocumentationModeMustNotBeNoneAnalyzer()
+        : base(DiagnosticId, DiagnosticCategory.Analyzer, nameof(AnalyzerResources.RH0702Title), nameof(AnalyzerResources.RH0702MessageFormat))
+    {
+    }
+
+    #endregion // Constructor
+
+    #region Methods
+
+    /// <summary>
+    /// Create location
+    /// </summary>
+    /// <param name="syntaxTree">Syntax tree</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Location</returns>
+    private static Location CreateLocation(SyntaxTree syntaxTree, CancellationToken cancellationToken)
+    {
+        var firstToken = syntaxTree.GetRoot(cancellationToken).GetFirstToken(includeZeroWidth: true);
+
+        return firstToken != default
+                   ? firstToken.GetLocation()
+                   : Location.Create(syntaxTree, new TextSpan(0, 0));
+    }
+
+    /// <summary>
+    /// Analyze compilation
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnCompilation(CompilationAnalysisContext context)
+    {
+        foreach (var syntaxTree in context.Compilation.SyntaxTrees)
+        {
+            if (syntaxTree.Options is CSharpParseOptions parseOptions)
+            {
+                if (parseOptions.DocumentationMode == DocumentationMode.None)
+                {
+                    context.ReportDiagnostic(CreateDiagnostic(CreateLocation(syntaxTree, context.CancellationToken)));
+                }
+
+                break;
+            }
+        }
+    }
+
+    #endregion // Methods
+
+    #region DiagnosticAnalyzer
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        base.Initialize(context);
+
+        context.RegisterCompilationAction(OnCompilation);
+    }
+
+    #endregion // DiagnosticAnalyzer
+}

--- a/Reihitsu.sln
+++ b/Reihitsu.sln
@@ -248,6 +248,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		documentation\rules\RH0613.md = documentation\rules\RH0613.md
 		documentation\rules\RH0614.md = documentation\rules\RH0614.md
 		documentation\rules\RH0701.md = documentation\rules\RH0701.md
+		documentation\rules\RH0702.md = documentation\rules\RH0702.md
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Reihitsu.Formatter", "Reihitsu.Formatter\Reihitsu.Formatter.csproj", "{E0C1F14C-6D72-4719-998B-F076CFCD665C}"

--- a/documentation/rules/RH0702.md
+++ b/documentation/rules/RH0702.md
@@ -1,0 +1,28 @@
+# RH0702 — Documentation rules are currently not active for this project
+
+| Property | Value |
+|----------|-------|
+| **ID** | RH0702 |
+| **Category** | Analyzer |
+| **Severity** | Warning |
+| **Code Fix** | ❌ |
+
+## Description
+
+This rule indicates that documentation-category analysis is currently not enabled by the project configuration.
+
+## Why is this a problem?
+
+If this project configuration remains disabled, documentation-category rules cannot process XML documentation comments as intended. This can hide documentation issues that would otherwise be reported.
+
+## How to fix it
+
+Enable XML documentation generation in the project file:
+
+```cs
+<PropertyGroup>
+  <GenerateDocumentationFile>true</GenerateDocumentationFile>
+</PropertyGroup>
+```
+
+This project setting enables the required processing so documentation-category rules can run.


### PR DESCRIPTION
## Summary

Add analyzer rule RH0702 to report when documentation-category analysis is not active due to project configuration.

## Why

Documentation rules depend on XML documentation processing. When this is not enabled in the project, those rules cannot run as intended and users do not get expected diagnostics.

## Linked issues

None

## Review notes

- Adds RH0702 analyzer (no code fix) and reports once per project.
- Adds rule documentation and analyzer tests, including one-diagnostic-per-project coverage.

## Follow-up work

None
