### PR TITLE
Add DocumentationMode.None guard tests for RH04 analyzers

### DIFF
--- a/Reihitsu.Analyzer.Test/Base/AnalyzerTestsBase{TAnalyzer}.cs
+++ b/Reihitsu.Analyzer.Test/Base/AnalyzerTestsBase{TAnalyzer}.cs
@@ -2,6 +2,8 @@
 using System.Threading;
 using System.Threading.Tasks;
 
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
@@ -92,6 +94,24 @@ public abstract class AnalyzerTestsBase<TAnalyzer>
         onConfigure?.Invoke(test);
 
         await test.RunAsync(CancellationToken.None);
+    }
+
+    /// <summary>
+    /// Applies <see cref="DocumentationMode.None"/> to the test project parse options
+    /// </summary>
+    /// <param name="solution">Solution</param>
+    /// <param name="projectId">Project ID</param>
+    /// <returns>Solution</returns>
+    protected static Solution ApplyDocumentationModeNoneToTestProject(Solution solution, ProjectId projectId)
+    {
+        var project = solution.GetProject(projectId);
+
+        if (project?.ParseOptions is CSharpParseOptions parseOptions)
+        {
+            solution = solution.WithProjectParseOptions(projectId, parseOptions.WithDocumentationMode(DocumentationMode.None));
+        }
+
+        return solution;
     }
 
     #endregion // Methods

--- a/Reihitsu.Analyzer.Test/Documentation/RH0401InheritdocShouldBeUsedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0401InheritdocShouldBeUsedAnalyzerTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -305,6 +305,34 @@ public class RH0401InheritdocShouldBeUsedAnalyzerTests : AnalyzerTestsBase<RH040
     public async Task VerifyDiagnosticForIndexer()
     {
         await Verify(IndexerTestData, IndexerResultData, Diagnostics(RH0401InheritdocShouldBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH0401MessageFormat, 1));
+    }
+
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              namespace TestNamespace;
+                              
+                              internal abstract class BaseType
+                              {
+                                  /// <summary>Base docs.</summary>
+                                  public abstract void Execute();
+                              }
+                              
+                              internal class DerivedType : BaseType
+                              {
+                                  /// <summary>Implementation docs.</summary>
+                                  public override void Execute()
+                                  {
+                                  }
+                              }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
     }
 
     #endregion // Methods

--- a/Reihitsu.Analyzer.Test/Documentation/RH0402NonPrivateClassesMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0402NonPrivateClassesMustBeDocumentedAnalyzerTests.cs
@@ -297,5 +297,19 @@ public class RH0402NonPrivateClassesMustBeDocumentedAnalyzerTests : AnalyzerTest
         }
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal class TestClass { }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Malformed XML cases
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0403PrivateClassesMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0403PrivateClassesMustBeDocumentedAnalyzerTests.cs
@@ -158,5 +158,19 @@ public class RH0403PrivateClassesMustBeDocumentedAnalyzerTests : AnalyzerTestsBa
         await Verify(source);
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal class OuterType { private class NestedType { } }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // No-diagnostic cases
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0404NonPrivateStructsMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0404NonPrivateStructsMustBeDocumentedAnalyzerTests.cs
@@ -158,5 +158,19 @@ public class RH0404NonPrivateStructsMustBeDocumentedAnalyzerTests : AnalyzerTest
         await Verify(source);
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal struct TestStruct { }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // No-diagnostic cases
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0405PrivateStructsMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0405PrivateStructsMustBeDocumentedAnalyzerTests.cs
@@ -132,5 +132,19 @@ public class RH0405PrivateStructsMustBeDocumentedAnalyzerTests : AnalyzerTestsBa
         await Verify(source);
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal class OuterType { private struct NestedStruct { } }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // No-diagnostic cases
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0406NonPrivateInterfacesMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0406NonPrivateInterfacesMustBeDocumentedAnalyzerTests.cs
@@ -172,5 +172,19 @@ public class RH0406NonPrivateInterfacesMustBeDocumentedAnalyzerTests : AnalyzerT
         await Verify(source);
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal interface IContract { }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // No-diagnostic cases
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0407PrivateInterfacesMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0407PrivateInterfacesMustBeDocumentedAnalyzerTests.cs
@@ -155,5 +155,19 @@ public class RH0407PrivateInterfacesMustBeDocumentedAnalyzerTests : AnalyzerTest
         await Verify(source);
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal class OuterType { private interface INestedContract { } }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // No-diagnostic cases
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0408NonPrivateRecordsMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0408NonPrivateRecordsMustBeDocumentedAnalyzerTests.cs
@@ -231,5 +231,19 @@ public class RH0408NonPrivateRecordsMustBeDocumentedAnalyzerTests : AnalyzerTest
         await Verify(source);
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal record TestRecord;
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // No-diagnostic cases
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0409PrivateRecordsMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0409PrivateRecordsMustBeDocumentedAnalyzerTests.cs
@@ -147,5 +147,19 @@ public class RH0409PrivateRecordsMustBeDocumentedAnalyzerTests : AnalyzerTestsBa
         await Verify(source);
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal class OuterType { private record NestedRecord; }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // No-diagnostic cases
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0410NonPrivateRecordStructsMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0410NonPrivateRecordStructsMustBeDocumentedAnalyzerTests.cs
@@ -177,5 +177,19 @@ public class RH0410NonPrivateRecordStructsMustBeDocumentedAnalyzerTests : Analyz
         await Verify(source);
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal record struct TestRecordStruct;
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // No-diagnostic cases
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0411PrivateRecordStructsMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0411PrivateRecordStructsMustBeDocumentedAnalyzerTests.cs
@@ -147,5 +147,19 @@ public class RH0411PrivateRecordStructsMustBeDocumentedAnalyzerTests : AnalyzerT
         await Verify(source);
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal class OuterType { private record struct NestedRecordStruct; }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // No-diagnostic cases
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0412NonPrivateEnumsMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0412NonPrivateEnumsMustBeDocumentedAnalyzerTests.cs
@@ -209,5 +209,19 @@ public class RH0412NonPrivateEnumsMustBeDocumentedAnalyzerTests : AnalyzerTestsB
         await Verify(source);
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal enum TestEnum { Value }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // No-diagnostic cases
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0413PrivateEnumsMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0413PrivateEnumsMustBeDocumentedAnalyzerTests.cs
@@ -165,5 +165,19 @@ public class RH0413PrivateEnumsMustBeDocumentedAnalyzerTests : AnalyzerTestsBase
         await Verify(source);
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal class OuterType { private enum NestedEnum { Value } }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // No-diagnostic cases
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0414NonPrivateEnumMembersMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0414NonPrivateEnumMembersMustBeDocumentedAnalyzerTests.cs
@@ -283,5 +283,19 @@ public class RH0414NonPrivateEnumMembersMustBeDocumentedAnalyzerTests : Analyzer
         }
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal enum TestEnum { Value }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Malformed XML cases
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0415PrivateEnumMembersMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0415PrivateEnumMembersMustBeDocumentedAnalyzerTests.cs
@@ -194,5 +194,19 @@ public class RH0415PrivateEnumMembersMustBeDocumentedAnalyzerTests : AnalyzerTes
         await Verify(source);
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal class OuterType { private enum NestedEnum { Value } }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Access-boundary cases
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0416NonPrivateDelegatesMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0416NonPrivateDelegatesMustBeDocumentedAnalyzerTests.cs
@@ -198,5 +198,19 @@ public class RH0416NonPrivateDelegatesMustBeDocumentedAnalyzerTests : AnalyzerTe
         await Verify(source);
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal delegate void TestDelegate();
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Access-boundary cases
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0417PrivateDelegatesMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0417PrivateDelegatesMustBeDocumentedAnalyzerTests.cs
@@ -164,5 +164,19 @@ public class RH0417PrivateDelegatesMustBeDocumentedAnalyzerTests : AnalyzerTests
         await Verify(source);
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal class OuterType { private delegate void NestedDelegate(); }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Access-boundary cases
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0418NonPrivateConstructorsMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0418NonPrivateConstructorsMustBeDocumentedAnalyzerTests.cs
@@ -37,5 +37,19 @@ public class RH0418NonPrivateConstructorsMustBeDocumentedAnalyzerTests : Analyze
         await Verify(source, Diagnostics(RH0418NonPrivateConstructorsMustBeDocumentedAnalyzer.DiagnosticId, AnalyzerResources.RH0418MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal class TestClass { internal TestClass() { } }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0419PrivateConstructorsMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0419PrivateConstructorsMustBeDocumentedAnalyzerTests.cs
@@ -37,5 +37,19 @@ public class RH0419PrivateConstructorsMustBeDocumentedAnalyzerTests : AnalyzerTe
         await Verify(source, Diagnostics(RH0419PrivateConstructorsMustBeDocumentedAnalyzer.DiagnosticId, AnalyzerResources.RH0419MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal class TestClass { private TestClass() { } }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0420DestructorsMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0420DestructorsMustBeDocumentedAnalyzerTests.cs
@@ -37,5 +37,19 @@ public class RH0420DestructorsMustBeDocumentedAnalyzerTests : AnalyzerTestsBase<
         await Verify(source, Diagnostics(RH0420DestructorsMustBeDocumentedAnalyzer.DiagnosticId, AnalyzerResources.RH0420MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal class TestClass { ~TestClass() { } }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0421NonPrivateMethodsMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0421NonPrivateMethodsMustBeDocumentedAnalyzerTests.cs
@@ -37,5 +37,19 @@ public class RH0421NonPrivateMethodsMustBeDocumentedAnalyzerTests : AnalyzerTest
         await Verify(source, Diagnostics(RH0421NonPrivateMethodsMustBeDocumentedAnalyzer.DiagnosticId, AnalyzerResources.RH0421MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal class TestClass { internal void Execute() { } }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0422PrivateMethodsMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0422PrivateMethodsMustBeDocumentedAnalyzerTests.cs
@@ -37,5 +37,19 @@ public class RH0422PrivateMethodsMustBeDocumentedAnalyzerTests : AnalyzerTestsBa
         await Verify(source, Diagnostics(RH0422PrivateMethodsMustBeDocumentedAnalyzer.DiagnosticId, AnalyzerResources.RH0422MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal class TestClass { private void Execute() { } }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0423NonPrivatePropertiesMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0423NonPrivatePropertiesMustBeDocumentedAnalyzerTests.cs
@@ -35,5 +35,19 @@ public class RH0423NonPrivatePropertiesMustBeDocumentedAnalyzerTests : AnalyzerT
         await Verify(source, Diagnostics(RH0423NonPrivatePropertiesMustBeDocumentedAnalyzer.DiagnosticId, AnalyzerResources.RH0423MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal class TestClass { internal int Value { get; } }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0424PrivatePropertiesMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0424PrivatePropertiesMustBeDocumentedAnalyzerTests.cs
@@ -35,5 +35,19 @@ public class RH0424PrivatePropertiesMustBeDocumentedAnalyzerTests : AnalyzerTest
         await Verify(source, Diagnostics(RH0424PrivatePropertiesMustBeDocumentedAnalyzer.DiagnosticId, AnalyzerResources.RH0424MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal class TestClass { private int Value { get; } }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0425NonPrivateIndexersMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0425NonPrivateIndexersMustBeDocumentedAnalyzerTests.cs
@@ -35,5 +35,19 @@ public class RH0425NonPrivateIndexersMustBeDocumentedAnalyzerTests : AnalyzerTes
         await Verify(source, Diagnostics(RH0425NonPrivateIndexersMustBeDocumentedAnalyzer.DiagnosticId, AnalyzerResources.RH0425MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal class TestClass { internal int this[int index] => index; }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0426PrivateIndexersMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0426PrivateIndexersMustBeDocumentedAnalyzerTests.cs
@@ -35,5 +35,19 @@ public class RH0426PrivateIndexersMustBeDocumentedAnalyzerTests : AnalyzerTestsB
         await Verify(source, Diagnostics(RH0426PrivateIndexersMustBeDocumentedAnalyzer.DiagnosticId, AnalyzerResources.RH0426MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal class TestClass { private int this[int index] => index; }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0427NonPrivateFieldsMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0427NonPrivateFieldsMustBeDocumentedAnalyzerTests.cs
@@ -35,5 +35,19 @@ public class RH0427NonPrivateFieldsMustBeDocumentedAnalyzerTests : AnalyzerTests
         await Verify(source, Diagnostics(RH0427NonPrivateFieldsMustBeDocumentedAnalyzer.DiagnosticId, AnalyzerResources.RH0427MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal class TestClass { internal int currentValue; }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0428PrivateFieldsMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0428PrivateFieldsMustBeDocumentedAnalyzerTests.cs
@@ -35,5 +35,19 @@ public class RH0428PrivateFieldsMustBeDocumentedAnalyzerTests : AnalyzerTestsBas
         await Verify(source, Diagnostics(RH0428PrivateFieldsMustBeDocumentedAnalyzer.DiagnosticId, AnalyzerResources.RH0428MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal class TestClass { private int currentValue; }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0429NonPrivateEventsMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0429NonPrivateEventsMustBeDocumentedAnalyzerTests.cs
@@ -83,5 +83,19 @@ public class RH0429NonPrivateEventsMustBeDocumentedAnalyzerTests : AnalyzerTests
         await Verify(source);
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal class TestClass { internal event System.Action Changed; }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0430PrivateEventsMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0430PrivateEventsMustBeDocumentedAnalyzerTests.cs
@@ -35,5 +35,19 @@ public class RH0430PrivateEventsMustBeDocumentedAnalyzerTests : AnalyzerTestsBas
         await Verify(source, Diagnostics(RH0430PrivateEventsMustBeDocumentedAnalyzer.DiagnosticId, AnalyzerResources.RH0430MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal class TestClass { private event System.Action Changed; }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0431ElementDocumentationMustHaveSummaryTextAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0431ElementDocumentationMustHaveSummaryTextAnalyzerTests.cs
@@ -73,5 +73,24 @@ public class RH0431ElementDocumentationMustHaveSummaryTextAnalyzerTests : Analyz
         await Verify(source);
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              namespace TestNamespace;
+                              
+                              /// {|#0:<summary></summary>|}
+                              internal partial class TestClass
+                              {
+                              }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0432ValueTagMustNotBeUsedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0432ValueTagMustNotBeUsedAnalyzerTests.cs
@@ -49,5 +49,27 @@ public class RH0432ValueTagMustNotBeUsedAnalyzerTests : AnalyzerTestsBase<RH0432
                      Diagnostics(RH0432ValueTagMustNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH0432MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              namespace TestNamespace;
+                              
+                              /// <summary>Stores the current value.</summary>
+                              internal class TestClass
+                              {
+                                  /// <summary>Gets the current value.</summary>
+                                  /// {|#0:<value>The current value.</value>|}
+                                  internal int Value { get; }
+                              }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0433ElementParametersMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0433ElementParametersMustBeDocumentedAnalyzerTests.cs
@@ -38,5 +38,28 @@ public class RH0433ElementParametersMustBeDocumentedAnalyzerTests : AnalyzerTest
         await Verify(source, Diagnostics(RH0433ElementParametersMustBeDocumentedAnalyzer.DiagnosticId, AnalyzerResources.RH0433MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              namespace TestNamespace;
+                              
+                              internal class TestClass
+                              {
+                                  /// <summary>Runs the method.</summary>
+                                  /// <param name="secondValue">Second value.</param>
+                                  internal void TestMethod(int {|#0:firstValue|}, int secondValue)
+                                  {
+                                  }
+                              }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0434ElementParameterDocumentationMustMatchElementParametersAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0434ElementParameterDocumentationMustMatchElementParametersAnalyzerTests.cs
@@ -39,5 +39,29 @@ public class RH0434ElementParameterDocumentationMustMatchElementParametersAnalyz
         await Verify(source, Diagnostics(RH0434ElementParameterDocumentationMustMatchElementParametersAnalyzer.DiagnosticId, AnalyzerResources.RH0434MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              namespace TestNamespace;
+                              
+                              internal class TestClass
+                              {
+                                  /// <summary>Runs the method.</summary>
+                                  /// <param name="firstValue">First value.</param>
+                                  /// {|#0:<param name="missingValue">Missing value.</param>|}
+                                  internal void TestMethod(int firstValue, int secondValue)
+                                  {
+                                  }
+                              }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0435ElementParameterDocumentationMustDeclareParameterNameAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0435ElementParameterDocumentationMustDeclareParameterNameAnalyzerTests.cs
@@ -38,5 +38,28 @@ public class RH0435ElementParameterDocumentationMustDeclareParameterNameAnalyzer
         await Verify(source, Diagnostics(RH0435ElementParameterDocumentationMustDeclareParameterNameAnalyzer.DiagnosticId, AnalyzerResources.RH0435MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              namespace TestNamespace;
+                              
+                              internal class TestClass
+                              {
+                                  /// <summary>Runs the method.</summary>
+                                  /// {|#0:<param>First value.</param>|}
+                                  internal void TestMethod(int firstValue)
+                                  {
+                                  }
+                              }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0436ElementParameterDocumentationMustHaveTextAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0436ElementParameterDocumentationMustHaveTextAnalyzerTests.cs
@@ -38,5 +38,28 @@ public class RH0436ElementParameterDocumentationMustHaveTextAnalyzerTests : Anal
         await Verify(source, Diagnostics(RH0436ElementParameterDocumentationMustHaveTextAnalyzer.DiagnosticId, AnalyzerResources.RH0436MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              namespace TestNamespace;
+                              
+                              internal class TestClass
+                              {
+                                  /// <summary>Runs the method.</summary>
+                                  /// {|#0:<param name="firstValue"></param>|}
+                                  internal void TestMethod(int firstValue)
+                                  {
+                                  }
+                              }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0437ElementReturnValueMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0437ElementReturnValueMustBeDocumentedAnalyzerTests.cs
@@ -38,5 +38,28 @@ public class RH0437ElementReturnValueMustBeDocumentedAnalyzerTests : AnalyzerTes
         await Verify(source, Diagnostics(RH0437ElementReturnValueMustBeDocumentedAnalyzer.DiagnosticId, AnalyzerResources.RH0437MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              namespace TestNamespace;
+                              
+                              internal class TestClass
+                              {
+                                  /// <summary>Gets the value.</summary>
+                                  internal {|#0:int|} GetValue()
+                                  {
+                                      return 1;
+                                  }
+                              }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0438ElementReturnValueDocumentationMustHaveTextAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0438ElementReturnValueDocumentationMustHaveTextAnalyzerTests.cs
@@ -39,5 +39,29 @@ public class RH0438ElementReturnValueDocumentationMustHaveTextAnalyzerTests : An
         await Verify(source, Diagnostics(RH0438ElementReturnValueDocumentationMustHaveTextAnalyzer.DiagnosticId, AnalyzerResources.RH0438MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              namespace TestNamespace;
+                              
+                              internal class TestClass
+                              {
+                                  /// <summary>Gets the value.</summary>
+                                  /// {|#0:<returns></returns>|}
+                                  internal int GetValue()
+                                  {
+                                      return 1;
+                                  }
+                              }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0439VoidReturnValueMustNotBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0439VoidReturnValueMustNotBeDocumentedAnalyzerTests.cs
@@ -53,5 +53,28 @@ public class RH0439VoidReturnValueMustNotBeDocumentedAnalyzerTests : AnalyzerTes
                      Diagnostics(RH0439VoidReturnValueMustNotBeDocumentedAnalyzer.DiagnosticId, AnalyzerResources.RH0439MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              namespace TestNamespace;
+                              
+                              internal class TestClass
+                              {
+                                  /// <summary>Runs the method.</summary>
+                                  /// {|#0:<returns>Nothing.</returns>|}
+                                  internal void TestMethod()
+                                  {
+                                  }
+                              }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0440GenericTypeParametersMustBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0440GenericTypeParametersMustBeDocumentedAnalyzerTests.cs
@@ -57,5 +57,28 @@ public class RH0440GenericTypeParametersMustBeDocumentedAnalyzerTests : Analyzer
         await Verify(source, Diagnostics(RH0440GenericTypeParametersMustBeDocumentedAnalyzer.DiagnosticId, AnalyzerResources.RH0440MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              namespace TestNamespace;
+                              
+                              internal class TestClass
+                              {
+                                  /// <summary>Creates a value.</summary>
+                                  internal T Create<{|#0:T|}>()
+                                  {
+                                      return default;
+                                  }
+                              }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0441GenericTypeParameterDocumentationMustMatchTypeParametersAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0441GenericTypeParameterDocumentationMustMatchTypeParametersAnalyzerTests.cs
@@ -36,5 +36,26 @@ public class RH0441GenericTypeParameterDocumentationMustMatchTypeParametersAnaly
         await Verify(source, Diagnostics(RH0441GenericTypeParameterDocumentationMustMatchTypeParametersAnalyzer.DiagnosticId, AnalyzerResources.RH0441MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              namespace TestNamespace;
+                              
+                              /// <summary>Represents a pair.</summary>
+                              /// <typeparam name="TFirst">First value.</typeparam>
+                              /// {|#0:<typeparam name="TMissing">Missing value.</typeparam>|}
+                              internal class Pair<TFirst, TSecond>
+                              {
+                              }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0442GenericTypeParameterDocumentationMustDeclareParameterNameAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0442GenericTypeParameterDocumentationMustDeclareParameterNameAnalyzerTests.cs
@@ -35,5 +35,25 @@ public class RH0442GenericTypeParameterDocumentationMustDeclareParameterNameAnal
         await Verify(source, Diagnostics(RH0442GenericTypeParameterDocumentationMustDeclareParameterNameAnalyzer.DiagnosticId, AnalyzerResources.RH0442MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              namespace TestNamespace;
+                              
+                              /// <summary>Represents a generic type.</summary>
+                              /// {|#0:<typeparam>Value.</typeparam>|}
+                              internal class Repository<T>
+                              {
+                              }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0443GenericTypeParameterDocumentationMustHaveTextAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0443GenericTypeParameterDocumentationMustHaveTextAnalyzerTests.cs
@@ -35,5 +35,25 @@ public class RH0443GenericTypeParameterDocumentationMustHaveTextAnalyzerTests : 
         await Verify(source, Diagnostics(RH0443GenericTypeParameterDocumentationMustHaveTextAnalyzer.DiagnosticId, AnalyzerResources.RH0443MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              namespace TestNamespace;
+                              
+                              /// <summary>Represents a generic type.</summary>
+                              /// {|#0:<typeparam name="T"></typeparam>|}
+                              internal class Repository<T>
+                              {
+                              }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0444SingleLineCommentsMustNotUseDocumentationStyleSlashesAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0444SingleLineCommentsMustNotUseDocumentationStyleSlashesAnalyzerTests.cs
@@ -50,5 +50,27 @@ public class RH0444SingleLineCommentsMustNotUseDocumentationStyleSlashesAnalyzer
         await Verify(source, fixedSource, Diagnostics(RH0444SingleLineCommentsMustNotUseDocumentationStyleSlashesAnalyzer.DiagnosticId, AnalyzerResources.RH0444MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              namespace TestNamespace;
+                              
+                              internal class TestClass
+                              {
+                                  {|#0:///|} just a comment
+                                  internal void TestMethod()
+                                  {
+                                  }
+                              }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0445InheritdocMustBeUsedWithInheritingClassAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0445InheritdocMustBeUsedWithInheritingClassAnalyzerTests.cs
@@ -64,5 +64,24 @@ public class RH0445InheritdocMustBeUsedWithInheritingClassAnalyzerTests : Analyz
         await Verify(source);
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              namespace TestNamespace;
+                              
+                              /// {|#0:<inheritdoc/>|}
+                              internal class TestClass
+                              {
+                              }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0446DoNotUsePlaceholderElementsAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0446DoNotUsePlaceholderElementsAnalyzerTests.cs
@@ -44,5 +44,24 @@ public class RH0446DoNotUsePlaceholderElementsAnalyzerTests : AnalyzerTestsBase<
         await Verify(source, fixedSource, Diagnostics(RH0446DoNotUsePlaceholderElementsAnalyzer.DiagnosticId, AnalyzerResources.RH0446MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              namespace TestNamespace;
+                              
+                              /// <summary>This method {|#0:<placeholder>does work</placeholder>|}.</summary>
+                              internal class TestClass
+                              {
+                              }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0447XmlDocumentationElementsMustBeOnSeparateLinesAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0447XmlDocumentationElementsMustBeOnSeparateLinesAnalyzerTests.cs
@@ -92,5 +92,27 @@ public class RH0447XmlDocumentationElementsMustBeOnSeparateLinesAnalyzerTests : 
         await Verify(testData);
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal class TestClass
+                              {
+                                  /// <summary>
+                                  /// Summary.
+                                  /// </summary><param name="value">Value.</param>
+                                  internal void Execute(string value)
+                                  {
+                                  }
+                              }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0448SummaryElementMustSpanAtLeastThreeLinesAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0448SummaryElementMustSpanAtLeastThreeLinesAnalyzerTests.cs
@@ -186,5 +186,25 @@ public class RH0448SummaryElementMustSpanAtLeastThreeLinesAnalyzerTests : Analyz
         await Verify(testData, fixedData, Diagnostics(RH0448SummaryElementMustSpanAtLeastThreeLinesAnalyzer.DiagnosticId, AnalyzerResources.RH0448MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal class TestClass
+                              {
+                                  /// <summary>Summary text</summary>
+                                  internal void Execute()
+                                  {
+                                  }
+                              }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0449XmlDocumentationElementTextMustNotEndWithPeriodAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0449XmlDocumentationElementTextMustNotEndWithPeriodAnalyzerTests.cs
@@ -155,5 +155,27 @@ public class RH0449XmlDocumentationElementTextMustNotEndWithPeriodAnalyzerTests 
         await Verify(testData);
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal class TestClass
+                              {
+                                  /// <summary>
+                                  /// This method validates the input.
+                                  /// </summary>
+                                  internal void Execute()
+                                  {
+                                  }
+                              }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0450TextAfterOpeningXmlTagMustBeOnSameLineAsClosingTagAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0450TextAfterOpeningXmlTagMustBeOnSameLineAsClosingTagAnalyzerTests.cs
@@ -189,5 +189,26 @@ public class RH0450TextAfterOpeningXmlTagMustBeOnSameLineAsClosingTagAnalyzerTes
         await Verify(testData, fixedData, Diagnostics(RH0450TextAfterOpeningXmlTagMustBeOnSameLineAsClosingTagAnalyzer.DiagnosticId, AnalyzerResources.RH0450MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal class TestClass
+                              {
+                                  /// <summary><see cref="string"/>
+                                  /// values</summary>
+                                  internal void Execute()
+                                  {
+                                  }
+                              }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH0451NoContentShouldAppearAfterClosingXmlTagsAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH0451NoContentShouldAppearAfterClosingXmlTagsAnalyzerTests.cs
@@ -134,5 +134,25 @@ public class RH0451NoContentShouldAppearAfterClosingXmlTagsAnalyzerTests : Analy
         await Verify(testData, fixedData, Diagnostics(RH0451NoContentShouldAppearAfterClosingXmlTagsAnalyzer.DiagnosticId, AnalyzerResources.RH0451MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies no diagnostics are reported when documentation mode is none
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenDocumentationModeIsNone()
+    {
+        const string source = """
+                              internal class TestClass
+                              {
+                                  /// <summary>Summary.</summary> Additional text
+                                  internal void Execute()
+                                  {
+                                  }
+                              }
+                              """;
+
+        await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
+    }
+
     #endregion // Tests
 }


### PR DESCRIPTION
## Summary

Add DocumentationMode.None suppression coverage directly to each RH0401-RH0451 documentation analyzer test class.
Use the existing `Verify(...)` test flow with a shared base-class parse-options transform helper.

## Why

This ensures every analyzer that relies on documentation-mode guarded syntax registration is explicitly validated to not report diagnostics when documentation mode is disabled, while keeping tests aligned with repository verifier conventions.

## Linked issues

None

## Review notes

- Each affected documentation analyzer test class now contains `VerifyNoDiagnosticsWhenDocumentationModeIsNone`.
- The checks run through `AnalyzerTestsBase.Verify` using `SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject)`.

## Follow-up work

None
