### PR TITLE
Guard the RH7309 region swap against relocating preprocessor directives

### DIFF
--- a/Reihitsu.Analyzer.CodeFixes/Rules/Organization/RH7309RegionsShouldFollowCategoryOrderCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Organization/RH7309RegionsShouldFollowCategoryOrderCodeFixProvider.cs
@@ -87,11 +87,12 @@ public class RH7309RegionsShouldFollowCategoryOrderCodeFixProvider : CodeFixProv
     }
 
     /// <summary>
-    /// Determines whether the top-level regions can be exchanged without breaking conditional compilation.
-    /// The fix swaps whole region texts, so a conditional directive that is not paired inside the block it
-    /// belongs to — an <c>#if</c> that wraps one region but not the other, or one that opens inside a region
-    /// and closes outside it — would be separated from its partner. Depending on the shape that either moves
-    /// members into or out of a conditional section or leaves the document with unmatched directives
+    /// Determines whether the top-level regions can be exchanged without changing what the preprocessor
+    /// directives around them mean. The fix swaps whole region texts, which is unsafe in two ways: a
+    /// conditional directive that is not paired inside the block it belongs to gets separated from its partner,
+    /// and a position sensitive directive such as <c>#pragma warning</c>, <c>#nullable</c> or <c>#line</c> ends
+    /// up covering different code than before. Both are checked for every swapped block and for the text
+    /// between two blocks
     /// </summary>
     /// <param name="typeDeclaration">Type declaration whose regions should be reordered</param>
     /// <param name="regions">Top-level region pairs of the type</param>
@@ -112,12 +113,12 @@ public class RH7309RegionsShouldFollowCategoryOrderCodeFixProvider : CodeFixProv
 
             if (previousBlockEnd >= 0
                 && previousBlockEnd < span.Start
-                && SyntaxTriviaUtilities.ContainsUnbalancedConditionalDirectives(typeDeclaration, TextSpan.FromBounds(previousBlockEnd, span.Start)))
+                && ContainsUnsafeDirectives(typeDeclaration, TextSpan.FromBounds(previousBlockEnd, span.Start)))
             {
                 return false;
             }
 
-            if (SyntaxTriviaUtilities.ContainsUnbalancedConditionalDirectives(typeDeclaration, span))
+            if (ContainsUnsafeDirectives(typeDeclaration, span))
             {
                 return false;
             }
@@ -126,6 +127,18 @@ public class RH7309RegionsShouldFollowCategoryOrderCodeFixProvider : CodeFixProv
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Determines whether the span holds a directive that must not be relocated by the region swap
+    /// </summary>
+    /// <param name="typeDeclaration">Type declaration whose regions should be reordered</param>
+    /// <param name="span">Span to inspect</param>
+    /// <returns><see langword="true"/> if the span must not be moved</returns>
+    private static bool ContainsUnsafeDirectives(TypeDeclarationSyntax typeDeclaration, TextSpan span)
+    {
+        return SyntaxTriviaUtilities.ContainsUnbalancedConditionalDirectives(typeDeclaration, span)
+               || SyntaxTriviaUtilities.ContainsPositionSensitiveDirectives(typeDeclaration, span);
     }
 
     /// <summary>
@@ -167,11 +180,22 @@ public class RH7309RegionsShouldFollowCategoryOrderCodeFixProvider : CodeFixProv
         }
 
         var sourceText = await context.Document.GetTextAsync(context.CancellationToken).ConfigureAwait(false);
+        var reorderableTypes = new Dictionary<TypeDeclarationSyntax, bool>();
 
         foreach (var diagnostic in context.Diagnostics)
         {
-            if (root.FindTrivia(diagnostic.Location.SourceSpan.Start).Token.Parent?.FirstAncestorOrSelf<TypeDeclarationSyntax>() is { } typeDeclaration
-                && CanReorderSafely(typeDeclaration, RegionDirectiveUtilities.GetTopLevelRegions(typeDeclaration), sourceText))
+            if (root.FindTrivia(diagnostic.Location.SourceSpan.Start).Token.Parent?.FirstAncestorOrSelf<TypeDeclarationSyntax>() is not { } typeDeclaration)
+            {
+                continue;
+            }
+
+            if (reorderableTypes.TryGetValue(typeDeclaration, out var canReorder) == false)
+            {
+                canReorder = CanReorderSafely(typeDeclaration, RegionDirectiveUtilities.GetTopLevelRegions(typeDeclaration), sourceText);
+                reorderableTypes[typeDeclaration] = canReorder;
+            }
+
+            if (canReorder)
             {
                 context.RegisterCodeFix(CodeAction.Create(CodeFixResources.RH7309Title,
                                                           cancellationToken => ReorderRegionsAsync(context.Document, typeDeclaration, cancellationToken),

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Organization/RH7309RegionsShouldFollowCategoryOrderCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Organization/RH7309RegionsShouldFollowCategoryOrderCodeFixProvider.cs
@@ -51,6 +51,12 @@ public class RH7309RegionsShouldFollowCategoryOrderCodeFixProvider : CodeFixProv
         }
 
         var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+
+        if (CanReorderSafely(typeDeclaration, regions, sourceText) == false)
+        {
+            return document;
+        }
+
         var blocks = new List<(TextSpan Span, string Text, RegionCategory Category, int Index)>();
 
         for (var index = 0; index < regions.Count; index++)
@@ -62,9 +68,7 @@ public class RH7309RegionsShouldFollowCategoryOrderCodeFixProvider : CodeFixProv
                 return document;
             }
 
-            var startLine = sourceText.Lines.GetLineFromPosition(region.Region.SpanStart);
-            var endLine = sourceText.Lines.GetLineFromPosition(region.EndRegion.SpanStart);
-            var span = TextSpan.FromBounds(startLine.Start, endLine.End);
+            var span = GetRegionBlockSpan(sourceText, region);
             var description = RegionDirectiveUtilities.GetRegionDescription(regionDirective);
 
             blocks.Add((span, sourceText.ToString(span), RegionCategoryUtilities.GetRegionCategory(typeSymbol, description), index));
@@ -80,6 +84,63 @@ public class RH7309RegionsShouldFollowCategoryOrderCodeFixProvider : CodeFixProv
         var changes = blocks.Select((block, index) => new TextChange(block.Span, orderedBlocks[index].Text));
 
         return document.WithText(sourceText.WithChanges(changes));
+    }
+
+    /// <summary>
+    /// Determines whether the top-level regions can be exchanged without breaking conditional compilation.
+    /// The fix swaps whole region texts, so a conditional directive that is not paired inside the block it
+    /// belongs to — an <c>#if</c> that wraps one region but not the other, or one that opens inside a region
+    /// and closes outside it — would be separated from its partner. Depending on the shape that either moves
+    /// members into or out of a conditional section or leaves the document with unmatched directives
+    /// </summary>
+    /// <param name="typeDeclaration">Type declaration whose regions should be reordered</param>
+    /// <param name="regions">Top-level region pairs of the type</param>
+    /// <param name="sourceText">Source text of the document</param>
+    /// <returns><see langword="true"/> if the regions can be reordered safely</returns>
+    private static bool CanReorderSafely(TypeDeclarationSyntax typeDeclaration, IReadOnlyList<(SyntaxTrivia Region, SyntaxTrivia EndRegion)> regions, SourceText sourceText)
+    {
+        if (regions.Count < 2)
+        {
+            return false;
+        }
+
+        var previousBlockEnd = -1;
+
+        foreach (var region in regions)
+        {
+            var span = GetRegionBlockSpan(sourceText, region);
+
+            if (previousBlockEnd >= 0
+                && previousBlockEnd < span.Start
+                && SyntaxTriviaUtilities.ContainsUnbalancedConditionalDirectives(typeDeclaration, TextSpan.FromBounds(previousBlockEnd, span.Start)))
+            {
+                return false;
+            }
+
+            if (SyntaxTriviaUtilities.ContainsUnbalancedConditionalDirectives(typeDeclaration, span))
+            {
+                return false;
+            }
+
+            previousBlockEnd = span.End;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Gets the line-aligned text span of the region block, covering the <c>#region</c> line through the
+    /// <c>#endregion</c> line
+    /// </summary>
+    /// <param name="sourceText">Source text of the document</param>
+    /// <param name="region">Region pair</param>
+    /// <returns>Text span of the region block</returns>
+    private static TextSpan GetRegionBlockSpan(SourceText sourceText, (SyntaxTrivia Region, SyntaxTrivia EndRegion) region)
+    {
+        var startLine = sourceText.Lines.GetLineFromPosition(region.Region.SpanStart);
+        var endLine = sourceText.Lines.GetLineFromPosition(region.EndRegion.SpanStart);
+
+        return TextSpan.FromBounds(startLine.Start, endLine.End);
     }
 
     #endregion // Methods
@@ -105,9 +166,12 @@ public class RH7309RegionsShouldFollowCategoryOrderCodeFixProvider : CodeFixProv
             return;
         }
 
+        var sourceText = await context.Document.GetTextAsync(context.CancellationToken).ConfigureAwait(false);
+
         foreach (var diagnostic in context.Diagnostics)
         {
-            if (root.FindTrivia(diagnostic.Location.SourceSpan.Start).Token.Parent?.FirstAncestorOrSelf<TypeDeclarationSyntax>() is { } typeDeclaration)
+            if (root.FindTrivia(diagnostic.Location.SourceSpan.Start).Token.Parent?.FirstAncestorOrSelf<TypeDeclarationSyntax>() is { } typeDeclaration
+                && CanReorderSafely(typeDeclaration, RegionDirectiveUtilities.GetTopLevelRegions(typeDeclaration), sourceText))
             {
                 context.RegisterCodeFix(CodeAction.Create(CodeFixResources.RH7309Title,
                                                           cancellationToken => ReorderRegionsAsync(context.Document, typeDeclaration, cancellationToken),

--- a/Reihitsu.Analyzer.Test/Formatting/RH7309RegionsShouldFollowCategoryOrderAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH7309RegionsShouldFollowCategoryOrderAnalyzerTests.cs
@@ -844,6 +844,192 @@ public class RH7309RegionsShouldFollowCategoryOrderAnalyzerTests : AnalyzerTests
         await Verify(testData, fixedData, Diagnostics(RH7309RegionsShouldFollowCategoryOrderAnalyzer.DiagnosticId, CreateMessage("Methods")));
     }
 
+    /// <summary>
+    /// Verifies that no code fix is offered when a region contains a pragma warning directive, because the swap
+    /// would change which code the suppression covers
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoCodeFixWhenRegionContainsPragmaWarningDirective()
+    {
+        const string testData = """
+                                internal interface IWidget
+                                {
+                                    void Render();
+                                }
+
+                                internal class Widget : IWidget
+                                {
+                                    #region IWidget
+
+                                #pragma warning disable CS0169
+
+                                    public void Render()
+                                    {
+                                    }
+
+                                    #endregion // IWidget
+
+                                    #region Methods
+
+                                    private int _unused;
+
+                                    #endregion // Methods
+                                }
+                                """;
+
+        var actions = await GetCodeFixActionsAsync(testData,
+                                                   RH7309RegionsShouldFollowCategoryOrderAnalyzer.DiagnosticId,
+                                                   GetLastRegionDirectiveLocation);
+
+        Assert.IsEmpty(actions);
+    }
+
+    /// <summary>
+    /// Verifies that no code fix is offered when a region contains a nullable directive, because the swap would
+    /// change the annotation context of the moved members
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoCodeFixWhenRegionContainsNullableDirective()
+    {
+        const string testData = """
+                                internal interface IWidget
+                                {
+                                    void Render();
+                                }
+
+                                internal class Widget : IWidget
+                                {
+                                    #region IWidget
+
+                                #nullable enable
+
+                                    public void Render()
+                                    {
+                                    }
+
+                                    #endregion // IWidget
+
+                                    #region Methods
+
+                                    public void Refresh()
+                                    {
+                                    }
+
+                                    #endregion // Methods
+                                }
+                                """;
+
+        var actions = await GetCodeFixActionsAsync(testData,
+                                                   RH7309RegionsShouldFollowCategoryOrderAnalyzer.DiagnosticId,
+                                                   GetLastRegionDirectiveLocation);
+
+        Assert.IsEmpty(actions);
+    }
+
+    /// <summary>
+    /// Verifies that no code fix is offered when a pragma warning directive sits between the two regions
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoCodeFixWhenPragmaWarningDirectiveSitsBetweenRegions()
+    {
+        const string testData = """
+                                internal interface IWidget
+                                {
+                                    void Render();
+                                }
+
+                                internal class Widget : IWidget
+                                {
+                                    #region IWidget
+
+                                    public void Render()
+                                    {
+                                    }
+
+                                    #endregion // IWidget
+
+                                #pragma warning disable CS0169
+
+                                    #region Methods
+
+                                    private int _unused;
+
+                                    #endregion // Methods
+                                }
+                                """;
+
+        var actions = await GetCodeFixActionsAsync(testData,
+                                                   RH7309RegionsShouldFollowCategoryOrderAnalyzer.DiagnosticId,
+                                                   GetLastRegionDirectiveLocation);
+
+        Assert.IsEmpty(actions);
+    }
+
+    /// <summary>
+    /// Verifies that regions are still reordered when a pragma warning directive sits ahead of every reordered
+    /// region, because the swap does not change what the suppression covers
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCodeFixReordersRegionsFollowingAPragmaWarningDirective()
+    {
+        const string testData = """
+                                internal interface IWidget
+                                {
+                                    void Render();
+                                }
+
+                                internal class Widget : IWidget
+                                {
+                                #pragma warning disable CS0169
+
+                                    #region IWidget
+
+                                    public void Render()
+                                    {
+                                    }
+
+                                    #endregion // IWidget
+
+                                    {|#0:#region Methods|}
+
+                                    private int _unused;
+
+                                    #endregion // Methods
+                                }
+                                """;
+        const string fixedData = """
+                                 internal interface IWidget
+                                 {
+                                     void Render();
+                                 }
+
+                                 internal class Widget : IWidget
+                                 {
+                                 #pragma warning disable CS0169
+
+                                     #region Methods
+
+                                     private int _unused;
+
+                                     #endregion // Methods
+
+                                     #region IWidget
+
+                                     public void Render()
+                                     {
+                                     }
+
+                                     #endregion // IWidget
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH7309RegionsShouldFollowCategoryOrderAnalyzer.DiagnosticId, CreateMessage("Methods")));
+    }
+
     #endregion // Tests
 
     #region Methods

--- a/Reihitsu.Analyzer.Test/Formatting/RH7309RegionsShouldFollowCategoryOrderAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH7309RegionsShouldFollowCategoryOrderAnalyzerTests.cs
@@ -1,5 +1,8 @@
+using System.Linq;
 using System.Threading.Tasks;
 
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Reihitsu.Analyzer.CodeFixes.Rules.Organization;
@@ -504,9 +507,359 @@ public class RH7309RegionsShouldFollowCategoryOrderAnalyzerTests : AnalyzerTests
         await Verify(testData, fixedData, Diagnostics(RH7309RegionsShouldFollowCategoryOrderAnalyzer.DiagnosticId, CreateMessage("WidgetBase")));
     }
 
+    /// <summary>
+    /// Verifies that no code fix is offered when a conditional directive is improperly nested with the region
+    /// directives, opening inside one region and closing inside another
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoCodeFixWhenConditionalDirectiveIsImproperlyNestedWithRegions()
+    {
+        const string testData = """
+                                internal interface IWidget
+                                {
+                                    void Render();
+                                }
+
+                                internal class Widget : IWidget
+                                {
+                                    #region IWidget
+
+                                    public void Render()
+                                    {
+                                    }
+                                #if DEBUG
+
+                                    #endregion // IWidget
+
+                                    #region Methods
+
+                                    public void Refresh()
+                                    {
+                                    }
+                                #endif
+
+                                    #endregion // Methods
+                                }
+                                """;
+
+        var actions = await GetCodeFixActionsAsync(testData,
+                                                   RH7309RegionsShouldFollowCategoryOrderAnalyzer.DiagnosticId,
+                                                   GetLastRegionDirectiveLocation,
+                                                   "DEBUG");
+
+        Assert.IsEmpty(actions);
+    }
+
+    /// <summary>
+    /// Verifies that no code fix is offered when a conditional directive wraps only the later of the two regions
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoCodeFixWhenConditionalDirectiveWrapsOnlyTheLaterRegion()
+    {
+        const string testData = """
+                                internal interface IWidget
+                                {
+                                    void Render();
+                                }
+
+                                internal class Widget : IWidget
+                                {
+                                    #region IWidget
+
+                                    public void Render()
+                                    {
+                                    }
+
+                                    #endregion // IWidget
+
+                                #if DEBUG
+                                    #region Methods
+
+                                    public void Refresh()
+                                    {
+                                    }
+
+                                    #endregion // Methods
+                                #endif
+                                }
+                                """;
+
+        var actions = await GetCodeFixActionsAsync(testData,
+                                                   RH7309RegionsShouldFollowCategoryOrderAnalyzer.DiagnosticId,
+                                                   GetLastRegionDirectiveLocation,
+                                                   "DEBUG");
+
+        Assert.IsEmpty(actions);
+    }
+
+    /// <summary>
+    /// Verifies that no code fix is offered when a conditional directive wraps only the earlier of the two regions
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoCodeFixWhenConditionalDirectiveWrapsOnlyTheEarlierRegion()
+    {
+        const string testData = """
+                                internal interface IWidget
+                                {
+                                    void Render();
+                                }
+
+                                internal class Widget : IWidget
+                                {
+                                #if DEBUG
+                                    #region IWidget
+
+                                    public void Render()
+                                    {
+                                    }
+
+                                    #endregion // IWidget
+                                #endif
+
+                                    #region Methods
+
+                                    public void Refresh()
+                                    {
+                                    }
+
+                                    #endregion // Methods
+                                }
+                                """;
+
+        var actions = await GetCodeFixActionsAsync(testData,
+                                                   RH7309RegionsShouldFollowCategoryOrderAnalyzer.DiagnosticId,
+                                                   GetLastRegionDirectiveLocation,
+                                                   "DEBUG");
+
+        Assert.IsEmpty(actions);
+    }
+
+    /// <summary>
+    /// Verifies that regions are still reordered when the same conditional directive wraps both of them
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCodeFixReordersRegionsWrappedByTheSameConditionalDirective()
+    {
+        const string testData = """
+                                internal class WidgetBase
+                                {
+                                    public virtual void Reset()
+                                    {
+                                    }
+                                }
+
+                                internal class Widget : WidgetBase
+                                {
+                                #if DEBUG
+                                    #region WidgetBase
+
+                                    public override void Reset()
+                                    {
+                                    }
+
+                                    #endregion // WidgetBase
+
+                                    {|#0:#region Methods|}
+
+                                    public void Refresh()
+                                    {
+                                    }
+
+                                    #endregion // Methods
+                                #endif
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class WidgetBase
+                                 {
+                                     public virtual void Reset()
+                                     {
+                                     }
+                                 }
+
+                                 internal class Widget : WidgetBase
+                                 {
+                                 #if DEBUG
+                                     #region Methods
+
+                                     public void Refresh()
+                                     {
+                                     }
+
+                                     #endregion // Methods
+
+                                     #region WidgetBase
+
+                                     public override void Reset()
+                                     {
+                                     }
+
+                                     #endregion // WidgetBase
+                                 #endif
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH7309RegionsShouldFollowCategoryOrderAnalyzer.DiagnosticId, CreateMessage("Methods")));
+    }
+
+    /// <summary>
+    /// Verifies that regions are still reordered when a conditional directive pair sits completely inside one region
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCodeFixReordersRegionsContainingBalancedConditionalDirectives()
+    {
+        const string testData = """
+                                internal interface IWidget
+                                {
+                                    void Render();
+                                }
+
+                                internal class Widget : IWidget
+                                {
+                                    #region IWidget
+
+                                    public void Render()
+                                    {
+                                    }
+
+                                    #endregion // IWidget
+
+                                    {|#0:#region Methods|}
+
+                                #if DEBUG
+                                    public void Refresh()
+                                    {
+                                    }
+                                #endif
+
+                                    #endregion // Methods
+                                }
+                                """;
+        const string fixedData = """
+                                 internal interface IWidget
+                                 {
+                                     void Render();
+                                 }
+
+                                 internal class Widget : IWidget
+                                 {
+                                     #region Methods
+
+                                 #if DEBUG
+                                     public void Refresh()
+                                     {
+                                     }
+                                 #endif
+
+                                     #endregion // Methods
+
+                                     #region IWidget
+
+                                     public void Render()
+                                     {
+                                     }
+
+                                     #endregion // IWidget
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH7309RegionsShouldFollowCategoryOrderAnalyzer.DiagnosticId, CreateMessage("Methods")));
+    }
+
+    /// <summary>
+    /// Verifies that regions are still reordered when a conditional directive pair sits completely between two regions
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCodeFixReordersRegionsWithBalancedConditionalDirectivesBetweenThem()
+    {
+        const string testData = """
+                                internal interface IWidget
+                                {
+                                    void Render();
+                                }
+
+                                internal class Widget : IWidget
+                                {
+                                    #region IWidget
+
+                                    public void Render()
+                                    {
+                                    }
+
+                                    #endregion // IWidget
+
+                                #if DEBUG
+                                    public void Trace()
+                                    {
+                                    }
+                                #endif
+
+                                    {|#0:#region Methods|}
+
+                                    public void Refresh()
+                                    {
+                                    }
+
+                                    #endregion // Methods
+                                }
+                                """;
+        const string fixedData = """
+                                 internal interface IWidget
+                                 {
+                                     void Render();
+                                 }
+
+                                 internal class Widget : IWidget
+                                 {
+                                     #region Methods
+
+                                     public void Refresh()
+                                     {
+                                     }
+
+                                     #endregion // Methods
+
+                                 #if DEBUG
+                                     public void Trace()
+                                     {
+                                     }
+                                 #endif
+
+                                     #region IWidget
+
+                                     public void Render()
+                                     {
+                                     }
+
+                                     #endregion // IWidget
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH7309RegionsShouldFollowCategoryOrderAnalyzer.DiagnosticId, CreateMessage("Methods")));
+    }
+
     #endregion // Tests
 
     #region Methods
+
+    /// <summary>
+    /// Gets the location of the last <c>#region</c> directive in the syntax tree
+    /// </summary>
+    /// <param name="root">Syntax root</param>
+    /// <returns>Location of the last region directive</returns>
+    private static Location GetLastRegionDirectiveLocation(SyntaxNode root)
+    {
+        return root.DescendantNodes(descendIntoTrivia: true)
+                   .OfType<RegionDirectiveTriviaSyntax>()
+                   .Last()
+                   .GetLocation();
+    }
 
     /// <summary>
     /// Creates the expected diagnostic message for the given region description

--- a/Reihitsu.Core.Test/SyntaxTriviaUtilitiesTests.cs
+++ b/Reihitsu.Core.Test/SyntaxTriviaUtilitiesTests.cs
@@ -255,6 +255,90 @@ public class SyntaxTriviaUtilitiesTests
     }
 
     /// <summary>
+    /// Verifies that an unusable root refuses the move instead of reporting balanced directives
+    /// </summary>
+    [TestMethod]
+    public void ContainsUnbalancedConditionalDirectivesReturnsTrueForMissingRoot()
+    {
+        Assert.IsTrue(SyntaxTriviaUtilities.ContainsUnbalancedConditionalDirectives(null, TextSpan.FromBounds(0, 1)));
+    }
+
+    /// <summary>
+    /// Verifies that a pragma warning directive is reported as position sensitive
+    /// </summary>
+    [TestMethod]
+    public void ContainsPositionSensitiveDirectivesReturnsTrueForPragmaWarningDirective()
+    {
+        const string source = "class C\n{\n#pragma warning disable CS0169\n    private int _x;\n}\n";
+
+        Assert.IsTrue(ContainsPositionSensitiveDirectives(source, 0, source.Length));
+    }
+
+    /// <summary>
+    /// Verifies that a nullable directive is reported as position sensitive
+    /// </summary>
+    [TestMethod]
+    public void ContainsPositionSensitiveDirectivesReturnsTrueForNullableDirective()
+    {
+        const string source = "class C\n{\n#nullable enable\n    private string _x;\n}\n";
+
+        Assert.IsTrue(ContainsPositionSensitiveDirectives(source, 0, source.Length));
+    }
+
+    /// <summary>
+    /// Verifies that a line directive is reported as position sensitive
+    /// </summary>
+    [TestMethod]
+    public void ContainsPositionSensitiveDirectivesReturnsTrueForLineDirective()
+    {
+        const string source = "class C\n{\n#line 200\n    private int _x;\n}\n";
+
+        Assert.IsTrue(ContainsPositionSensitiveDirectives(source, 0, source.Length));
+    }
+
+    /// <summary>
+    /// Verifies that region directives are not reported, since a region reorder moves them on purpose
+    /// </summary>
+    [TestMethod]
+    public void ContainsPositionSensitiveDirectivesReturnsFalseForRegionDirectives()
+    {
+        const string source = "class C\n{\n    #region Fields\n\n    private int _x;\n\n    #endregion\n}\n";
+
+        Assert.IsFalse(ContainsPositionSensitiveDirectives(source, 0, source.Length));
+    }
+
+    /// <summary>
+    /// Verifies that conditional directives are not reported, since their nesting is checked separately
+    /// </summary>
+    [TestMethod]
+    public void ContainsPositionSensitiveDirectivesReturnsFalseForConditionalDirectives()
+    {
+        const string source = "class C\n{\n#if DEBUG\n    private int _x;\n#else\n    private int _y;\n#endif\n}\n";
+
+        Assert.IsFalse(ContainsPositionSensitiveDirectives(source, 0, source.Length));
+    }
+
+    /// <summary>
+    /// Verifies that a directive outside the inspected span is not reported
+    /// </summary>
+    [TestMethod]
+    public void ContainsPositionSensitiveDirectivesReturnsFalseForDirectiveOutsideTheSpan()
+    {
+        const string source = "class C\n{\n#pragma warning disable CS0169\n    private int _x;\n}\n";
+
+        Assert.IsFalse(ContainsPositionSensitiveDirectives(source, source.IndexOf("    private", StringComparison.Ordinal), source.Length));
+    }
+
+    /// <summary>
+    /// Verifies that an unusable root refuses the move instead of reporting no position sensitive directives
+    /// </summary>
+    [TestMethod]
+    public void ContainsPositionSensitiveDirectivesReturnsTrueForMissingRoot()
+    {
+        Assert.IsTrue(SyntaxTriviaUtilities.ContainsPositionSensitiveDirectives(null, TextSpan.FromBounds(0, 1)));
+    }
+
+    /// <summary>
     /// Verifies that the insertion index stays at zero when no directive is present
     /// </summary>
     [TestMethod]
@@ -415,6 +499,18 @@ public class SyntaxTriviaUtilitiesTests
     private static bool ContainsUnbalancedConditionalDirectives(string source, int start, int end)
     {
         return SyntaxTriviaUtilities.ContainsUnbalancedConditionalDirectives(GetRoot(source), TextSpan.FromBounds(start, end));
+    }
+
+    /// <summary>
+    /// Parses the source and checks the requested span for position sensitive directives
+    /// </summary>
+    /// <param name="source">Source text</param>
+    /// <param name="start">Start of the span to inspect</param>
+    /// <param name="end">End of the span to inspect</param>
+    /// <returns><see langword="true"/> if the span contains a position sensitive directive</returns>
+    private static bool ContainsPositionSensitiveDirectives(string source, int start, int end)
+    {
+        return SyntaxTriviaUtilities.ContainsPositionSensitiveDirectives(GetRoot(source), TextSpan.FromBounds(start, end));
     }
 
     /// <summary>

--- a/Reihitsu.Core.Test/SyntaxTriviaUtilitiesTests.cs
+++ b/Reihitsu.Core.Test/SyntaxTriviaUtilitiesTests.cs
@@ -204,7 +204,10 @@ public class SyntaxTriviaUtilitiesTests
     {
         const string source = "class C\n{\n#if DEBUG\n    void M()\n    {\n    }\n#endif\n}\n";
 
-        Assert.IsFalse(ContainsUnbalancedConditionalDirectives(source, source.IndexOf("#if", StringComparison.Ordinal), source.IndexOf("}\n", StringComparison.Ordinal)));
+        var start = source.IndexOf("#if", StringComparison.Ordinal);
+        var end = source.IndexOf("#endif", StringComparison.Ordinal) + "#endif".Length;
+
+        Assert.IsFalse(ContainsUnbalancedConditionalDirectives(source, start, end));
     }
 
     /// <summary>

--- a/Reihitsu.Core.Test/SyntaxTriviaUtilitiesTests.cs
+++ b/Reihitsu.Core.Test/SyntaxTriviaUtilitiesTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Reihitsu.Core.Test;
@@ -196,6 +197,61 @@ public class SyntaxTriviaUtilitiesTests
     }
 
     /// <summary>
+    /// Verifies that a conditional directive pair contained in the span is treated as balanced
+    /// </summary>
+    [TestMethod]
+    public void ContainsUnbalancedConditionalDirectivesReturnsFalseForCompletePair()
+    {
+        const string source = "class C\n{\n#if DEBUG\n    void M()\n    {\n    }\n#endif\n}\n";
+
+        Assert.IsFalse(ContainsUnbalancedConditionalDirectives(source, source.IndexOf("#if", StringComparison.Ordinal), source.IndexOf("}\n", StringComparison.Ordinal)));
+    }
+
+    /// <summary>
+    /// Verifies that a span without any conditional directive is treated as balanced
+    /// </summary>
+    [TestMethod]
+    public void ContainsUnbalancedConditionalDirectivesReturnsFalseWithoutConditionalDirectives()
+    {
+        const string source = "class C\n{\n    #region Methods\n\n    void M()\n    {\n    }\n\n    #endregion\n}\n";
+
+        Assert.IsFalse(ContainsUnbalancedConditionalDirectives(source, 0, source.Length));
+    }
+
+    /// <summary>
+    /// Verifies that an opening conditional directive without its closing partner is reported
+    /// </summary>
+    [TestMethod]
+    public void ContainsUnbalancedConditionalDirectivesReturnsTrueForUnclosedIfDirective()
+    {
+        const string source = "class C\n{\n#if DEBUG\n    void M()\n    {\n    }\n#endif\n}\n";
+
+        Assert.IsTrue(ContainsUnbalancedConditionalDirectives(source, source.IndexOf("#if", StringComparison.Ordinal), source.IndexOf("#endif", StringComparison.Ordinal)));
+    }
+
+    /// <summary>
+    /// Verifies that a closing conditional directive without its opening partner is reported
+    /// </summary>
+    [TestMethod]
+    public void ContainsUnbalancedConditionalDirectivesReturnsTrueForUnopenedEndIfDirective()
+    {
+        const string source = "class C\n{\n#if DEBUG\n    void M()\n    {\n    }\n#endif\n}\n";
+
+        Assert.IsTrue(ContainsUnbalancedConditionalDirectives(source, source.IndexOf("void", StringComparison.Ordinal), source.Length));
+    }
+
+    /// <summary>
+    /// Verifies that an else branch whose opening conditional directive lies outside the span is reported
+    /// </summary>
+    [TestMethod]
+    public void ContainsUnbalancedConditionalDirectivesReturnsTrueForDetachedElseDirective()
+    {
+        const string source = "class C\n{\n#if DEBUG\n    void M()\n    {\n    }\n#else\n    void N()\n    {\n    }\n#endif\n}\n";
+
+        Assert.IsTrue(ContainsUnbalancedConditionalDirectives(source, source.IndexOf("#else", StringComparison.Ordinal), source.Length));
+    }
+
+    /// <summary>
     /// Verifies that the insertion index stays at zero when no directive is present
     /// </summary>
     [TestMethod]
@@ -345,6 +401,18 @@ public class SyntaxTriviaUtilitiesTests
     #endregion // Tests
 
     #region Methods
+
+    /// <summary>
+    /// Parses the source and checks the requested span for unbalanced conditional directives
+    /// </summary>
+    /// <param name="source">Source text</param>
+    /// <param name="start">Start of the span to inspect</param>
+    /// <param name="end">End of the span to inspect</param>
+    /// <returns><see langword="true"/> if the span contains an unbalanced conditional directive</returns>
+    private static bool ContainsUnbalancedConditionalDirectives(string source, int start, int end)
+    {
+        return SyntaxTriviaUtilities.ContainsUnbalancedConditionalDirectives(GetRoot(source), TextSpan.FromBounds(start, end));
+    }
 
     /// <summary>
     /// Parses the source and returns the first trivia of the requested kind

--- a/Reihitsu.Core/SyntaxTriviaUtilities.cs
+++ b/Reihitsu.Core/SyntaxTriviaUtilities.cs
@@ -4,6 +4,7 @@ using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Reihitsu.Core;
 
@@ -192,6 +193,56 @@ public static class SyntaxTriviaUtilities
                                                                     && candidate.IsKind(SyntaxKind.EndOfLineTrivia) == false);
 
         return firstContentTrivia is { IsDirective: true };
+    }
+
+    /// <summary>
+    /// Determines whether the specified span contains a conditional-compilation directive whose partner
+    /// directive lies outside the span. Rewrites that relocate a span as one block — for example a region
+    /// reorder that exchanges whole <c>#region</c>…<c>#endregion</c> texts — would carry such a directive
+    /// away from its partner and leave the document with unmatched directives (CS1027/CS1028), so callers
+    /// use this predicate to refuse the move instead
+    /// </summary>
+    /// <param name="root">Syntax node containing the span</param>
+    /// <param name="span">Span to inspect</param>
+    /// <returns><see langword="true"/> if the span contains an unbalanced conditional directive; otherwise, <see langword="false"/></returns>
+    public static bool ContainsUnbalancedConditionalDirectives(SyntaxNode root, TextSpan span)
+    {
+        if (root == null)
+        {
+            return false;
+        }
+
+        var nestingLevel = 0;
+
+        foreach (var trivia in root.DescendantTrivia(span, descendIntoTrivia: true))
+        {
+            if (span.Contains(trivia.SpanStart) == false)
+            {
+                continue;
+            }
+
+            if (trivia.IsKind(SyntaxKind.IfDirectiveTrivia))
+            {
+                nestingLevel++;
+            }
+            else if (trivia.IsKind(SyntaxKind.EndIfDirectiveTrivia))
+            {
+                nestingLevel--;
+
+                if (nestingLevel < 0)
+                {
+                    return true;
+                }
+            }
+            else if (nestingLevel == 0
+                     && (trivia.IsKind(SyntaxKind.ElifDirectiveTrivia)
+                         || trivia.IsKind(SyntaxKind.ElseDirectiveTrivia)))
+            {
+                return true;
+            }
+        }
+
+        return nestingLevel != 0;
     }
 
     /// <summary>

--- a/Reihitsu.Core/SyntaxTriviaUtilities.cs
+++ b/Reihitsu.Core/SyntaxTriviaUtilities.cs
@@ -204,12 +204,16 @@ public static class SyntaxTriviaUtilities
     /// </summary>
     /// <param name="root">Syntax node containing the span</param>
     /// <param name="span">Span to inspect</param>
-    /// <returns><see langword="true"/> if the span contains an unbalanced conditional directive; otherwise, <see langword="false"/></returns>
+    /// <returns>
+    /// <see langword="true"/> if the span contains an unbalanced conditional directive, or when
+    /// <paramref name="root"/> is <see langword="null"/> and the span therefore cannot be inspected; otherwise,
+    /// <see langword="false"/>
+    /// </returns>
     public static bool ContainsUnbalancedConditionalDirectives(SyntaxNode root, TextSpan span)
     {
         if (root == null)
         {
-            return false;
+            return true;
         }
 
         var nestingLevel = 0;
@@ -243,6 +247,36 @@ public static class SyntaxTriviaUtilities
         }
 
         return nestingLevel != 0;
+    }
+
+    /// <summary>
+    /// Determines whether the specified span contains a preprocessor directive whose effect is bound to where it
+    /// sits rather than to the block around it. <c>#pragma warning</c>, <c>#nullable</c> and <c>#line</c> all
+    /// apply from their own position onwards, so a rewrite that relocates the surrounding block silently changes
+    /// which code they cover. <c>#region</c>/<c>#endregion</c> are excluded because a region reorder moves them
+    /// deliberately, and conditional directives are excluded because their pairing is checked by
+    /// <see cref="ContainsUnbalancedConditionalDirectives"/>; every other directive kind — including a malformed
+    /// one — counts, so the predicate stays safe for directives it does not know about
+    /// </summary>
+    /// <param name="root">Syntax node containing the span</param>
+    /// <param name="span">Span to inspect</param>
+    /// <returns>
+    /// <see langword="true"/> if the span contains a position sensitive directive, or when
+    /// <paramref name="root"/> is <see langword="null"/> and the span therefore cannot be inspected; otherwise,
+    /// <see langword="false"/>
+    /// </returns>
+    public static bool ContainsPositionSensitiveDirectives(SyntaxNode root, TextSpan span)
+    {
+        if (root == null)
+        {
+            return true;
+        }
+
+        return root.DescendantTrivia(span, descendIntoTrivia: true)
+                   .Any(trivia => span.Contains(trivia.SpanStart)
+                                  && trivia.IsDirective
+                                  && IsRegionDirective(trivia) == false
+                                  && IsConditionalDirective(trivia) == false);
     }
 
     /// <summary>
@@ -351,6 +385,30 @@ public static class SyntaxTriviaUtilities
         }
 
         return SyntaxFactory.TriviaList(indentation);
+    }
+
+    /// <summary>
+    /// Determines whether the trivia is a <c>#region</c> or <c>#endregion</c> directive
+    /// </summary>
+    /// <param name="trivia">The trivia to check</param>
+    /// <returns><see langword="true"/> if the trivia is a region directive; otherwise, <see langword="false"/></returns>
+    private static bool IsRegionDirective(SyntaxTrivia trivia)
+    {
+        return trivia.IsKind(SyntaxKind.RegionDirectiveTrivia)
+               || trivia.IsKind(SyntaxKind.EndRegionDirectiveTrivia);
+    }
+
+    /// <summary>
+    /// Determines whether the trivia is one of the conditional-compilation directives
+    /// </summary>
+    /// <param name="trivia">The trivia to check</param>
+    /// <returns><see langword="true"/> if the trivia is a conditional directive; otherwise, <see langword="false"/></returns>
+    private static bool IsConditionalDirective(SyntaxTrivia trivia)
+    {
+        return trivia.IsKind(SyntaxKind.IfDirectiveTrivia)
+               || trivia.IsKind(SyntaxKind.ElifDirectiveTrivia)
+               || trivia.IsKind(SyntaxKind.ElseDirectiveTrivia)
+               || trivia.IsKind(SyntaxKind.EndIfDirectiveTrivia);
     }
 
     /// <summary>

--- a/documentation/rules/RH7309.md
+++ b/documentation/rules/RH7309.md
@@ -27,6 +27,8 @@ A predictable region layout makes a type scannable: readers see the type's own s
 
 Move whole `#region … #endregion` blocks so that all custom regions come first, followed by the base-type override regions, followed by the interface implementation regions. The code fix performs this reordering automatically.
 
+The code fix exchanges whole region texts, so it is not offered when that would separate a conditional-compilation directive from its partner. The common case is an `#if … #endif` block that wraps one of the regions but not the other: swapping the two blocks would move the wrapped members out of the conditional section and the unwrapped members into it. A conditional block that stays completely inside a single region, completely between two regions, or wraps all of the reordered regions is unaffected and still gets the fix. Where the fix is withheld, reorder the regions by hand.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH7309.md
+++ b/documentation/rules/RH7309.md
@@ -27,7 +27,12 @@ A predictable region layout makes a type scannable: readers see the type's own s
 
 Move whole `#region … #endregion` blocks so that all custom regions come first, followed by the base-type override regions, followed by the interface implementation regions. The code fix performs this reordering automatically.
 
-The code fix exchanges whole region texts, so it is not offered when that would separate a conditional-compilation directive from its partner. The common case is an `#if … #endif` block that wraps one of the regions but not the other: swapping the two blocks would move the wrapped members out of the conditional section and the unwrapped members into it. A conditional block that stays completely inside a single region, completely between two regions, or wraps all of the reordered regions is unaffected and still gets the fix. Where the fix is withheld, reorder the regions by hand.
+The code fix exchanges whole region texts, so it is not offered when that would change what the preprocessor directives around the regions mean. Two cases are withheld:
+
+- A conditional block that is not paired inside the region it belongs to — typically an `#if … #endif` wrapping one of the regions but not the other. Swapping the blocks would move the wrapped members out of the conditional section and the unwrapped members into it.
+- A position-sensitive directive such as `#pragma warning`, `#nullable` or `#line` inside one of the regions or in the text between them. These apply from where they sit onwards, so relocating the surrounding block changes which code they cover — a moved `#pragma warning disable` stops suppressing the warning it was added for.
+
+Directives that keep their meaning are unaffected and still get the fix: a conditional block wholly inside a single region, wholly between two regions, or wrapping all of the reordered regions, and any directive that sits ahead of every reordered region. Where the fix is withheld, reorder the regions by hand.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

`RH7309RegionsShouldFollowCategoryOrderCodeFixProvider` no longer offers a fix when exchanging the region blocks would change what the surrounding preprocessor directives mean. `CanReorderSafely` inspects every swapped region block and every stretch of text between two blocks, and refuses on either of two conditions, backed by new predicates in `Reihitsu.Core`:

- `SyntaxTriviaUtilities.ContainsUnbalancedConditionalDirectives` — a conditional directive (`#if`/`#elif`/`#else`/`#endif`) whose partner lies outside the segment.
- `SyntaxTriviaUtilities.ContainsPositionSensitiveDirectives` — any directive that is neither a region nor a conditional directive, covering `#pragma warning`, `#nullable` and `#line`.

## Why

The reorder exchanged whole `#region … #endregion` text blocks with no directive guard, which broke two distinct ways on source that compiles cleanly today:

- An `#if … #endif` wrapping one of the two regions but not the other: the swap moves the wrapped members out of the conditional section and the unwrapped members into it.
- A `#pragma warning disable` (or `#nullable`, `#line`) inside a region or in the gap between regions: these apply from where they sit onwards, so relocating the surrounding block silently changes their coverage. A moved `#pragma warning disable CS0169` stops suppressing the warning it was added for — a build break under `TreatWarningsAsErrors`.

Worth noting: the repro in #461 (an `#if` opening inside one region and closing inside another) is not valid C#. Roslyn refuses an `#endregion` that closes a region opened outside the enclosing `#if`, so that source already carries `CS1038`/`CS1027` and parses the directives as `BadDirectiveTrivia`, leaving `GetTopLevelRegions` with nothing to reorder. It is covered regardless — fewer than two resolvable regions also refuses, so that input no longer gets a no-op code action.

## Linked issues

Closes #461

## Review notes

- Directives that keep their meaning still get the fix, each with a test: a conditional block wholly inside one region, wholly between two regions, or wrapping *all* reordered regions, and any directive sitting ahead of every reordered region.
- `ContainsPositionSensitiveDirectives` refuses on *any* unrecognised directive kind rather than matching an enumerated list, so it fails closed for kinds it does not know about, including malformed ones. `#region`/`#endregion` are excluded deliberately: they carry no compilation meaning, and a region reorder moves them on purpose.
- Both Core predicates fail closed on a `null` root — an uninspectable span refuses the rewrite instead of permitting it.
- The guard sits in `RegisterCodeFixesAsync`, so no action is offered rather than a no-op action; `ReorderRegionsAsync` repeats the check, covering the `BatchFixer` fix-all path. The per-type decision is memoized so the region walk runs once per type, not once per diagnostic.
- `documentation/rules/RH7309.md` documents both withheld cases and the shapes that still get the fix.

## Follow-up work

- A reorder guard that needs `#region`/`#endregion` treated as unsafe — the way `OrderingDeclarationUtilities.MoveRangeContainsDirectives` treats every directive — should get its own predicate (for example `ContainsAnyDirective`) rather than a flag on `ContainsPositionSensitiveDirectives`, which answers a different question.
