### PR TITLE
Replace multi-line documentation comments in the RH8201 code fix

### DIFF
--- a/Reihitsu.Analyzer.CodeFixes/Rules/Documentation/RH8201InheritdocShouldBeUsedCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Documentation/RH8201InheritdocShouldBeUsedCodeFixProvider.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 using Reihitsu.Analyzer.Rules.Documentation;
+using Reihitsu.Core;
 using Reihitsu.Formatter;
 
 namespace Reihitsu.Analyzer.CodeFixes.Rules.Documentation;
@@ -53,18 +54,15 @@ public class RH8201InheritdocShouldBeUsedCodeFixProvider : CodeFixProvider
     {
         var replaced = false;
         var isLineBreakPending = false;
-        var pendingTrivia = new List<SyntaxTrivia>();
 
         foreach (var trivia in triviaList)
         {
             if (isLineBreakPending)
             {
-                // Whitespace between the replaced comment and its line break is buffered so it can be restored
-                // when no line break follows after all
+                // Whitespace between the replaced comment and its line break is dropped along with the line break.
+                // Where no line break follows, the code action's post-processing re-indents the affected lines
                 if (trivia.IsKind(SyntaxKind.WhitespaceTrivia))
                 {
-                    pendingTrivia.Add(trivia);
-
                     continue;
                 }
 
@@ -72,24 +70,14 @@ public class RH8201InheritdocShouldBeUsedCodeFixProvider : CodeFixProvider
 
                 if (trivia.IsKind(SyntaxKind.EndOfLineTrivia))
                 {
-                    pendingTrivia.Clear();
-
                     continue;
                 }
-
-                foreach (var buffered in pendingTrivia)
-                {
-                    yield return buffered;
-                }
-
-                pendingTrivia.Clear();
             }
 
             // Only the flagged (first) documentation comment is replaced. Replacing every documentation comment would
             // emit multiple <inheritdoc/> lines when a member carries more than one documentation comment
             if (replaced == false
-                && (trivia.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia)
-                    || trivia.IsKind(SyntaxKind.MultiLineDocumentationCommentTrivia)))
+                && SyntaxTriviaUtilities.IsDocumentationCommentTrivia(trivia))
             {
                 replaced = true;
 
@@ -104,11 +92,6 @@ public class RH8201InheritdocShouldBeUsedCodeFixProvider : CodeFixProvider
             }
 
             yield return trivia;
-        }
-
-        foreach (var buffered in pendingTrivia)
-        {
-            yield return buffered;
         }
     }
 

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Documentation/RH8201InheritdocShouldBeUsedCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Documentation/RH8201InheritdocShouldBeUsedCodeFixProvider.cs
@@ -43,7 +43,8 @@ public class RH8201InheritdocShouldBeUsedCodeFixProvider : CodeFixProvider
     }
 
     /// <summary>
-    /// Replacing the first <see cref="SyntaxKind.SingleLineDocumentationCommentTrivia"/> with a &amp;lt;inheritdoc/&amp;gt; trivia
+    /// Replacing the first <see cref="SyntaxKind.SingleLineDocumentationCommentTrivia"/> or
+    /// <see cref="SyntaxKind.MultiLineDocumentationCommentTrivia"/> with a &amp;lt;inheritdoc/&amp;gt; trivia
     /// </summary>
     /// <param name="triviaList">List of trivia elements</param>
     /// <param name="endOfLine">End-of-line sequence to use for the trailing line break</param>
@@ -51,15 +52,51 @@ public class RH8201InheritdocShouldBeUsedCodeFixProvider : CodeFixProvider
     private IEnumerable<SyntaxTrivia> ReplaceDocumentation(SyntaxTriviaList triviaList, string endOfLine)
     {
         var replaced = false;
+        var isLineBreakPending = false;
+        var pendingTrivia = new List<SyntaxTrivia>();
 
         foreach (var trivia in triviaList)
         {
+            if (isLineBreakPending)
+            {
+                // Whitespace between the replaced comment and its line break is buffered so it can be restored
+                // when no line break follows after all
+                if (trivia.IsKind(SyntaxKind.WhitespaceTrivia))
+                {
+                    pendingTrivia.Add(trivia);
+
+                    continue;
+                }
+
+                isLineBreakPending = false;
+
+                if (trivia.IsKind(SyntaxKind.EndOfLineTrivia))
+                {
+                    pendingTrivia.Clear();
+
+                    continue;
+                }
+
+                foreach (var buffered in pendingTrivia)
+                {
+                    yield return buffered;
+                }
+
+                pendingTrivia.Clear();
+            }
+
             // Only the flagged (first) documentation comment is replaced. Replacing every documentation comment would
             // emit multiple <inheritdoc/> lines when a member carries more than one documentation comment
             if (replaced == false
-                && trivia.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia))
+                && (trivia.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia)
+                    || trivia.IsKind(SyntaxKind.MultiLineDocumentationCommentTrivia)))
             {
                 replaced = true;
+
+                // A /** ... */ comment does not carry its own line break, while the synthesized <inheritdoc/> trivia
+                // does. The line break that terminated the replaced comment is therefore dropped so the fix does not
+                // introduce a blank line before the member
+                isLineBreakPending = trivia.IsKind(SyntaxKind.MultiLineDocumentationCommentTrivia);
 
                 yield return CreateInheritdocTrivia(endOfLine);
 
@@ -68,11 +105,17 @@ public class RH8201InheritdocShouldBeUsedCodeFixProvider : CodeFixProvider
 
             yield return trivia;
         }
+
+        foreach (var buffered in pendingTrivia)
+        {
+            yield return buffered;
+        }
     }
 
     /// <summary>
-    /// Applies the code fix by replacing <see cref="SyntaxKind.SingleLineDocumentationCommentTrivia"/>
-    /// with a &lt;inheritdoc/&gt; trivia in the leading trivia of the specified <see cref="MemberDeclarationSyntax"/>
+    /// Applies the code fix by replacing <see cref="SyntaxKind.SingleLineDocumentationCommentTrivia"/> or
+    /// <see cref="SyntaxKind.MultiLineDocumentationCommentTrivia"/> with a &lt;inheritdoc/&gt; trivia in the
+    /// leading trivia of the specified <see cref="MemberDeclarationSyntax"/>
     /// </summary>
     /// <param name="document">The <see cref="Document"/> to apply the fix to</param>
     /// <param name="memberDeclaration">The <see cref="MemberDeclarationSyntax"/> to fix</param>

--- a/Reihitsu.Analyzer.Test/Documentation/RH8201InheritdocShouldBeUsedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH8201InheritdocShouldBeUsedAnalyzerTests.cs
@@ -604,7 +604,13 @@ public class RH8201InheritdocShouldBeUsedAnalyzerTests : AnalyzerTestsBase<RH820
 
     /// <summary>
     /// Verifies that only the flagged multi-line (/** */) documentation comment is replaced when a member
-    /// carries a second documentation comment (issue #463)
+    /// carries a second documentation comment (issue #463).
+    /// The surviving second comment is intentional and matches the single-line behavior asserted by
+    /// <see cref="VerifyOnlyFirstDocumentationCommentIsReplaced"/>: the analyzer flags only the first
+    /// documentation comment, so the fix replaces only that one. The compiler concatenates both comments into
+    /// a single member entry in the generated XML documentation file (verified: the member emits
+    /// &lt;inheritdoc/&gt; followed by the surviving &lt;summary&gt;) and reports no warning for the pair, so
+    /// the fixed code neither drops documentation nor introduces a compiler diagnostic
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
     [TestMethod]
@@ -695,6 +701,204 @@ public class RH8201InheritdocShouldBeUsedAnalyzerTests : AnalyzerTestsBase<RH820
         var fixedSource = await ApplyCodeFixAsync(NormalizeToCarriageReturnLineFeed(testData));
 
         Assert.Contains("/// <inheritdoc/>\r\n        public override void TestMethod()", fixedSource);
+    }
+
+    /// <summary>
+    /// Verifies that a trailing comment sharing the line with a multi-line (/** */) documentation comment
+    /// survives the replacement and keeps its own line. The fix drops the line break that terminated the
+    /// replaced comment, so this guards that deletion against consuming the trailing comment (issue #463)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyTrailingCommentIsPreservedWhenMultiLineDocumentationCommentIsReplaced()
+    {
+        const string testData = """
+                                using System;
+
+                                namespace TestNamespace
+                                {
+                                    internal abstract class TestBase
+                                    {
+                                        /// <summary>
+                                        /// Base documentation
+                                        /// </summary>
+                                        public abstract void TestMethod();
+                                    }
+
+                                    internal class TestImplementation : TestBase
+                                    {
+                                        /**{|#0: <summary>Implementation documentation</summary> */|} // trailing
+                                        public override void TestMethod()
+                                        {
+                                        }
+                                    }
+                                }
+                                """;
+
+        const string resultData = """
+                                  using System;
+
+                                  namespace TestNamespace
+                                  {
+                                      internal abstract class TestBase
+                                      {
+                                          /// <summary>
+                                          /// Base documentation
+                                          /// </summary>
+                                          public abstract void TestMethod();
+                                      }
+
+                                      internal class TestImplementation : TestBase
+                                      {
+                                          /// <inheritdoc/>
+                                          // trailing
+                                          public override void TestMethod()
+                                          {
+                                          }
+                                      }
+                                  }
+                                  """;
+
+        await Verify(testData, resultData, Diagnostics(RH8201InheritdocShouldBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH8201MessageFormat, 1));
+    }
+
+    /// <summary>
+    /// Verifies that a preprocessor directive between a multi-line (/** */) documentation comment and the
+    /// member keeps its own line when the comment is replaced. The fix drops the line break that terminated
+    /// the replaced comment, so this guards that deletion against joining the directive onto the
+    /// &lt;inheritdoc/&gt; line, which would not compile (issue #463)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDirectiveIsPreservedWhenMultiLineDocumentationCommentIsReplaced()
+    {
+        const string testData = """
+                                using System;
+
+                                namespace TestNamespace
+                                {
+                                    internal abstract class TestBase
+                                    {
+                                        /// <summary>
+                                        /// Base documentation
+                                        /// </summary>
+                                        public abstract void TestMethod();
+                                    }
+
+                                    internal class TestImplementation : TestBase
+                                    {
+                                        /**{|#0: <summary>Implementation documentation</summary> */|}
+                                #if true
+                                        public override void TestMethod()
+                                        {
+                                        }
+                                #endif
+                                    }
+                                }
+                                """;
+
+        const string resultData = """
+                                  using System;
+
+                                  namespace TestNamespace
+                                  {
+                                      internal abstract class TestBase
+                                      {
+                                          /// <summary>
+                                          /// Base documentation
+                                          /// </summary>
+                                          public abstract void TestMethod();
+                                      }
+
+                                      internal class TestImplementation : TestBase
+                                      {
+                                          /// <inheritdoc/>
+                                  #if true
+                                          public override void TestMethod()
+                                          {
+                                          }
+                                  #endif
+                                      }
+                                  }
+                                  """;
+
+        await Verify(testData, resultData, Diagnostics(RH8201InheritdocShouldBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH8201MessageFormat, 1));
+    }
+
+    /// <summary>
+    /// Verifies that Fix All replaces every multi-line (/** */) documentation comment in a type in one
+    /// iteration, which is the common shape when a type overrides several documented members (issue #463)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyMultipleMultiLineDocumentationCommentsAreFixedInOneFixAllIteration()
+    {
+        const string testData = """
+                                using System;
+
+                                namespace TestNamespace
+                                {
+                                    internal abstract class TestBase
+                                    {
+                                        /// <summary>
+                                        /// Base documentation
+                                        /// </summary>
+                                        public abstract void TestMethod();
+
+                                        /// <summary>
+                                        /// Base documentation
+                                        /// </summary>
+                                        public abstract int TestProperty { get; set; }
+                                    }
+
+                                    internal class TestImplementation : TestBase
+                                    {
+                                        /**{|#0: <summary>Implementation documentation</summary> */|}
+                                        public override void TestMethod()
+                                        {
+                                        }
+
+                                        /**{|#1: <summary>Implementation documentation</summary> */|}
+                                        public override int TestProperty { get; set; }
+                                    }
+                                }
+                                """;
+
+        const string resultData = """
+                                  using System;
+
+                                  namespace TestNamespace
+                                  {
+                                      internal abstract class TestBase
+                                      {
+                                          /// <summary>
+                                          /// Base documentation
+                                          /// </summary>
+                                          public abstract void TestMethod();
+
+                                          /// <summary>
+                                          /// Base documentation
+                                          /// </summary>
+                                          public abstract int TestProperty { get; set; }
+                                      }
+
+                                      internal class TestImplementation : TestBase
+                                      {
+                                          /// <inheritdoc/>
+                                          public override void TestMethod()
+                                          {
+                                          }
+
+                                          /// <inheritdoc/>
+                                          public override int TestProperty { get; set; }
+                                      }
+                                  }
+                                  """;
+
+        await Verify(testData,
+                     resultData,
+                     static config => config.NumberOfFixAllIterations = 1,
+                     Diagnostics(RH8201InheritdocShouldBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH8201MessageFormat, 2));
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer.Test/Documentation/RH8201InheritdocShouldBeUsedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH8201InheritdocShouldBeUsedAnalyzerTests.cs
@@ -375,9 +375,8 @@ public class RH8201InheritdocShouldBeUsedAnalyzerTests : AnalyzerTestsBase<RH820
     }
 
     /// <summary>
-    /// Verifies a diagnostic is reported when an overriding member is documented with a multi-line (/** */)
-    /// documentation comment that does not contain &lt;inheritdoc&gt;. The code fix intentionally only rewrites
-    /// single-line documentation comments, so this scenario is verified for the diagnostic only
+    /// Verifies that a multi-line (/** */) documentation comment spanning several lines is replaced with
+    /// &lt;inheritdoc/&gt; instead of the code fix registering a no-op action (issue #463)
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
     [TestMethod]
@@ -408,7 +407,294 @@ public class RH8201InheritdocShouldBeUsedAnalyzerTests : AnalyzerTestsBase<RH820
                                 }
                                 """;
 
-        await Verify(testData, Diagnostics(RH8201InheritdocShouldBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH8201MessageFormat, 1));
+        const string resultData = """
+                                  using System;
+
+                                  namespace TestNamespace
+                                  {
+                                      internal abstract class TestBase
+                                      {
+                                          /// <summary>
+                                          /// Base documentation
+                                          /// </summary>
+                                          public abstract void TestMethod();
+                                      }
+
+                                      internal class TestImplementation : TestBase
+                                      {
+                                          /// <inheritdoc/>
+                                          public override void TestMethod()
+                                          {
+                                          }
+                                      }
+                                  }
+                                  """;
+
+        await Verify(testData, resultData, Diagnostics(RH8201InheritdocShouldBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH8201MessageFormat, 1));
+    }
+
+    /// <summary>
+    /// Verifies that a multi-line (/** */) documentation comment written on a single line is replaced with
+    /// &lt;inheritdoc/&gt; (issue #463)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticForSingleLineFormMultiLineDocumentationComment()
+    {
+        const string testData = """
+                                using System;
+
+                                namespace TestNamespace
+                                {
+                                    internal abstract class TestBase
+                                    {
+                                        /// <summary>
+                                        /// Base documentation
+                                        /// </summary>
+                                        public abstract void TestMethod();
+                                    }
+
+                                    internal class TestImplementation : TestBase
+                                    {
+                                        /**{|#0: <summary>Implementation documentation</summary> */|}
+                                        public override void TestMethod()
+                                        {
+                                        }
+                                    }
+                                }
+                                """;
+
+        const string resultData = """
+                                  using System;
+
+                                  namespace TestNamespace
+                                  {
+                                      internal abstract class TestBase
+                                      {
+                                          /// <summary>
+                                          /// Base documentation
+                                          /// </summary>
+                                          public abstract void TestMethod();
+                                      }
+
+                                      internal class TestImplementation : TestBase
+                                      {
+                                          /// <inheritdoc/>
+                                          public override void TestMethod()
+                                          {
+                                          }
+                                      }
+                                  }
+                                  """;
+
+        await Verify(testData, resultData, Diagnostics(RH8201InheritdocShouldBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH8201MessageFormat, 1));
+    }
+
+    /// <summary>
+    /// Verifies that a multi-line (/** */) documentation comment on an overridden property is replaced with
+    /// &lt;inheritdoc/&gt; (issue #463)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticForMultiLineDocumentationCommentOnProperty()
+    {
+        const string testData = """
+                                using System;
+
+                                namespace TestNamespace
+                                {
+                                    internal abstract class TestBase
+                                    {
+                                        /// <summary>
+                                        /// Base documentation
+                                        /// </summary>
+                                        public abstract int TestProperty { get; set; }
+                                    }
+
+                                    internal class TestImplementation : TestBase
+                                    {
+                                        /**{|#0: <summary>Implementation documentation</summary> */|}
+                                        public override int TestProperty { get; set; }
+                                    }
+                                }
+                                """;
+
+        const string resultData = """
+                                  using System;
+
+                                  namespace TestNamespace
+                                  {
+                                      internal abstract class TestBase
+                                      {
+                                          /// <summary>
+                                          /// Base documentation
+                                          /// </summary>
+                                          public abstract int TestProperty { get; set; }
+                                      }
+
+                                      internal class TestImplementation : TestBase
+                                      {
+                                          /// <inheritdoc/>
+                                          public override int TestProperty { get; set; }
+                                      }
+                                  }
+                                  """;
+
+        await Verify(testData, resultData, Diagnostics(RH8201InheritdocShouldBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH8201MessageFormat, 1));
+    }
+
+    /// <summary>
+    /// Verifies that a leading comment placed before a multi-line (/** */) documentation comment is preserved
+    /// when the documentation comment is replaced with &lt;inheritdoc/&gt; (issue #463)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifySurroundingTriviaIsPreservedForMultiLineDocumentationComment()
+    {
+        const string testData = """
+                                using System;
+
+                                namespace TestNamespace
+                                {
+                                    internal abstract class TestBase
+                                    {
+                                        /// <summary>
+                                        /// Base documentation
+                                        /// </summary>
+                                        public abstract void TestMethod();
+                                    }
+
+                                    internal class TestImplementation : TestBase
+                                    {
+                                        // Leading comment
+                                        /**{|#0: <summary>Implementation documentation</summary> */|}
+                                        public override void TestMethod()
+                                        {
+                                        }
+                                    }
+                                }
+                                """;
+
+        const string resultData = """
+                                  using System;
+
+                                  namespace TestNamespace
+                                  {
+                                      internal abstract class TestBase
+                                      {
+                                          /// <summary>
+                                          /// Base documentation
+                                          /// </summary>
+                                          public abstract void TestMethod();
+                                      }
+
+                                      internal class TestImplementation : TestBase
+                                      {
+                                          // Leading comment
+                                          /// <inheritdoc/>
+                                          public override void TestMethod()
+                                          {
+                                          }
+                                      }
+                                  }
+                                  """;
+
+        await Verify(testData, resultData, Diagnostics(RH8201InheritdocShouldBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH8201MessageFormat, 1));
+    }
+
+    /// <summary>
+    /// Verifies that only the flagged multi-line (/** */) documentation comment is replaced when a member
+    /// carries a second documentation comment (issue #463)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyOnlyFirstMultiLineDocumentationCommentIsReplaced()
+    {
+        const string testData = """
+                                using System;
+
+                                namespace TestNamespace
+                                {
+                                    internal abstract class TestBase
+                                    {
+                                        /// <summary>
+                                        /// Base documentation
+                                        /// </summary>
+                                        public abstract void TestMethod();
+                                    }
+
+                                    internal class TestImplementation : TestBase
+                                    {
+                                        /**{|#0: <summary>Implementation documentation</summary> */|}
+                                        /** <summary>Second documentation</summary> */
+                                        public override void TestMethod()
+                                        {
+                                        }
+                                    }
+                                }
+                                """;
+
+        const string resultData = """
+                                  using System;
+
+                                  namespace TestNamespace
+                                  {
+                                      internal abstract class TestBase
+                                      {
+                                          /// <summary>
+                                          /// Base documentation
+                                          /// </summary>
+                                          public abstract void TestMethod();
+                                      }
+
+                                      internal class TestImplementation : TestBase
+                                      {
+                                          /// <inheritdoc/>
+                                          /** <summary>Second documentation</summary> */
+                                          public override void TestMethod()
+                                          {
+                                          }
+                                      }
+                                  }
+                                  """;
+
+        await Verify(testData, resultData, Diagnostics(RH8201InheritdocShouldBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH8201MessageFormat, 1));
+    }
+
+    /// <summary>
+    /// Verifies that the synthesized &lt;inheritdoc/&gt; trivia replacing a multi-line (/** */) documentation
+    /// comment uses the document's detected CRLF end-of-line sequence (issue #463)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyMultiLineDocumentationCommentReplacementUsesDetectedCarriageReturnLineFeedEndOfLine()
+    {
+        const string testData = """
+                                using System;
+
+                                namespace TestNamespace
+                                {
+                                    internal abstract class TestBase
+                                    {
+                                        /// <summary>
+                                        /// Base documentation
+                                        /// </summary>
+                                        public abstract void TestMethod();
+                                    }
+
+                                    internal class TestImplementation : TestBase
+                                    {
+                                        /** <summary>Implementation documentation</summary> */
+                                        public override void TestMethod()
+                                        {
+                                        }
+                                    }
+                                }
+                                """;
+
+        var fixedSource = await ApplyCodeFixAsync(NormalizeToCarriageReturnLineFeed(testData));
+
+        Assert.Contains("/// <inheritdoc/>\r\n        public override void TestMethod()", fixedSource);
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer/Rules/Documentation/RH8201InheritdocShouldBeUsedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH8201InheritdocShouldBeUsedAnalyzer.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 using Reihitsu.Analyzer.Base;
 using Reihitsu.Analyzer.Enumerations;
+using Reihitsu.Core;
 
 namespace Reihitsu.Analyzer.Rules.Documentation;
 
@@ -47,8 +48,7 @@ public class RH8201InheritdocShouldBeUsedAnalyzer : DiagnosticAnalyzerBase
             && node.Modifiers.Any(SyntaxKind.OverrideKeyword))
         {
             var documentation = node.GetLeadingTrivia()
-                                    .FirstOrDefault(obj => obj.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia)
-                                                           || obj.IsKind(SyntaxKind.MultiLineDocumentationCommentTrivia));
+                                    .FirstOrDefault(SyntaxTriviaUtilities.IsDocumentationCommentTrivia);
 
             if (documentation != default
                 && documentation.HasStructure)

--- a/Reihitsu.Core.Test/SyntaxTriviaUtilitiesTests.cs
+++ b/Reihitsu.Core.Test/SyntaxTriviaUtilitiesTests.cs
@@ -16,6 +16,50 @@ public class SyntaxTriviaUtilitiesTests
     #region Tests
 
     /// <summary>
+    /// Verifies that a single-line (///) documentation comment is recognized as a documentation comment
+    /// </summary>
+    [TestMethod]
+    public void IsDocumentationCommentTriviaReturnsTrueForSingleLineDocumentationComment()
+    {
+        var trivia = GetFirstTrivia("/// <summary>Doc.</summary>\nclass TestClass;\n", SyntaxKind.SingleLineDocumentationCommentTrivia);
+
+        Assert.IsTrue(SyntaxTriviaUtilities.IsDocumentationCommentTrivia(trivia));
+    }
+
+    /// <summary>
+    /// Verifies that a multi-line (/** */) documentation comment is recognized as a documentation comment
+    /// </summary>
+    [TestMethod]
+    public void IsDocumentationCommentTriviaReturnsTrueForMultiLineDocumentationComment()
+    {
+        var trivia = GetFirstTrivia("/** <summary>Doc.</summary> */\nclass TestClass;\n", SyntaxKind.MultiLineDocumentationCommentTrivia);
+
+        Assert.IsTrue(SyntaxTriviaUtilities.IsDocumentationCommentTrivia(trivia));
+    }
+
+    /// <summary>
+    /// Verifies that an ordinary single-line comment is not treated as a documentation comment
+    /// </summary>
+    [TestMethod]
+    public void IsDocumentationCommentTriviaReturnsFalseForSingleLineComment()
+    {
+        var trivia = GetFirstTrivia("// note\nvar x = 1;\n", SyntaxKind.SingleLineCommentTrivia);
+
+        Assert.IsFalse(SyntaxTriviaUtilities.IsDocumentationCommentTrivia(trivia));
+    }
+
+    /// <summary>
+    /// Verifies that an ordinary multi-line comment is not treated as a documentation comment
+    /// </summary>
+    [TestMethod]
+    public void IsDocumentationCommentTriviaReturnsFalseForMultiLineComment()
+    {
+        var trivia = GetFirstTrivia("/* note */\nvar x = 1;\n", SyntaxKind.MultiLineCommentTrivia);
+
+        Assert.IsFalse(SyntaxTriviaUtilities.IsDocumentationCommentTrivia(trivia));
+    }
+
+    /// <summary>
     /// Verifies that a preprocessor directive is recognized as directive trivia
     /// </summary>
     [TestMethod]

--- a/Reihitsu.Core/SyntaxTriviaUtilities.cs
+++ b/Reihitsu.Core/SyntaxTriviaUtilities.cs
@@ -36,6 +36,20 @@ public static class SyntaxTriviaUtilities
     }
 
     /// <summary>
+    /// Determines whether a trivia is an XML documentation comment, in either the single-line (<c>///</c>) or
+    /// the multi-line (<c>/** */</c>) form. Analyzers and their code fixes share this predicate so both ends
+    /// agree on which comments carry documentation; drifting copies let an analyzer report a shape its fix
+    /// cannot rewrite, which produces a code action that silently does nothing
+    /// </summary>
+    /// <param name="trivia">The trivia to check</param>
+    /// <returns><see langword="true"/> if the trivia is a documentation comment; otherwise, <see langword="false"/></returns>
+    public static bool IsDocumentationCommentTrivia(SyntaxTrivia trivia)
+    {
+        return trivia.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia)
+               || trivia.IsKind(SyntaxKind.MultiLineDocumentationCommentTrivia);
+    }
+
+    /// <summary>
     /// Determines whether a trivia is a comment
     /// </summary>
     /// <param name="trivia">The trivia to check</param>
@@ -44,8 +58,7 @@ public static class SyntaxTriviaUtilities
     {
         return trivia.IsKind(SyntaxKind.SingleLineCommentTrivia)
                || trivia.IsKind(SyntaxKind.MultiLineCommentTrivia)
-               || trivia.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia)
-               || trivia.IsKind(SyntaxKind.MultiLineDocumentationCommentTrivia);
+               || IsDocumentationCommentTrivia(trivia);
     }
 
     /// <summary>

--- a/Reihitsu.Formatter/Pipeline/BlankLines/BlankLineCollapser.cs
+++ b/Reihitsu.Formatter/Pipeline/BlankLines/BlankLineCollapser.cs
@@ -98,8 +98,7 @@ internal sealed class BlankLineCollapser : CSharpSyntaxRewriter
     private static bool EndsWithEmbeddedLineBreak(SyntaxTrivia trivia)
     {
         if (SyntaxTriviaUtilities.IsDirectiveOrDisabledTextTrivia(trivia) == false
-            && trivia.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia) == false
-            && trivia.IsKind(SyntaxKind.MultiLineDocumentationCommentTrivia) == false)
+            && SyntaxTriviaUtilities.IsDocumentationCommentTrivia(trivia) == false)
         {
             return false;
         }

--- a/Reihitsu.Formatter/Pipeline/BlankLines/BlankLineTokenCleanupRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/BlankLines/BlankLineTokenCleanupRewriter.cs
@@ -3,6 +3,8 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 
+using Reihitsu.Core;
+
 namespace Reihitsu.Formatter.Pipeline.BlankLines;
 
 /// <summary>
@@ -41,8 +43,7 @@ internal sealed class BlankLineTokenCleanupRewriter : CSharpSyntaxRewriter
     /// <returns><see langword="true"/> if documentation comment trivia is present</returns>
     private static bool HasDocumentationCommentInLeadingTrivia(SyntaxToken token)
     {
-        return token.LeadingTrivia.Any(static trivia => trivia.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia)
-                                                        || trivia.IsKind(SyntaxKind.MultiLineDocumentationCommentTrivia));
+        return token.LeadingTrivia.Any(SyntaxTriviaUtilities.IsDocumentationCommentTrivia);
     }
 
     /// <summary>
@@ -276,24 +277,13 @@ internal sealed class BlankLineTokenCleanupRewriter : CSharpSyntaxRewriter
     {
         for (var triviaIndex = trivia.Count - 1; triviaIndex >= 0; triviaIndex--)
         {
-            if (IsDocumentationCommentTrivia(trivia[triviaIndex]))
+            if (SyntaxTriviaUtilities.IsDocumentationCommentTrivia(trivia[triviaIndex]))
             {
                 return triviaIndex;
             }
         }
 
         return -1;
-    }
-
-    /// <summary>
-    /// Determines whether the provided trivia is a documentation comment
-    /// </summary>
-    /// <param name="trivia">The trivia to inspect</param>
-    /// <returns><see langword="true"/> when the trivia is a documentation comment</returns>
-    private static bool IsDocumentationCommentTrivia(SyntaxTrivia trivia)
-    {
-        return trivia.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia)
-               || trivia.IsKind(SyntaxKind.MultiLineDocumentationCommentTrivia);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

`RH8201InheritdocShouldBeUsedCodeFixProvider.ReplaceDocumentation` now matches multi-line (`/** ... */`) documentation comments in addition to single-line ones, so a `/** ... */`-documented override is rewritten to `/// <inheritdoc/>` instead of the code action returning the document unchanged. Because the synthesized `<inheritdoc/>` trivia carries its own line break while a `/** ... */` comment does not, the line break that terminated the replaced comment is dropped so no blank line is introduced before the member.

The predicate that decides what counts as a documentation comment is now `SyntaxTriviaUtilities.IsDocumentationCommentTrivia` in `Reihitsu.Core`, shared by the analyzer, this code fix, and the formatter's blank-line phase.

## Why

The analyzer reports both documentation-comment kinds, but the code fix only rewrote the single-line kind. On a `/** ... */`-documented override the lightbulb action was offered and applying it did nothing — a registered no-op code action. That drift was possible because the analyzer and its fix each carried a private copy of the same two-kind predicate.

## Linked issues

Closes #463

## Review notes

- The analyzer's reporting is unchanged; this is a code-fix behavior change, so no diagnostic was rescoped or removed.
- Analyzer/fix parity is now structural: `SyntaxTriviaUtilities.IsDocumentationCommentTrivia` is the single definition, `IsCommentTrivia` delegates to it, and the three surviving copies in `Reihitsu.Formatter` (`BlankLineTokenCleanupRewriter` ×2, `BlankLineCollapser`) were replaced with it. Those formatter substitutions are behavior-preserving — each tested the same two syntax kinds.
- Whitespace between the replaced comment and its line break is skipped along with the line break. Restoring it is unnecessary: the code action's post-processing re-indents the affected lines, so the `/** doc */ // trailing` and `/** doc */ public override ...` shapes come out identical either way.
- Only the first documentation comment in the member's leading trivia is replaced, matching the analyzer's `FirstOrDefault` selection and the pre-existing single-line behavior. Where a second documentation comment survives, the compiler concatenates both into one XML `<member>` entry and reports no warning, so no documentation is lost.
- The line break is dropped in the code fix rather than delegated to the formatter, because the formatter's blank-line cleanup has a known defect around `/** */` comments (#526).
- Coverage: nine RH8201 analyzer tests (multi-line block form, single-line `/** */` form, property member, preserved leading comment, second documentation comment left intact, CRLF preservation, trailing comment in the trivia gap, preprocessor directive in the trivia gap, and Fix All over two documented overrides) plus four `SyntaxTriviaUtilities` tests for the extracted predicate.

## Follow-up work

- RH8201 registration still misses `EventFieldDeclaration`, so documented field-like override events are not checked. That minor is tracked separately in #467 and is intentionally left out of this fix-scoped change.