### PR TITLE
Fix RH3201 crash on unterminated block comments

### DIFF
--- a/Reihitsu.Analyzer.Test/Clarity/RH3201CommentsMustContainTextAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Clarity/RH3201CommentsMustContainTextAnalyzerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 
+using Microsoft.CodeAnalysis.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Reihitsu.Analyzer.CodeFixes.Rules.Clarity;
@@ -323,6 +324,79 @@ public class RH3201CommentsMustContainTextAnalyzerTests : AnalyzerTestsBase<RH32
                                 """;
 
         await Verify(testCode);
+    }
+
+    /// <summary>
+    /// Verifying an unterminated multi-line comment at the end of the file is not reported and does not crash the analyzer
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task UnterminatedMultiLineCommentAtEndOfFileIsNotReported()
+    {
+        const string testCode = """
+                                public class Test
+                                {
+                                }
+                                /*
+                                """;
+
+        await Verify(testCode, test => test.CompilerDiagnostics = CompilerDiagnostics.None);
+    }
+
+    /// <summary>
+    /// Verifying an unterminated documentation-style multi-line comment at the end of the file is not reported and does not crash the analyzer
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task UnterminatedDocumentationStyleMultiLineCommentAtEndOfFileIsNotReported()
+    {
+        const string testCode = """
+                                public class Test
+                                {
+                                }
+                                /**
+                                """;
+
+        await Verify(testCode,
+                     test =>
+                     {
+                         test.CompilerDiagnostics = CompilerDiagnostics.None;
+                         test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject);
+                     });
+    }
+
+    /// <summary>
+    /// Verifying an unterminated multi-line comment whose closing slash is missing is not reported and does not crash the analyzer
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task UnterminatedSlashStarSlashCommentAtEndOfFileIsNotReported()
+    {
+        const string testCode = """
+                                public class Test
+                                {
+                                }
+                                /*/
+                                """;
+
+        await Verify(testCode, test => test.CompilerDiagnostics = CompilerDiagnostics.None);
+    }
+
+    /// <summary>
+    /// Verifying a longer unterminated multi-line comment is treated as non-empty and its trailing content is not chopped
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task LongUnterminatedMultiLineCommentWithTrailingContentIsNotReported()
+    {
+        const string testCode = """
+                                public class Test
+                                {
+                                }
+                                /*  hi
+                                """;
+
+        await Verify(testCode, test => test.CompilerDiagnostics = CompilerDiagnostics.None);
     }
 
     #endregion // Tests

--- a/Reihitsu.Analyzer/Rules/Clarity/RH3201CommentsMustContainTextAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Clarity/RH3201CommentsMustContainTextAnalyzer.cs
@@ -45,14 +45,36 @@ public class RH3201CommentsMustContainTextAnalyzer : DiagnosticAnalyzerBase
     /// <returns><see langword="true"/> if the comment is empty</returns>
     private static bool IsEmptyComment(SyntaxTrivia commentTrivia)
     {
+        var text = commentTrivia.ToString();
+
         var commentText = commentTrivia.Kind() switch
                           {
-                              SyntaxKind.SingleLineCommentTrivia => commentTrivia.ToString().Substring(2),
-                              SyntaxKind.MultiLineCommentTrivia => commentTrivia.ToString().Substring(2, commentTrivia.ToString().Length - 4),
+                              SyntaxKind.SingleLineCommentTrivia => text.Substring(2),
+                              SyntaxKind.MultiLineCommentTrivia => GetMultiLineCommentContent(text),
                               _ => string.Empty
                           };
 
         return string.IsNullOrWhiteSpace(commentText);
+    }
+
+    /// <summary>
+    /// Extract the content of a multi-line comment, excluding the surrounding <c>/*</c> and <c>*/</c> delimiters
+    /// </summary>
+    /// <param name="text">Full comment trivia text</param>
+    /// <returns>The comment content, or the full text when the comment is unterminated</returns>
+    private static string GetMultiLineCommentContent(string text)
+    {
+        // An unterminated block comment (for example "/*", "/**" or "/*/" while still typing at the end of a file)
+        // is still MultiLineCommentTrivia but has no closing "*/". Returning the full, non-empty text treats it as
+        // non-empty so mid-typing states never report the diagnostic and the slicing below never runs with a
+        // negative length or chops trailing content characters.
+        if ((text.Length < 4)
+            || (text.EndsWith("*/", StringComparison.Ordinal) == false))
+        {
+            return text;
+        }
+
+        return text.Substring(2, text.Length - 4);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Guard `RH3201CommentsMustContainTextAnalyzer.IsEmptyComment` so an unterminated block comment is treated as non-empty instead of crashing or losing content when the comment trivia is sliced.

## Why

`IsEmptyComment` sliced multi-line comment trivia with `Substring(2, length - 4)`. An unterminated block comment is still `MultiLineCommentTrivia`, so `/*`, `/**`, or `/*/` at end of file — routine mid-typing states in an editor — produced a negative length and threw `ArgumentOutOfRangeException`, killing the analyzer run (surfacing as AD0001). Longer unterminated comments silently lost their last two content characters, which could also misreport a non-empty comment as empty (RH3201 false positive).

## Linked issues

Closes #452

## Review notes

- A new `GetMultiLineCommentContent` helper returns the full, non-empty text when the comment is under four characters or does not end with `*/`, so unterminated comments never fire the diagnostic and the slice only runs on properly terminated comments.
- Behavior change: unterminated block comments are now treated as non-empty (previously a crash or a potential false positive). Terminated empty comments such as `/**/` and `/*   */` are still reported exactly as before.
- Four focused regression tests cover `/*`, `/**`, `/*/`, and a longer unterminated comment (`/*  hi`) asserting no trailing content is chopped. The documentation-style `/**` case runs under `DocumentationMode.None` so it is lexed as a regular multi-line comment, and the unterminated sources use `CompilerDiagnostics.None` to focus on analyzer behavior.

## Follow-up work

None.