### PR TITLE
Remove only the flagged element in the RH8107 and RH8202 code fixes

### DIFF
--- a/Reihitsu.Analyzer.CodeFixes/Core/DocumentationCommentCodeFixUtilities.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Core/DocumentationCommentCodeFixUtilities.cs
@@ -11,7 +11,7 @@ using Reihitsu.Formatter;
 namespace Reihitsu.Analyzer.CodeFixes.Core;
 
 /// <summary>
-/// Shared helpers for documentation-comment line-break code fixes
+/// Shared helpers for documentation-comment code fixes which rewrite line breaks or remove elements
 /// </summary>
 internal static class DocumentationCommentCodeFixUtilities
 {

--- a/Reihitsu.Analyzer.CodeFixes/Core/DocumentationCommentCodeFixUtilities.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Core/DocumentationCommentCodeFixUtilities.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 
 using Reihitsu.Core;
@@ -49,6 +50,87 @@ internal static class DocumentationCommentCodeFixUtilities
     }
 
     /// <summary>
+    /// Determines whether the documentation element at the specified span can be removed safely
+    /// </summary>
+    /// <param name="root">Syntax root</param>
+    /// <param name="elementSpan">Span of the documentation element</param>
+    /// <returns><see langword="true"/> if the element is well formed enough to be removed</returns>
+    /// <remarks>
+    /// An element without an end tag is left alone. Roslyn extends such an element to the end of the documentation
+    /// comment, so its span reaches past the trailing line break and can cover unrelated tags and the declaration
+    /// which follows. Removing that span would move source code into the comment or drop neighboring documentation
+    /// </remarks>
+    internal static bool CanRemoveElement(SyntaxNode root, TextSpan elementSpan)
+    {
+        var node = root.FindNode(elementSpan, findInsideTrivia: true, getInnermostNodeForTie: true);
+
+        return node is not XmlElementSyntax element
+               || element.EndTag.IsMissing == false;
+    }
+
+    /// <summary>
+    /// Gets the span which has to be removed to delete a documentation element without touching co-located content
+    /// </summary>
+    /// <param name="sourceText">Source text</param>
+    /// <param name="elementSpan">Span of the documentation element</param>
+    /// <returns>The removal span</returns>
+    /// <remarks>
+    /// Lines which carry nothing but the element are removed completely. As soon as another tag or documentation text
+    /// shares the first or the last line, only the element itself and its adjacent horizontal whitespace are removed.
+    /// The result is always contained in the lines the element occupies, so no trivia outside those lines is touched
+    /// </remarks>
+    internal static TextSpan GetElementRemovalSpan(SourceText sourceText, TextSpan elementSpan)
+    {
+        var startLine = sourceText.Lines.GetLineFromPosition(elementSpan.Start);
+        var endLine = sourceText.Lines.GetLineFromPosition(elementSpan.End);
+        var isLineStartOwnedByElement = DocumentationCommentUtilities.IsExteriorOnly(sourceText.ToString(TextSpan.FromBounds(startLine.Start, elementSpan.Start)));
+        var isLineEndOwnedByElement = string.IsNullOrWhiteSpace(sourceText.ToString(TextSpan.FromBounds(elementSpan.End, endLine.End)));
+
+        if (isLineStartOwnedByElement
+            && isLineEndOwnedByElement)
+        {
+            return TextSpan.FromBounds(startLine.Start, endLine.EndIncludingLineBreak);
+        }
+
+        var start = elementSpan.Start;
+        var end = elementSpan.End;
+
+        if (isLineEndOwnedByElement)
+        {
+            end = endLine.End;
+        }
+        else if (isLineStartOwnedByElement)
+        {
+            while (end < endLine.End
+                   && IsHorizontalWhitespace(sourceText[end]))
+            {
+                end++;
+            }
+        }
+
+        if (isLineStartOwnedByElement == false)
+        {
+            while (start > startLine.Start
+                   && IsHorizontalWhitespace(sourceText[start - 1]))
+            {
+                start--;
+            }
+        }
+
+        return TextSpan.FromBounds(start, end);
+    }
+
+    /// <summary>
+    /// Determines whether the specified character is horizontal whitespace
+    /// </summary>
+    /// <param name="value">Character to inspect</param>
+    /// <returns><see langword="true"/> if the character is a space or tab</returns>
+    internal static bool IsHorizontalWhitespace(char value)
+    {
+        return value is ' ' or '\t';
+    }
+
+    /// <summary>
     /// Gets the line break sequence for the affected line
     /// </summary>
     /// <param name="sourceText">Source text</param>
@@ -60,16 +142,6 @@ internal static class DocumentationCommentCodeFixUtilities
         return line.EndIncludingLineBreak > line.End
                    ? sourceText.ToString(TextSpan.FromBounds(line.End, line.EndIncludingLineBreak))
                    : ReihitsuFormatterHelpers.DetectEndOfLine(root);
-    }
-
-    /// <summary>
-    /// Determines whether the specified character is horizontal whitespace
-    /// </summary>
-    /// <param name="value">Character to inspect</param>
-    /// <returns><see langword="true"/> if the character is a space or tab</returns>
-    private static bool IsHorizontalWhitespace(char value)
-    {
-        return value is ' ' or '\t';
     }
 
     #endregion // Methods

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Documentation/RH8107VoidReturnValueMustNotBeDocumentedCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Documentation/RH8107VoidReturnValueMustNotBeDocumentedCodeFixProvider.cs
@@ -32,7 +32,7 @@ public class RH8107VoidReturnValueMustNotBeDocumentedCodeFixProvider : CodeFixPr
     private static async Task<Document> ApplyCodeFixAsync(Document document, TextSpan diagnosticSpan, CancellationToken cancellationToken)
     {
         var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-        var removalSpan = DocumentationAnalysisUtilities.GetLineSpanContainingSpan(text, diagnosticSpan);
+        var removalSpan = DocumentationAnalysisUtilities.GetDocumentationElementRemovalSpan(text, diagnosticSpan);
 
         return document.WithText(text.Replace(removalSpan, string.Empty));
     }

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Documentation/RH8107VoidReturnValueMustNotBeDocumentedCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Documentation/RH8107VoidReturnValueMustNotBeDocumentedCodeFixProvider.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Text;
 
-using Reihitsu.Analyzer.Core;
+using Reihitsu.Analyzer.CodeFixes.Core;
 using Reihitsu.Analyzer.Rules.Documentation;
 
 namespace Reihitsu.Analyzer.CodeFixes.Rules.Documentation;
@@ -32,7 +32,7 @@ public class RH8107VoidReturnValueMustNotBeDocumentedCodeFixProvider : CodeFixPr
     private static async Task<Document> ApplyCodeFixAsync(Document document, TextSpan diagnosticSpan, CancellationToken cancellationToken)
     {
         var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-        var removalSpan = DocumentationAnalysisUtilities.GetDocumentationElementRemovalSpan(text, diagnosticSpan);
+        var removalSpan = DocumentationCommentCodeFixUtilities.GetElementRemovalSpan(text, diagnosticSpan);
 
         return document.WithText(text.Replace(removalSpan, string.Empty));
     }
@@ -62,6 +62,11 @@ public class RH8107VoidReturnValueMustNotBeDocumentedCodeFixProvider : CodeFixPr
 
         foreach (var diagnostic in context.Diagnostics)
         {
+            if (DocumentationCommentCodeFixUtilities.CanRemoveElement(root, diagnostic.Location.SourceSpan) == false)
+            {
+                continue;
+            }
+
             context.RegisterCodeFix(CodeAction.Create(CodeFixResources.RH8107Title,
                                                       token => ApplyCodeFixAsync(context.Document, diagnostic.Location.SourceSpan, token),
                                                       nameof(RH8107VoidReturnValueMustNotBeDocumentedCodeFixProvider)),

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Documentation/RH8202ValueTagMustNotBeUsedCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Documentation/RH8202ValueTagMustNotBeUsedCodeFixProvider.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Text;
 
-using Reihitsu.Analyzer.Core;
+using Reihitsu.Analyzer.CodeFixes.Core;
 using Reihitsu.Analyzer.Rules.Documentation;
 
 namespace Reihitsu.Analyzer.CodeFixes.Rules.Documentation;
@@ -32,7 +32,7 @@ public class RH8202ValueTagMustNotBeUsedCodeFixProvider : CodeFixProvider
     private static async Task<Document> ApplyCodeFixAsync(Document document, TextSpan diagnosticSpan, CancellationToken cancellationToken)
     {
         var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-        var removalSpan = DocumentationAnalysisUtilities.GetDocumentationElementRemovalSpan(text, diagnosticSpan);
+        var removalSpan = DocumentationCommentCodeFixUtilities.GetElementRemovalSpan(text, diagnosticSpan);
 
         return document.WithText(text.Replace(removalSpan, string.Empty));
     }
@@ -62,6 +62,11 @@ public class RH8202ValueTagMustNotBeUsedCodeFixProvider : CodeFixProvider
 
         foreach (var diagnostic in context.Diagnostics)
         {
+            if (DocumentationCommentCodeFixUtilities.CanRemoveElement(root, diagnostic.Location.SourceSpan) == false)
+            {
+                continue;
+            }
+
             context.RegisterCodeFix(CodeAction.Create(CodeFixResources.RH8202Title,
                                                       token => ApplyCodeFixAsync(context.Document, diagnostic.Location.SourceSpan, token),
                                                       nameof(RH8202ValueTagMustNotBeUsedCodeFixProvider)),

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Documentation/RH8202ValueTagMustNotBeUsedCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Documentation/RH8202ValueTagMustNotBeUsedCodeFixProvider.cs
@@ -32,7 +32,7 @@ public class RH8202ValueTagMustNotBeUsedCodeFixProvider : CodeFixProvider
     private static async Task<Document> ApplyCodeFixAsync(Document document, TextSpan diagnosticSpan, CancellationToken cancellationToken)
     {
         var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-        var removalSpan = DocumentationAnalysisUtilities.GetLineSpanContainingSpan(text, diagnosticSpan);
+        var removalSpan = DocumentationAnalysisUtilities.GetDocumentationElementRemovalSpan(text, diagnosticSpan);
 
         return document.WithText(text.Replace(removalSpan, string.Empty));
     }

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Documentation/RH8308NoContentShouldAppearAfterClosingXmlTagsCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Documentation/RH8308NoContentShouldAppearAfterClosingXmlTagsCodeFixProvider.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Text;
 
+using Reihitsu.Analyzer.CodeFixes.Core;
 using Reihitsu.Analyzer.Rules.Documentation;
 
 namespace Reihitsu.Analyzer.CodeFixes.Rules.Documentation;
@@ -35,7 +36,7 @@ public class RH8308NoContentShouldAppearAfterClosingXmlTagsCodeFixProvider : Cod
         var replacementStart = diagnosticSpan.Start;
 
         while (replacementStart > affectedLine.Start
-               && (sourceText[replacementStart - 1] == ' ' || sourceText[replacementStart - 1] == '\t'))
+               && DocumentationCommentCodeFixUtilities.IsHorizontalWhitespace(sourceText[replacementStart - 1]))
         {
             replacementStart--;
         }

--- a/Reihitsu.Analyzer.Test/Documentation/RH8107VoidReturnValueMustNotBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH8107VoidReturnValueMustNotBeDocumentedAnalyzerTests.cs
@@ -414,6 +414,47 @@ public class RH8107VoidReturnValueMustNotBeDocumentedAnalyzerTests : AnalyzerTes
     }
 
     /// <summary>
+    /// Verifies a diagnostic is reported for a returns tag nested in a remarks element
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticForReturnsTagNestedInRemarks()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              internal class TestClass
+                              {
+                                  /// <summary>Runs the method.</summary>
+                                  /// <remarks>
+                                  /// {|#0:<returns>Nothing.</returns>|}
+                                  /// </remarks>
+                                  internal void TestMethod()
+                                  {
+                                  }
+                              }
+                              """;
+
+        const string fixedSource = """
+                                   namespace TestNamespace;
+
+                                   internal class TestClass
+                                   {
+                                       /// <summary>Runs the method.</summary>
+                                       /// <remarks>
+                                       /// </remarks>
+                                       internal void TestMethod()
+                                       {
+                                       }
+                                   }
+                                   """;
+
+        await Verify(source,
+                     fixedSource,
+                     Diagnostics(RH8107VoidReturnValueMustNotBeDocumentedAnalyzer.DiagnosticId, AnalyzerResources.RH8107MessageFormat));
+    }
+
+    /// <summary>
     /// Verifies no diagnostic is reported for a returns tag which only appears inside a code sample
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer.Test/Documentation/RH8107VoidReturnValueMustNotBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH8107VoidReturnValueMustNotBeDocumentedAnalyzerTests.cs
@@ -210,6 +210,187 @@ public class RH8107VoidReturnValueMustNotBeDocumentedAnalyzerTests : AnalyzerTes
     }
 
     /// <summary>
+    /// Verifies the code fix keeps the tags on both sides of the returns tag on a shared line
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCodeFixKeepsSurroundingTagsSharingTheLine()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              internal class TestClass
+                              {
+                                  /// <summary>Runs the method.</summary>{|#0:<returns>Nothing.</returns>|}<param name="value">Value.</param>
+                                  internal void TestMethod(int value)
+                                  {
+                                  }
+                              }
+                              """;
+
+        const string fixedSource = """
+                                   namespace TestNamespace;
+
+                                   internal class TestClass
+                                   {
+                                       /// <summary>Runs the method.</summary><param name="value">Value.</param>
+                                       internal void TestMethod(int value)
+                                       {
+                                       }
+                                   }
+                                   """;
+
+        await Verify(source,
+                     fixedSource,
+                     Diagnostics(RH8107VoidReturnValueMustNotBeDocumentedAnalyzer.DiagnosticId, AnalyzerResources.RH8107MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies the code fix removes the returns tag from a delimited documentation comment
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCodeFixRemovesReturnsTagFromDelimitedDocumentationComment()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              internal class TestClass
+                              {
+                                  /**
+                                   * <summary>Runs the method.</summary>
+                                   * {|#0:<returns>Nothing.</returns>|}
+                                   */
+                                  internal void TestMethod()
+                                  {
+                                  }
+                              }
+                              """;
+
+        const string fixedSource = """
+                                   namespace TestNamespace;
+
+                                   internal class TestClass
+                                   {
+                                       /**
+                                        * <summary>Runs the method.</summary>
+                                        */
+                                       internal void TestMethod()
+                                       {
+                                       }
+                                   }
+                                   """;
+
+        await Verify(source,
+                     fixedSource,
+                     Diagnostics(RH8107VoidReturnValueMustNotBeDocumentedAnalyzer.DiagnosticId, AnalyzerResources.RH8107MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies multiple returns tags are detected and fixed together
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyReturnsTagsAreFixedTogether()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              internal class TestClass
+                              {
+                                  /// <summary>Runs the method.</summary>
+                                  /// {|#0:<returns>Nothing.</returns>|}
+                                  internal void TestMethod()
+                                  {
+                                  }
+
+                                  /// <summary>Runs the other method.</summary>{|#1:<returns>Nothing.</returns>|}
+                                  internal void TestOtherMethod()
+                                  {
+                                  }
+                              }
+                              """;
+
+        const string fixedSource = """
+                                   namespace TestNamespace;
+
+                                   internal class TestClass
+                                   {
+                                       /// <summary>Runs the method.</summary>
+                                       internal void TestMethod()
+                                       {
+                                       }
+
+                                       /// <summary>Runs the other method.</summary>
+                                       internal void TestOtherMethod()
+                                       {
+                                       }
+                                   }
+                                   """;
+
+        await Verify(source,
+                     fixedSource,
+                     static config => config.NumberOfFixAllIterations = 1,
+                     Diagnostics(RH8107VoidReturnValueMustNotBeDocumentedAnalyzer.DiagnosticId, AnalyzerResources.RH8107MessageFormat, 2));
+    }
+
+    /// <summary>
+    /// Verifies no code fix is offered when the returns tag has no end tag
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    /// <remarks>
+    /// Roslyn extends the element span past the trailing line break when the end tag is missing, so the following
+    /// declaration would be pulled into the documentation comment
+    /// </remarks>
+    [TestMethod]
+    public async Task VerifyNoCodeFixWhenEndTagIsMissing()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              internal class TestClass
+                              {
+                                  /// <summary>Runs the method.</summary>
+                                  /// <returns>Nothing.
+                                  internal void TestMethod()
+                                  {
+                                  }
+                              }
+                              """;
+
+        await Verify(source,
+                     source,
+                     Diagnostic(RH8107VoidReturnValueMustNotBeDocumentedAnalyzer.DiagnosticId).WithSpan(6, 9, 7, 1)
+                                                                                              .WithMessage(AnalyzerResources.RH8107MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies no code fix is offered when a returns tag without an end tag swallows a following tag
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoCodeFixWhenEndTagIsMissingAndFollowingTagIsSwallowed()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              internal class TestClass
+                              {
+                                  /// <returns>Nothing.
+                                  /// <param name="value">Value.</param>
+                                  internal void TestMethod(int value)
+                                  {
+                                  }
+                              }
+                              """;
+
+        await Verify(source,
+                     source,
+                     Diagnostic(RH8107VoidReturnValueMustNotBeDocumentedAnalyzer.DiagnosticId).WithSpan(5, 9, 7, 1)
+                                                                                              .WithMessage(AnalyzerResources.RH8107MessageFormat));
+    }
+
+    /// <summary>
     /// Verifies no diagnostics are reported when documentation mode is none
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer.Test/Documentation/RH8107VoidReturnValueMustNotBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH8107VoidReturnValueMustNotBeDocumentedAnalyzerTests.cs
@@ -55,6 +55,161 @@ public class RH8107VoidReturnValueMustNotBeDocumentedAnalyzerTests : AnalyzerTes
     }
 
     /// <summary>
+    /// Verifies the code fix keeps a summary tag which shares the line with the returns tag
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCodeFixKeepsSummaryTagSharingTheLine()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              internal class TestClass
+                              {
+                                  /// <summary>Runs the method.</summary>{|#0:<returns>Nothing.</returns>|}
+                                  internal void TestMethod()
+                                  {
+                                  }
+                              }
+                              """;
+
+        const string fixedSource = """
+                                   namespace TestNamespace;
+
+                                   internal class TestClass
+                                   {
+                                       /// <summary>Runs the method.</summary>
+                                       internal void TestMethod()
+                                       {
+                                       }
+                                   }
+                                   """;
+
+        await Verify(source,
+                     fixedSource,
+                     Diagnostics(RH8107VoidReturnValueMustNotBeDocumentedAnalyzer.DiagnosticId, AnalyzerResources.RH8107MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies the code fix keeps the end tag of a preceding element which shares the line with the returns tag
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCodeFixKeepsPrecedingEndTagSharingTheLine()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              internal class TestClass
+                              {
+                                  /// <summary>
+                                  /// Runs the method.
+                                  /// </summary>{|#0:<returns>Nothing.</returns>|}
+                                  internal void TestMethod()
+                                  {
+                                  }
+                              }
+                              """;
+
+        const string fixedSource = """
+                                   namespace TestNamespace;
+
+                                   internal class TestClass
+                                   {
+                                       /// <summary>
+                                       /// Runs the method.
+                                       /// </summary>
+                                       internal void TestMethod()
+                                       {
+                                       }
+                                   }
+                                   """;
+
+        await Verify(source,
+                     fixedSource,
+                     Diagnostics(RH8107VoidReturnValueMustNotBeDocumentedAnalyzer.DiagnosticId, AnalyzerResources.RH8107MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies the code fix keeps the following tag which starts on the last line of the returns tag
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCodeFixKeepsFollowingTagSharingTheLastLine()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              internal class TestClass
+                              {
+                                  /// <summary>Runs the method.</summary>
+                                  /// {|#0:<returns>
+                                  /// Nothing.
+                                  /// </returns>|}<param name="value">Value.</param>
+                                  internal void TestMethod(int value)
+                                  {
+                                  }
+                              }
+                              """;
+
+        const string fixedSource = """
+                                   namespace TestNamespace;
+
+                                   internal class TestClass
+                                   {
+                                       /// <summary>Runs the method.</summary>
+                                       /// <param name="value">Value.</param>
+                                       internal void TestMethod(int value)
+                                       {
+                                       }
+                                   }
+                                   """;
+
+        await Verify(source,
+                     fixedSource,
+                     Diagnostics(RH8107VoidReturnValueMustNotBeDocumentedAnalyzer.DiagnosticId, AnalyzerResources.RH8107MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies the code fix removes every line of a multi line returns tag which owns its lines
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCodeFixRemovesMultiLineReturnsTagCompletely()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              internal class TestClass
+                              {
+                                  /// <summary>Runs the method.</summary>
+                                  /// {|#0:<returns>
+                                  /// Nothing.
+                                  /// </returns>|}
+                                  internal void TestMethod()
+                                  {
+                                  }
+                              }
+                              """;
+
+        const string fixedSource = """
+                                   namespace TestNamespace;
+
+                                   internal class TestClass
+                                   {
+                                       /// <summary>Runs the method.</summary>
+                                       internal void TestMethod()
+                                       {
+                                       }
+                                   }
+                                   """;
+
+        await Verify(source,
+                     fixedSource,
+                     Diagnostics(RH8107VoidReturnValueMustNotBeDocumentedAnalyzer.DiagnosticId, AnalyzerResources.RH8107MessageFormat));
+    }
+
+    /// <summary>
     /// Verifies no diagnostics are reported when documentation mode is none
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer.Test/Documentation/RH8107VoidReturnValueMustNotBeDocumentedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH8107VoidReturnValueMustNotBeDocumentedAnalyzerTests.cs
@@ -413,5 +413,104 @@ public class RH8107VoidReturnValueMustNotBeDocumentedAnalyzerTests : AnalyzerTes
         await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
     }
 
+    /// <summary>
+    /// Verifies no diagnostic is reported for a returns tag which only appears inside a code sample
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticForReturnsTagInsideCodeSample()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              internal class TestClass
+                              {
+                                  /// <summary>
+                                  /// Saves the customer.
+                                  /// <code>
+                                  /// <returns>Sample tag inside a code block.</returns>
+                                  /// </code>
+                                  /// </summary>
+                                  internal void TestMethod()
+                                  {
+                                  }
+                              }
+                              """;
+
+        await Verify(source);
+    }
+
+    /// <summary>
+    /// Verifies no diagnostic is reported for a returns tag which only appears inside an example sample
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticForReturnsTagInsideExampleSample()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              internal class TestClass
+                              {
+                                  /// <summary>Saves the customer.</summary>
+                                  /// <example>
+                                  /// <returns>Sample tag inside an example.</returns>
+                                  /// </example>
+                                  internal void TestMethod()
+                                  {
+                                  }
+                              }
+                              """;
+
+        await Verify(source);
+    }
+
+    /// <summary>
+    /// Verifies a top level returns tag is still detected when a code sample also contains one
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyTopLevelReturnsTagIsDetectedBesideCodeSample()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              internal class TestClass
+                              {
+                                  /// <summary>
+                                  /// Saves the customer.
+                                  /// <code>
+                                  /// <returns>Sample tag inside a code block.</returns>
+                                  /// </code>
+                                  /// </summary>
+                                  /// {|#0:<returns>Nothing.</returns>|}
+                                  internal void TestMethod()
+                                  {
+                                  }
+                              }
+                              """;
+
+        const string fixedSource = """
+                                   namespace TestNamespace;
+
+                                   internal class TestClass
+                                   {
+                                       /// <summary>
+                                       /// Saves the customer.
+                                       /// <code>
+                                       /// <returns>Sample tag inside a code block.</returns>
+                                       /// </code>
+                                       /// </summary>
+                                       internal void TestMethod()
+                                       {
+                                       }
+                                   }
+                                   """;
+
+        await Verify(source,
+                     fixedSource,
+                     Diagnostics(RH8107VoidReturnValueMustNotBeDocumentedAnalyzer.DiagnosticId, AnalyzerResources.RH8107MessageFormat));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Documentation/RH8202ValueTagMustNotBeUsedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH8202ValueTagMustNotBeUsedAnalyzerTests.cs
@@ -198,6 +198,175 @@ public class RH8202ValueTagMustNotBeUsedAnalyzerTests : AnalyzerTestsBase<RH8202
     }
 
     /// <summary>
+    /// Verifies the code fix keeps the tags on both sides of the value tag on a shared line
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCodeFixKeepsSurroundingTagsSharingTheLine()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              /// <summary>Stores the current value.</summary>
+                              internal class TestClass
+                              {
+                                  /// <summary>Gets the current value.</summary>{|#0:<value>The current value.</value>|}<remarks>Never negative.</remarks>
+                                  internal int Value { get; }
+                              }
+                              """;
+
+        const string fixedSource = """
+                                   namespace TestNamespace;
+
+                                   /// <summary>Stores the current value.</summary>
+                                   internal class TestClass
+                                   {
+                                       /// <summary>Gets the current value.</summary><remarks>Never negative.</remarks>
+                                       internal int Value { get; }
+                                   }
+                                   """;
+
+        await Verify(source,
+                     fixedSource,
+                     Diagnostics(RH8202ValueTagMustNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH8202MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies the code fix removes the value tag from a delimited documentation comment
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCodeFixRemovesValueTagFromDelimitedDocumentationComment()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              /// <summary>Stores the current value.</summary>
+                              internal class TestClass
+                              {
+                                  /**
+                                   * <summary>Gets the current value.</summary>
+                                   * {|#0:<value>The current value.</value>|}
+                                   */
+                                  internal int Value { get; }
+                              }
+                              """;
+
+        const string fixedSource = """
+                                   namespace TestNamespace;
+
+                                   /// <summary>Stores the current value.</summary>
+                                   internal class TestClass
+                                   {
+                                       /**
+                                        * <summary>Gets the current value.</summary>
+                                        */
+                                       internal int Value { get; }
+                                   }
+                                   """;
+
+        await Verify(source,
+                     fixedSource,
+                     Diagnostics(RH8202ValueTagMustNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH8202MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies multiple value tags are detected and fixed together
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyValueTagsAreFixedTogether()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              /// <summary>Stores the current value.</summary>
+                              internal class TestClass
+                              {
+                                  /// <summary>Gets the current value.</summary>
+                                  /// {|#0:<value>The current value.</value>|}
+                                  internal int Value { get; }
+
+                                  /// <summary>Gets the previous value.</summary>{|#1:<value>The previous value.</value>|}
+                                  internal int PreviousValue { get; }
+                              }
+                              """;
+
+        const string fixedSource = """
+                                   namespace TestNamespace;
+
+                                   /// <summary>Stores the current value.</summary>
+                                   internal class TestClass
+                                   {
+                                       /// <summary>Gets the current value.</summary>
+                                       internal int Value { get; }
+
+                                       /// <summary>Gets the previous value.</summary>
+                                       internal int PreviousValue { get; }
+                                   }
+                                   """;
+
+        await Verify(source,
+                     fixedSource,
+                     static config => config.NumberOfFixAllIterations = 1,
+                     Diagnostics(RH8202ValueTagMustNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH8202MessageFormat, 2));
+    }
+
+    /// <summary>
+    /// Verifies no code fix is offered when the value tag has no end tag
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    /// <remarks>
+    /// Roslyn extends the element span past the trailing line break when the end tag is missing, so the following
+    /// declaration would be pulled into the documentation comment
+    /// </remarks>
+    [TestMethod]
+    public async Task VerifyNoCodeFixWhenEndTagIsMissing()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              /// <summary>Stores the current value.</summary>
+                              internal class TestClass
+                              {
+                                  /// <summary>Gets the current value.</summary>
+                                  /// <value>The current value.
+                                  internal int Value { get; }
+                              }
+                              """;
+
+        await Verify(source,
+                     source,
+                     Diagnostic(RH8202ValueTagMustNotBeUsedAnalyzer.DiagnosticId).WithSpan(7, 9, 8, 1)
+                                                                                 .WithMessage(AnalyzerResources.RH8202MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies no code fix is offered when a value tag without an end tag swallows a following tag
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoCodeFixWhenEndTagIsMissingAndFollowingTagIsSwallowed()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              /// <summary>Stores the current value.</summary>
+                              internal class TestClass
+                              {
+                                  /// <value>The current value.
+                                  /// <remarks>Never negative.</remarks>
+                                  internal int Value { get; }
+                              }
+                              """;
+
+        await Verify(source,
+                     source,
+                     Diagnostic(RH8202ValueTagMustNotBeUsedAnalyzer.DiagnosticId).WithSpan(6, 9, 8, 1)
+                                                                                 .WithMessage(AnalyzerResources.RH8202MessageFormat));
+    }
+
+    /// <summary>
     /// Verifies no diagnostics are reported when documentation mode is none
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer.Test/Documentation/RH8202ValueTagMustNotBeUsedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH8202ValueTagMustNotBeUsedAnalyzerTests.cs
@@ -488,6 +488,30 @@ public class RH8202ValueTagMustNotBeUsedAnalyzerTests : AnalyzerTestsBase<RH8202
     }
 
     /// <summary>
+    /// Verifies no diagnostic is reported for a value tag which only appears inside an example sample
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticForValueTagInsideExampleSample()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              /// <summary>Stores the current value.</summary>
+                              internal class TestClass
+                              {
+                                  /// <summary>Gets the current value.</summary>
+                                  /// <example>
+                                  /// <value>Sample tag inside an example.</value>
+                                  /// </example>
+                                  internal int Value { get; }
+                              }
+                              """;
+
+        await Verify(source);
+    }
+
+    /// <summary>
     /// Verifies a top level value tag is still detected when a code sample also contains one
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer.Test/Documentation/RH8202ValueTagMustNotBeUsedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH8202ValueTagMustNotBeUsedAnalyzerTests.cs
@@ -389,6 +389,79 @@ public class RH8202ValueTagMustNotBeUsedAnalyzerTests : AnalyzerTestsBase<RH8202
     }
 
     /// <summary>
+    /// Verifies a diagnostic is reported for a value tag nested in a remarks element
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticForValueTagNestedInRemarks()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              /// <summary>Stores the current value.</summary>
+                              internal class TestClass
+                              {
+                                  /// <summary>Gets the current value.</summary>
+                                  /// <remarks>
+                                  /// {|#0:<value>The current value.</value>|}
+                                  /// </remarks>
+                                  internal int Value { get; }
+                              }
+                              """;
+
+        const string fixedSource = """
+                                   namespace TestNamespace;
+
+                                   /// <summary>Stores the current value.</summary>
+                                   internal class TestClass
+                                   {
+                                       /// <summary>Gets the current value.</summary>
+                                       /// <remarks>
+                                       /// </remarks>
+                                       internal int Value { get; }
+                                   }
+                                   """;
+
+        await Verify(source,
+                     fixedSource,
+                     Diagnostics(RH8202ValueTagMustNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH8202MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies a diagnostic is reported for a value tag nested in summary text
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticForValueTagNestedInSummaryText()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              /// <summary>Stores the current value.</summary>
+                              internal class TestClass
+                              {
+                                  /// <summary>Gets the {|#0:<value>current</value>|} value.</summary>
+                                  internal int Value { get; }
+                              }
+                              """;
+
+        const string fixedSource = """
+                                   namespace TestNamespace;
+
+                                   /// <summary>Stores the current value.</summary>
+                                   internal class TestClass
+                                   {
+                                       /// <summary>Gets the value.</summary>
+                                       internal int Value { get; }
+                                   }
+                                   """;
+
+        await Verify(source,
+                     fixedSource,
+                     Diagnostics(RH8202ValueTagMustNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH8202MessageFormat));
+    }
+
+    /// <summary>
     /// Verifies no diagnostic is reported for a value tag which only appears inside a code sample
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer.Test/Documentation/RH8202ValueTagMustNotBeUsedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH8202ValueTagMustNotBeUsedAnalyzerTests.cs
@@ -51,6 +51,153 @@ public class RH8202ValueTagMustNotBeUsedAnalyzerTests : AnalyzerTestsBase<RH8202
     }
 
     /// <summary>
+    /// Verifies the code fix keeps a summary tag which shares the line with the value tag
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCodeFixKeepsSummaryTagSharingTheLine()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              /// <summary>Stores the current value.</summary>
+                              internal class TestClass
+                              {
+                                  /// <summary>Gets the current value.</summary>{|#0:<value>The current value.</value>|}
+                                  internal int Value { get; }
+                              }
+                              """;
+
+        const string fixedSource = """
+                                   namespace TestNamespace;
+
+                                   /// <summary>Stores the current value.</summary>
+                                   internal class TestClass
+                                   {
+                                       /// <summary>Gets the current value.</summary>
+                                       internal int Value { get; }
+                                   }
+                                   """;
+
+        await Verify(source,
+                     fixedSource,
+                     Diagnostics(RH8202ValueTagMustNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH8202MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies the code fix keeps the end tag of a preceding element which shares the line with the value tag
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCodeFixKeepsPrecedingEndTagSharingTheLine()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              /// <summary>Stores the current value.</summary>
+                              internal class TestClass
+                              {
+                                  /// <summary>
+                                  /// Gets the current value.
+                                  /// </summary>{|#0:<value>The current value.</value>|}
+                                  internal int Value { get; }
+                              }
+                              """;
+
+        const string fixedSource = """
+                                   namespace TestNamespace;
+
+                                   /// <summary>Stores the current value.</summary>
+                                   internal class TestClass
+                                   {
+                                       /// <summary>
+                                       /// Gets the current value.
+                                       /// </summary>
+                                       internal int Value { get; }
+                                   }
+                                   """;
+
+        await Verify(source,
+                     fixedSource,
+                     Diagnostics(RH8202ValueTagMustNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH8202MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies the code fix keeps the following tag which starts on the last line of the value tag
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCodeFixKeepsFollowingTagSharingTheLastLine()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              /// <summary>Stores the current value.</summary>
+                              internal class TestClass
+                              {
+                                  /// <summary>Gets the current value.</summary>
+                                  /// {|#0:<value>
+                                  /// The current value.
+                                  /// </value>|}<remarks>Never negative.</remarks>
+                                  internal int Value { get; }
+                              }
+                              """;
+
+        const string fixedSource = """
+                                   namespace TestNamespace;
+
+                                   /// <summary>Stores the current value.</summary>
+                                   internal class TestClass
+                                   {
+                                       /// <summary>Gets the current value.</summary>
+                                       /// <remarks>Never negative.</remarks>
+                                       internal int Value { get; }
+                                   }
+                                   """;
+
+        await Verify(source,
+                     fixedSource,
+                     Diagnostics(RH8202ValueTagMustNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH8202MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies the code fix removes every line of a multi line value tag which owns its lines
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCodeFixRemovesMultiLineValueTagCompletely()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              /// <summary>Stores the current value.</summary>
+                              internal class TestClass
+                              {
+                                  /// <summary>Gets the current value.</summary>
+                                  /// {|#0:<value>
+                                  /// The current value.
+                                  /// </value>|}
+                                  internal int Value { get; }
+                              }
+                              """;
+
+        const string fixedSource = """
+                                   namespace TestNamespace;
+
+                                   /// <summary>Stores the current value.</summary>
+                                   internal class TestClass
+                                   {
+                                       /// <summary>Gets the current value.</summary>
+                                       internal int Value { get; }
+                                   }
+                                   """;
+
+        await Verify(source,
+                     fixedSource,
+                     Diagnostics(RH8202ValueTagMustNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH8202MessageFormat));
+    }
+
+    /// <summary>
     /// Verifies no diagnostics are reported when documentation mode is none
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer.Test/Documentation/RH8202ValueTagMustNotBeUsedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH8202ValueTagMustNotBeUsedAnalyzerTests.cs
@@ -388,5 +388,76 @@ public class RH8202ValueTagMustNotBeUsedAnalyzerTests : AnalyzerTestsBase<RH8202
         await Verify(source, test => test.SolutionTransforms.Add(ApplyDocumentationModeNoneToTestProject));
     }
 
+    /// <summary>
+    /// Verifies no diagnostic is reported for a value tag which only appears inside a code sample
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticForValueTagInsideCodeSample()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              /// <summary>Stores the current value.</summary>
+                              internal class TestClass
+                              {
+                                  /// <summary>
+                                  /// Gets the current value.
+                                  /// <code>
+                                  /// <value>Sample tag inside a code block.</value>
+                                  /// </code>
+                                  /// </summary>
+                                  internal int Value { get; }
+                              }
+                              """;
+
+        await Verify(source);
+    }
+
+    /// <summary>
+    /// Verifies a top level value tag is still detected when a code sample also contains one
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyTopLevelValueTagIsDetectedBesideCodeSample()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              /// <summary>Stores the current value.</summary>
+                              internal class TestClass
+                              {
+                                  /// <summary>
+                                  /// Gets the current value.
+                                  /// <code>
+                                  /// <value>Sample tag inside a code block.</value>
+                                  /// </code>
+                                  /// </summary>
+                                  /// {|#0:<value>The current value.</value>|}
+                                  internal int Value { get; }
+                              }
+                              """;
+
+        const string fixedSource = """
+                                   namespace TestNamespace;
+
+                                   /// <summary>Stores the current value.</summary>
+                                   internal class TestClass
+                                   {
+                                       /// <summary>
+                                       /// Gets the current value.
+                                       /// <code>
+                                       /// <value>Sample tag inside a code block.</value>
+                                       /// </code>
+                                       /// </summary>
+                                       internal int Value { get; }
+                                   }
+                                   """;
+
+        await Verify(source,
+                     fixedSource,
+                     Diagnostics(RH8202ValueTagMustNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH8202MessageFormat));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer/Core/DirectDocumentationSyntaxChecker.cs
+++ b/Reihitsu.Analyzer/Core/DirectDocumentationSyntaxChecker.cs
@@ -43,7 +43,8 @@ internal static class DirectDocumentationSyntaxChecker
     }
 
     /// <summary>
-    /// Gets the first direct XML node with the specified tag name
+    /// Gets the first XML node with the specified tag name, falling back to nested nodes when the documentation
+    /// comment has no top-level match
     /// </summary>
     /// <param name="documentationComment">Documentation comment</param>
     /// <param name="tagName">Tag name</param>
@@ -72,7 +73,8 @@ internal static class DirectDocumentationSyntaxChecker
     }
 
     /// <summary>
-    /// Gets all direct XML nodes with the specified tag name
+    /// Gets the XML nodes with the specified tag name. Top-level nodes win; when the documentation comment has no
+    /// top-level match the search falls back to nested nodes, including content inside samples
     /// </summary>
     /// <param name="documentationComment">Documentation comment</param>
     /// <param name="tagName">Tag name</param>
@@ -102,7 +104,7 @@ internal static class DirectDocumentationSyntaxChecker
     }
 
     /// <summary>
-    /// Determines whether the documentation contains a direct tag
+    /// Determines whether the documentation contains the tag, at top level or nested
     /// </summary>
     /// <param name="documentationComment">Documentation comment</param>
     /// <param name="tagName">Tag name</param>

--- a/Reihitsu.Analyzer/Core/DirectDocumentationSyntaxChecker.cs
+++ b/Reihitsu.Analyzer/Core/DirectDocumentationSyntaxChecker.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 
 using Microsoft.CodeAnalysis;
@@ -13,6 +14,19 @@ namespace Reihitsu.Analyzer.Core;
 /// </summary>
 internal static class DirectDocumentationSyntaxChecker
 {
+    #region Fields
+
+    /// <summary>
+    /// Tag names whose content illustrates usage instead of documenting the member
+    /// </summary>
+    private static readonly HashSet<string> _sampleTagNames = new(StringComparer.OrdinalIgnoreCase)
+                                                              {
+                                                                  "code",
+                                                                  "example"
+                                                              };
+
+    #endregion // Fields
+
     #region Methods
 
     /// <summary>
@@ -34,32 +48,27 @@ internal static class DirectDocumentationSyntaxChecker
     /// <param name="documentationComment">Documentation comment</param>
     /// <param name="tagName">Tag name</param>
     /// <returns>The matching node, when present</returns>
-    internal static XmlNodeSyntax GetFirstDirectTag(DocumentationCommentTriviaSyntax documentationComment, string tagName)
+    internal static XmlNodeSyntax GetFirstTagIncludingNested(DocumentationCommentTriviaSyntax documentationComment, string tagName)
     {
-        return GetDirectTags(documentationComment, tagName).FirstOrDefault();
+        return GetTagsIncludingNested(documentationComment, tagName).FirstOrDefault();
     }
 
     /// <summary>
-    /// Gets the first XML node with the specified tag name which is a direct child of the documentation comment
+    /// Gets the first XML node with the specified tag name which documents the member itself
     /// </summary>
     /// <param name="documentationComment">Documentation comment</param>
     /// <param name="tagName">Tag name</param>
     /// <returns>The matching node, when present</returns>
     /// <remarks>
-    /// Unlike <see cref="GetFirstDirectTag"/> this never falls back to nested nodes, so a tag written inside a
-    /// <c>&lt;code&gt;</c> or <c>&lt;example&gt;</c> sample is never returned. Rules which remove the tag they
-    /// find must use this overload, otherwise the fix deletes sample text the documentation only illustrates
+    /// This searches the same nodes as <see cref="GetFirstTagIncludingNested"/> but skips anything inside a
+    /// <c>&lt;code&gt;</c> or <c>&lt;example&gt;</c> sample, where a tag illustrates usage instead of documenting
+    /// the member. Rules which remove the tag they find must use this overload, otherwise the fix deletes sample
+    /// text. Tags nested in prose such as <c>&lt;summary&gt;</c> or <c>&lt;remarks&gt;</c> are still returned —
+    /// they document the member and remain real violations
     /// </remarks>
-    internal static XmlNodeSyntax GetFirstTopLevelTag(DocumentationCommentTriviaSyntax documentationComment, string tagName)
+    internal static XmlNodeSyntax GetFirstDocumentingTag(DocumentationCommentTriviaSyntax documentationComment, string tagName)
     {
-        if (documentationComment == null)
-        {
-            return null;
-        }
-
-        return documentationComment.Content
-                                   .Where(obj => obj is XmlElementSyntax or XmlEmptyElementSyntax)
-                                   .FirstOrDefault(obj => string.Equals(XmlDocumentationElementOrderingUtilities.GetTagName(obj), tagName, StringComparison.OrdinalIgnoreCase));
+        return GetTagsIncludingNested(documentationComment, tagName).FirstOrDefault(obj => IsInsideSample(obj) == false);
     }
 
     /// <summary>
@@ -68,7 +77,7 @@ internal static class DirectDocumentationSyntaxChecker
     /// <param name="documentationComment">Documentation comment</param>
     /// <param name="tagName">Tag name</param>
     /// <returns>Matching nodes</returns>
-    internal static ImmutableArray<XmlNodeSyntax> GetDirectTags(DocumentationCommentTriviaSyntax documentationComment, string tagName)
+    internal static ImmutableArray<XmlNodeSyntax> GetTagsIncludingNested(DocumentationCommentTriviaSyntax documentationComment, string tagName)
     {
         if (documentationComment == null)
         {
@@ -98,9 +107,28 @@ internal static class DirectDocumentationSyntaxChecker
     /// <param name="documentationComment">Documentation comment</param>
     /// <param name="tagName">Tag name</param>
     /// <returns><see langword="true"/> if the tag exists</returns>
-    internal static bool HasDirectTag(DocumentationCommentTriviaSyntax documentationComment, string tagName)
+    internal static bool HasTagIncludingNested(DocumentationCommentTriviaSyntax documentationComment, string tagName)
     {
-        return GetDirectTags(documentationComment, tagName).Length > 0;
+        return GetTagsIncludingNested(documentationComment, tagName).Length > 0;
+    }
+
+    /// <summary>
+    /// Determines whether the node is contained in a code or example sample
+    /// </summary>
+    /// <param name="node">Node</param>
+    /// <returns><see langword="true"/> if an ancestor illustrates usage instead of documenting the member</returns>
+    private static bool IsInsideSample(XmlNodeSyntax node)
+    {
+        for (var ancestor = node.Parent; ancestor != null; ancestor = ancestor.Parent)
+        {
+            if (ancestor is XmlElementSyntax element
+                && _sampleTagNames.Contains(XmlDocumentationElementOrderingUtilities.GetTagName(element)))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     #endregion // Methods

--- a/Reihitsu.Analyzer/Core/DirectDocumentationSyntaxChecker.cs
+++ b/Reihitsu.Analyzer/Core/DirectDocumentationSyntaxChecker.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using System;
+using System.Collections.Immutable;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -36,6 +37,29 @@ internal static class DirectDocumentationSyntaxChecker
     internal static XmlNodeSyntax GetFirstDirectTag(DocumentationCommentTriviaSyntax documentationComment, string tagName)
     {
         return GetDirectTags(documentationComment, tagName).FirstOrDefault();
+    }
+
+    /// <summary>
+    /// Gets the first XML node with the specified tag name which is a direct child of the documentation comment
+    /// </summary>
+    /// <param name="documentationComment">Documentation comment</param>
+    /// <param name="tagName">Tag name</param>
+    /// <returns>The matching node, when present</returns>
+    /// <remarks>
+    /// Unlike <see cref="GetFirstDirectTag"/> this never falls back to nested nodes, so a tag written inside a
+    /// <c>&lt;code&gt;</c> or <c>&lt;example&gt;</c> sample is never returned. Rules which remove the tag they
+    /// find must use this overload, otherwise the fix deletes sample text the documentation only illustrates
+    /// </remarks>
+    internal static XmlNodeSyntax GetFirstTopLevelTag(DocumentationCommentTriviaSyntax documentationComment, string tagName)
+    {
+        if (documentationComment == null)
+        {
+            return null;
+        }
+
+        return documentationComment.Content
+                                   .Where(obj => obj is XmlElementSyntax or XmlEmptyElementSyntax)
+                                   .FirstOrDefault(obj => string.Equals(XmlDocumentationElementOrderingUtilities.GetTagName(obj), tagName, StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer/Core/DocumentationAnalysisUtilities.cs
+++ b/Reihitsu.Analyzer/Core/DocumentationAnalysisUtilities.cs
@@ -316,12 +316,12 @@ internal static class DocumentationAnalysisUtilities
             return false;
         }
 
-        if (DirectDocumentationSyntaxChecker.HasDirectTag(documentationComment, "inheritdoc"))
+        if (DirectDocumentationSyntaxChecker.HasTagIncludingNested(documentationComment, "inheritdoc"))
         {
             return true;
         }
 
-        if (DirectDocumentationSyntaxChecker.HasDirectTag(documentationComment, SummaryTagName))
+        if (DirectDocumentationSyntaxChecker.HasTagIncludingNested(documentationComment, SummaryTagName))
         {
             return true;
         }
@@ -357,12 +357,12 @@ internal static class DocumentationAnalysisUtilities
             return false;
         }
 
-        if (DirectDocumentationSyntaxChecker.HasDirectTag(documentationComment, "inheritdoc"))
+        if (DirectDocumentationSyntaxChecker.HasTagIncludingNested(documentationComment, "inheritdoc"))
         {
             return true;
         }
 
-        if (DirectDocumentationSyntaxChecker.HasDirectTag(documentationComment, SummaryTagName))
+        if (DirectDocumentationSyntaxChecker.HasTagIncludingNested(documentationComment, SummaryTagName))
         {
             return true;
         }

--- a/Reihitsu.Analyzer/Core/DocumentationAnalysisUtilities.cs
+++ b/Reihitsu.Analyzer/Core/DocumentationAnalysisUtilities.cs
@@ -302,17 +302,54 @@ internal static class DocumentationAnalysisUtilities
     }
 
     /// <summary>
-    /// Gets the first line-oriented span which fully contains the source span
+    /// Gets the span which has to be removed to delete a documentation element without touching co-located content
     /// </summary>
     /// <param name="text">Source text</param>
-    /// <param name="span">Source span</param>
-    /// <returns>The line span</returns>
-    internal static TextSpan GetLineSpanContainingSpan(SourceText text, TextSpan span)
+    /// <param name="span">Span of the documentation element</param>
+    /// <returns>The removal span</returns>
+    /// <remarks>
+    /// Lines which carry nothing but the element are removed completely. As soon as another tag or documentation text
+    /// shares the first or the last line, only the element itself and its adjacent whitespace are removed.
+    /// </remarks>
+    internal static TextSpan GetDocumentationElementRemovalSpan(SourceText text, TextSpan span)
     {
         var startLine = text.Lines.GetLineFromPosition(span.Start);
         var endLine = text.Lines.GetLineFromPosition(span.End);
+        var isLineStartOwnedByElement = IsDocumentationExteriorOnly(text.ToString(TextSpan.FromBounds(startLine.Start, span.Start)));
+        var isLineEndOwnedByElement = string.IsNullOrWhiteSpace(text.ToString(TextSpan.FromBounds(span.End, endLine.End)));
 
-        return TextSpan.FromBounds(startLine.Start, endLine.EndIncludingLineBreak);
+        if (isLineStartOwnedByElement
+            && isLineEndOwnedByElement)
+        {
+            return TextSpan.FromBounds(startLine.Start, endLine.EndIncludingLineBreak);
+        }
+
+        var start = span.Start;
+        var end = span.End;
+
+        if (isLineEndOwnedByElement)
+        {
+            end = endLine.End;
+        }
+        else if (isLineStartOwnedByElement)
+        {
+            while (end < endLine.End
+                   && char.IsWhiteSpace(text[end]))
+            {
+                end++;
+            }
+        }
+
+        if (isLineStartOwnedByElement == false)
+        {
+            while (start > startLine.Start
+                   && char.IsWhiteSpace(text[start - 1]))
+            {
+                start--;
+            }
+        }
+
+        return TextSpan.FromBounds(start, end);
     }
 
     /// <summary>
@@ -415,6 +452,32 @@ internal static class DocumentationAnalysisUtilities
     {
         return declaration.Parent is EnumDeclarationSyntax enumDeclaration
                && MatchesAccessibilityGroup(enumDeclaration, accessibilityGroup);
+    }
+
+    /// <summary>
+    /// Determines whether the text consists of whitespace and documentation comment exterior markers only
+    /// </summary>
+    /// <param name="text">Text</param>
+    /// <returns><see langword="true"/> if the text carries no documentation content</returns>
+    private static bool IsDocumentationExteriorOnly(string text)
+    {
+        var trimmed = text.Trim();
+
+        if (trimmed.Length == 0)
+        {
+            return true;
+        }
+
+        var isSlashOnly = true;
+        var isAsteriskOnly = true;
+
+        foreach (var character in trimmed)
+        {
+            isSlashOnly &= character == '/';
+            isAsteriskOnly &= character == '*';
+        }
+
+        return isSlashOnly || isAsteriskOnly;
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer/Core/DocumentationAnalysisUtilities.cs
+++ b/Reihitsu.Analyzer/Core/DocumentationAnalysisUtilities.cs
@@ -302,57 +302,6 @@ internal static class DocumentationAnalysisUtilities
     }
 
     /// <summary>
-    /// Gets the span which has to be removed to delete a documentation element without touching co-located content
-    /// </summary>
-    /// <param name="text">Source text</param>
-    /// <param name="span">Span of the documentation element</param>
-    /// <returns>The removal span</returns>
-    /// <remarks>
-    /// Lines which carry nothing but the element are removed completely. As soon as another tag or documentation text
-    /// shares the first or the last line, only the element itself and its adjacent whitespace are removed.
-    /// </remarks>
-    internal static TextSpan GetDocumentationElementRemovalSpan(SourceText text, TextSpan span)
-    {
-        var startLine = text.Lines.GetLineFromPosition(span.Start);
-        var endLine = text.Lines.GetLineFromPosition(span.End);
-        var isLineStartOwnedByElement = IsDocumentationExteriorOnly(text.ToString(TextSpan.FromBounds(startLine.Start, span.Start)));
-        var isLineEndOwnedByElement = string.IsNullOrWhiteSpace(text.ToString(TextSpan.FromBounds(span.End, endLine.End)));
-
-        if (isLineStartOwnedByElement
-            && isLineEndOwnedByElement)
-        {
-            return TextSpan.FromBounds(startLine.Start, endLine.EndIncludingLineBreak);
-        }
-
-        var start = span.Start;
-        var end = span.End;
-
-        if (isLineEndOwnedByElement)
-        {
-            end = endLine.End;
-        }
-        else if (isLineStartOwnedByElement)
-        {
-            while (end < endLine.End
-                   && char.IsWhiteSpace(text[end]))
-            {
-                end++;
-            }
-        }
-
-        if (isLineStartOwnedByElement == false)
-        {
-            while (start > startLine.Start
-                   && char.IsWhiteSpace(text[start - 1]))
-            {
-                start--;
-            }
-        }
-
-        return TextSpan.FromBounds(start, end);
-    }
-
-    /// <summary>
     /// Determines whether the declaration already has the required documentation contract
     /// </summary>
     /// <param name="declaration">Declaration</param>
@@ -452,32 +401,6 @@ internal static class DocumentationAnalysisUtilities
     {
         return declaration.Parent is EnumDeclarationSyntax enumDeclaration
                && MatchesAccessibilityGroup(enumDeclaration, accessibilityGroup);
-    }
-
-    /// <summary>
-    /// Determines whether the text consists of whitespace and documentation comment exterior markers only
-    /// </summary>
-    /// <param name="text">Text</param>
-    /// <returns><see langword="true"/> if the text carries no documentation content</returns>
-    private static bool IsDocumentationExteriorOnly(string text)
-    {
-        var trimmed = text.Trim();
-
-        if (trimmed.Length == 0)
-        {
-            return true;
-        }
-
-        var isSlashOnly = true;
-        var isAsteriskOnly = true;
-
-        foreach (var character in trimmed)
-        {
-            isSlashOnly &= character == '/';
-            isAsteriskOnly &= character == '*';
-        }
-
-        return isSlashOnly || isAsteriskOnly;
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer/Core/DocumentationAnalysisUtilities.cs
+++ b/Reihitsu.Analyzer/Core/DocumentationAnalysisUtilities.cs
@@ -5,7 +5,6 @@ using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 
 using Reihitsu.Analyzer.Base;
 using Reihitsu.Analyzer.Enumerations;

--- a/Reihitsu.Analyzer/Core/XmlDocumentationExpander.cs
+++ b/Reihitsu.Analyzer/Core/XmlDocumentationExpander.cs
@@ -52,7 +52,7 @@ internal static class XmlDocumentationExpander
     /// <returns><see langword="true"/> if the tag exists</returns>
     internal static bool HasTag(DocumentationCommentTriviaSyntax documentationComment, XElement expandedDocumentation, string tagName)
     {
-        if (DirectDocumentationSyntaxChecker.HasDirectTag(documentationComment, tagName))
+        if (DirectDocumentationSyntaxChecker.HasTagIncludingNested(documentationComment, tagName))
         {
             return true;
         }

--- a/Reihitsu.Analyzer/Rules/Documentation/RH8030ElementDocumentationMustHaveSummaryTextAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH8030ElementDocumentationMustHaveSummaryTextAnalyzer.cs
@@ -65,7 +65,7 @@ public class RH8030ElementDocumentationMustHaveSummaryTextAnalyzer : DiagnosticA
             return;
         }
 
-        var summaryNode = DirectDocumentationSyntaxChecker.GetFirstDirectTag(documentationComment, "summary");
+        var summaryNode = DirectDocumentationSyntaxChecker.GetFirstTagIncludingNested(documentationComment, "summary");
 
         if (summaryNode == null)
         {

--- a/Reihitsu.Analyzer/Rules/Documentation/RH8031ExtensionDeclarationsMustHaveSummaryTextAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH8031ExtensionDeclarationsMustHaveSummaryTextAnalyzer.cs
@@ -58,7 +58,7 @@ public class RH8031ExtensionDeclarationsMustHaveSummaryTextAnalyzer : Diagnostic
             return;
         }
 
-        var summaryNode = DirectDocumentationSyntaxChecker.GetFirstDirectTag(documentationComment, "summary");
+        var summaryNode = DirectDocumentationSyntaxChecker.GetFirstTagIncludingNested(documentationComment, "summary");
 
         if (summaryNode == null
             || DocumentationAnalysisUtilities.IsEmpty(summaryNode))

--- a/Reihitsu.Analyzer/Rules/Documentation/RH8102ElementParameterDocumentationMustMatchElementParametersAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH8102ElementParameterDocumentationMustMatchElementParametersAnalyzer.cs
@@ -59,7 +59,7 @@ public class RH8102ElementParameterDocumentationMustMatchElementParametersAnalyz
             return;
         }
 
-        var paramNodes = DirectDocumentationSyntaxChecker.GetDirectTags(documentationComment, "param");
+        var paramNodes = DirectDocumentationSyntaxChecker.GetTagsIncludingNested(documentationComment, "param");
 
         if (paramNodes.IsDefaultOrEmpty)
         {

--- a/Reihitsu.Analyzer/Rules/Documentation/RH8103ElementParameterDocumentationMustDeclareParameterNameAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH8103ElementParameterDocumentationMustDeclareParameterNameAnalyzer.cs
@@ -55,7 +55,7 @@ public class RH8103ElementParameterDocumentationMustDeclareParameterNameAnalyzer
             return;
         }
 
-        foreach (var paramNode in DirectDocumentationSyntaxChecker.GetDirectTags(documentationComment, "param")
+        foreach (var paramNode in DirectDocumentationSyntaxChecker.GetTagsIncludingNested(documentationComment, "param")
                                                                   .Where(paramNode => string.IsNullOrWhiteSpace(DocumentationAnalysisUtilities.GetNameAttributeValue(paramNode))))
         {
             context.ReportDiagnostic(CreateDiagnostic(paramNode.GetLocation()));

--- a/Reihitsu.Analyzer/Rules/Documentation/RH8104ElementParameterDocumentationMustHaveTextAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH8104ElementParameterDocumentationMustHaveTextAnalyzer.cs
@@ -55,7 +55,7 @@ public class RH8104ElementParameterDocumentationMustHaveTextAnalyzer : Diagnosti
             return;
         }
 
-        foreach (var paramNode in DirectDocumentationSyntaxChecker.GetDirectTags(documentationComment, "param")
+        foreach (var paramNode in DirectDocumentationSyntaxChecker.GetTagsIncludingNested(documentationComment, "param")
                                                                   .Where(paramNode => DocumentationAnalysisUtilities.IsEmpty(paramNode)))
         {
             context.ReportDiagnostic(CreateDiagnostic(paramNode.GetLocation()));

--- a/Reihitsu.Analyzer/Rules/Documentation/RH8106ElementReturnValueDocumentationMustHaveTextAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH8106ElementReturnValueDocumentationMustHaveTextAnalyzer.cs
@@ -55,7 +55,7 @@ public class RH8106ElementReturnValueDocumentationMustHaveTextAnalyzer : Diagnos
             return;
         }
 
-        var returnsNode = DirectDocumentationSyntaxChecker.GetFirstDirectTag(documentationComment, "returns");
+        var returnsNode = DirectDocumentationSyntaxChecker.GetFirstTagIncludingNested(documentationComment, "returns");
 
         if (returnsNode == null
             || DocumentationAnalysisUtilities.IsEmpty(returnsNode) == false)

--- a/Reihitsu.Analyzer/Rules/Documentation/RH8107VoidReturnValueMustNotBeDocumentedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH8107VoidReturnValueMustNotBeDocumentedAnalyzer.cs
@@ -56,7 +56,7 @@ public class RH8107VoidReturnValueMustNotBeDocumentedAnalyzer : DiagnosticAnalyz
             return;
         }
 
-        var returnsNode = DirectDocumentationSyntaxChecker.GetFirstTopLevelTag(documentationComment, "returns");
+        var returnsNode = DirectDocumentationSyntaxChecker.GetFirstDocumentingTag(documentationComment, "returns");
 
         if (returnsNode == null)
         {

--- a/Reihitsu.Analyzer/Rules/Documentation/RH8107VoidReturnValueMustNotBeDocumentedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH8107VoidReturnValueMustNotBeDocumentedAnalyzer.cs
@@ -56,7 +56,7 @@ public class RH8107VoidReturnValueMustNotBeDocumentedAnalyzer : DiagnosticAnalyz
             return;
         }
 
-        var returnsNode = DirectDocumentationSyntaxChecker.GetFirstDirectTag(documentationComment, "returns");
+        var returnsNode = DirectDocumentationSyntaxChecker.GetFirstTopLevelTag(documentationComment, "returns");
 
         if (returnsNode == null)
         {

--- a/Reihitsu.Analyzer/Rules/Documentation/RH8109GenericTypeParameterDocumentationMustMatchTypeParametersAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH8109GenericTypeParameterDocumentationMustMatchTypeParametersAnalyzer.cs
@@ -59,7 +59,7 @@ public class RH8109GenericTypeParameterDocumentationMustMatchTypeParametersAnaly
             return;
         }
 
-        var typeParameterNodes = DirectDocumentationSyntaxChecker.GetDirectTags(documentationComment, "typeparam");
+        var typeParameterNodes = DirectDocumentationSyntaxChecker.GetTagsIncludingNested(documentationComment, "typeparam");
 
         if (typeParameterNodes.IsDefaultOrEmpty)
         {

--- a/Reihitsu.Analyzer/Rules/Documentation/RH8110GenericTypeParameterDocumentationMustDeclareParameterNameAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH8110GenericTypeParameterDocumentationMustDeclareParameterNameAnalyzer.cs
@@ -55,7 +55,7 @@ public class RH8110GenericTypeParameterDocumentationMustDeclareParameterNameAnal
             return;
         }
 
-        var unnamedTypeParameterNodes = DirectDocumentationSyntaxChecker.GetDirectTags(documentationComment, "typeparam").Where(typeParameterNode => string.IsNullOrWhiteSpace(DocumentationAnalysisUtilities.GetNameAttributeValue(typeParameterNode)));
+        var unnamedTypeParameterNodes = DirectDocumentationSyntaxChecker.GetTagsIncludingNested(documentationComment, "typeparam").Where(typeParameterNode => string.IsNullOrWhiteSpace(DocumentationAnalysisUtilities.GetNameAttributeValue(typeParameterNode)));
 
         foreach (var typeParameterNode in unnamedTypeParameterNodes)
         {

--- a/Reihitsu.Analyzer/Rules/Documentation/RH8111GenericTypeParameterDocumentationMustHaveTextAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH8111GenericTypeParameterDocumentationMustHaveTextAnalyzer.cs
@@ -55,7 +55,7 @@ public class RH8111GenericTypeParameterDocumentationMustHaveTextAnalyzer : Diagn
             return;
         }
 
-        var emptyTypeParameterNodes = DirectDocumentationSyntaxChecker.GetDirectTags(documentationComment, "typeparam").Where(typeParameterNode => DocumentationAnalysisUtilities.IsEmpty(typeParameterNode));
+        var emptyTypeParameterNodes = DirectDocumentationSyntaxChecker.GetTagsIncludingNested(documentationComment, "typeparam").Where(typeParameterNode => DocumentationAnalysisUtilities.IsEmpty(typeParameterNode));
 
         foreach (var typeParameterNode in emptyTypeParameterNodes)
         {

--- a/Reihitsu.Analyzer/Rules/Documentation/RH8202ValueTagMustNotBeUsedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH8202ValueTagMustNotBeUsedAnalyzer.cs
@@ -57,7 +57,7 @@ public class RH8202ValueTagMustNotBeUsedAnalyzer : DiagnosticAnalyzerBase
             return;
         }
 
-        var valueNode = DirectDocumentationSyntaxChecker.GetFirstDirectTag(documentationComment, "value");
+        var valueNode = DirectDocumentationSyntaxChecker.GetFirstTopLevelTag(documentationComment, "value");
 
         if (valueNode == null)
         {

--- a/Reihitsu.Analyzer/Rules/Documentation/RH8202ValueTagMustNotBeUsedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH8202ValueTagMustNotBeUsedAnalyzer.cs
@@ -57,7 +57,7 @@ public class RH8202ValueTagMustNotBeUsedAnalyzer : DiagnosticAnalyzerBase
             return;
         }
 
-        var valueNode = DirectDocumentationSyntaxChecker.GetFirstTopLevelTag(documentationComment, "value");
+        var valueNode = DirectDocumentationSyntaxChecker.GetFirstDocumentingTag(documentationComment, "value");
 
         if (valueNode == null)
         {

--- a/Reihitsu.Analyzer/Rules/Documentation/RH8203InheritdocMustBeUsedWithInheritingClassAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH8203InheritdocMustBeUsedWithInheritingClassAnalyzer.cs
@@ -55,7 +55,7 @@ public class RH8203InheritdocMustBeUsedWithInheritingClassAnalyzer : DiagnosticA
             return;
         }
 
-        var inheritdocNode = DirectDocumentationSyntaxChecker.GetFirstDirectTag(documentationComment, "inheritdoc");
+        var inheritdocNode = DirectDocumentationSyntaxChecker.GetFirstTagIncludingNested(documentationComment, "inheritdoc");
         var expandedDocumentation = XmlDocumentationExpander.GetExpandedDocumentation(declaration, context.SemanticModel, context.CancellationToken);
         var expandedInheritdocElement = XmlDocumentationExpander.GetFirstExpandedElement(expandedDocumentation, "inheritdoc");
 

--- a/Reihitsu.Analyzer/Rules/Documentation/RH8306PropertySummaryMustUseNounPhraseInsteadOfSentenceAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH8306PropertySummaryMustUseNounPhraseInsteadOfSentenceAnalyzer.cs
@@ -160,7 +160,7 @@ public class RH8306PropertySummaryMustUseNounPhraseInsteadOfSentenceAnalyzer : D
         var documentationComment = DirectDocumentationSyntaxChecker.GetDocumentationComment(propertyDeclaration);
 
         if (documentationComment == null
-            || DirectDocumentationSyntaxChecker.GetFirstDirectTag(documentationComment, "summary") is not XmlElementSyntax summaryElement
+            || DirectDocumentationSyntaxChecker.GetFirstTagIncludingNested(documentationComment, "summary") is not XmlElementSyntax summaryElement
             || IsSentence(GetTextContent(summaryElement)) == false)
         {
             return;

--- a/Reihitsu.Core/DocumentationCommentUtilities.cs
+++ b/Reihitsu.Core/DocumentationCommentUtilities.cs
@@ -28,6 +28,11 @@ public static class DocumentationCommentUtilities
     /// </summary>
     /// <param name="text">Text</param>
     /// <returns><see langword="true"/> if the text carries no documentation content</returns>
+    /// <remarks>
+    /// This is intentionally wider than <see cref="GetContinuationPrefix"/>, which recognizes <c>///</c> only. The
+    /// two differ because they answer different questions: this one classifies existing text and must accept every
+    /// exterior form, while the other emits new text and must not invent a <c>*</c> continuation
+    /// </remarks>
     public static bool IsExteriorOnly(string text)
     {
         var trimmed = text.Trim();
@@ -58,6 +63,11 @@ public static class DocumentationCommentUtilities
     /// <param name="sourceText">Source text</param>
     /// <param name="line">Line</param>
     /// <returns>The continuation prefix, or an empty string when the line has no documentation exterior</returns>
+    /// <remarks>
+    /// This recognizes the <c>///</c> exterior only, so a <c>/** … */</c> comment yields an empty prefix and the
+    /// caller keeps the line as it is. That is intentionally narrower than <see cref="IsExteriorOnly"/>: emitting a
+    /// <c>*</c> continuation would rewrite delimited comments, which no caller is prepared for today
+    /// </remarks>
     public static string GetContinuationPrefix(SourceText sourceText, TextLine line)
     {
         var lineText = sourceText.ToString(line.Span);

--- a/Reihitsu.Core/DocumentationCommentUtilities.cs
+++ b/Reihitsu.Core/DocumentationCommentUtilities.cs
@@ -14,11 +14,40 @@ public static class DocumentationCommentUtilities
     /// <summary>
     /// The exterior marker that introduces a single-line documentation comment
     /// </summary>
-    private const string DocumentationExterior = "///";
+    public const string DocumentationExterior = "///";
 
     #endregion // Constants
 
     #region Methods
+
+    /// <summary>
+    /// Determines whether the text consists of whitespace and documentation comment exterior markers only.
+    /// Both the <c>///</c> exterior of a single-line comment and the <c>*</c> continuation exterior of a
+    /// <c>/** … */</c> comment are recognized. The <c>/**</c> opener is deliberately not an exterior, so
+    /// callers never treat the line that starts the comment as content-free
+    /// </summary>
+    /// <param name="text">Text</param>
+    /// <returns><see langword="true"/> if the text carries no documentation content</returns>
+    public static bool IsExteriorOnly(string text)
+    {
+        var trimmed = text.Trim();
+
+        if (trimmed.Length == 0)
+        {
+            return true;
+        }
+
+        var isSlashOnly = true;
+        var isAsteriskOnly = true;
+
+        foreach (var character in trimmed)
+        {
+            isSlashOnly &= character == '/';
+            isAsteriskOnly &= character == '*';
+        }
+
+        return isSlashOnly || isAsteriskOnly;
+    }
 
     /// <summary>
     /// Gets the continuation prefix for the specified documentation comment line. The prefix consists of

--- a/Reihitsu.Formatter/Pipeline/DocumentationComments/DocCommentElementNormalizer.cs
+++ b/Reihitsu.Formatter/Pipeline/DocumentationComments/DocCommentElementNormalizer.cs
@@ -159,9 +159,9 @@ internal static class DocCommentElementNormalizer
 
         var trimmedStart = rawLine.TrimStart(' ', '\t');
 
-        if (trimmedStart.StartsWith("///", StringComparison.Ordinal))
+        if (trimmedStart.StartsWith(DocumentationCommentUtilities.DocumentationExterior, StringComparison.Ordinal))
         {
-            var afterExterior = trimmedStart.Substring(3);
+            var afterExterior = trimmedStart.Substring(DocumentationCommentUtilities.DocumentationExterior.Length);
 
             return (afterExterior.StartsWith(" ", StringComparison.Ordinal) ? afterExterior.Substring(1) : afterExterior).TrimEnd();
         }

--- a/documentation/rules/RH8202.md
+++ b/documentation/rules/RH8202.md
@@ -5,7 +5,7 @@
 | **ID** | RH8202 |
 | **Category** | Documentation |
 | **Severity** | Warning |
-| **Code Fix** | ✔️ |
+| **Code Fix** | ✓ |
 
 ## Description
 


### PR DESCRIPTION
## Summary

The RH8107 and RH8202 code fixes no longer remove every line the flagged element touches. A line is still removed whole when the element is the only thing on it; as soon as another tag or documentation text shares the element's first or last line, only the element plus its adjacent horizontal whitespace is removed. Elements without an end tag are no longer offered a fix at all.

## Why

Both fixes deleted every line the flagged element touched. That silently dropped co-located documentation — a `summary` element sharing the line with the flagged `returns` element, or a `summary` end tag preceding it — and, when the element's last line carried the next tag's opening, deleted that opening too and left the comment as malformed XML.

## Linked issues

Closes #462

## Review notes

- **Trivia preservation follows from the span arithmetic.** The computed removal span is a subset of the whole-line span the old code used, in every branch: the element-owns-its-lines branch returns exactly that span, and the other three keep `start >= startLine.Start` and `end <= endLine.End`, which is strictly inside it because it stops short of the trailing line break. So the fix can only ever remove *less* than before — no trivia outside the element's own lines is reachable.
- **Malformed elements are skipped, not clamped.** When the end tag is missing, Roslyn extends the element to the end of the documentation comment, so its span runs past the trailing line break — `endLine` becomes the *next* source line and the whitespace absorption would pull the following declaration onto the `///` exterior. Clamping to the trivia does not save it: for an unterminated `returns` followed by a `param` line, the `param` element is parsed as a *child*, so a clamped span still deletes it. `CanRemoveElement` therefore skips fix registration when `EndTag.IsMissing`; the diagnostic is still reported. `main` corrupts both shapes as well, so this is a fix, not a regression.
- **Whitespace absorption is deliberately one-sided.** Content before the element means whitespace is absorbed on the left so the preceding tag keeps its separator; an exterior-only prefix means the `///` is kept and whitespace is absorbed on the right so a following tag moves up cleanly.
- **Placement.** The removal span is code-fix-only logic and now lives in `Reihitsu.Analyzer.CodeFixes/Core/DocumentationCommentCodeFixUtilities.cs`, sharing the existing `IsHorizontalWhitespace` primitive — which `RH8308`'s provider now calls too, replacing its inline copy. The exterior classification moved to `Reihitsu.Core.DocumentationCommentUtilities.IsExteriorOnly` so analyzer, code fix, and formatter agree on one policy; `DocCommentElementNormalizer` now consumes the shared `DocumentationExterior` constant. `GetLineSpanContainingSpan` is gone — it had no other callers.
- **Not done, deliberately:** the formatter's `StripDocumentationPrefix` still does not recognize the `*` continuation exterior. Routing it through the shared classifier would change formatter output for `/** … */` input, which is a behavior change rather than de-duplication and out of scope here.
- RH8304 flags the shared-line shapes this fix now preserves, so the two rules no longer conflict.

## Follow-up work

None.
