### PR TITLE
Restrict the conditional-access chain walk to the chain spine

### DIFF
--- a/Reihitsu.Formatter.Test/Regression/FullPipeline/MethodChainAlignmentFullPipelineTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/FullPipeline/MethodChainAlignmentFullPipelineTests.cs
@@ -170,10 +170,11 @@ public class MethodChainAlignmentFullPipelineTests : FormatterTestsBase
     }
 
     /// <summary>
-    /// Verifies that a comment above the first wrapped fluent call keeps the chain unchanged
+    /// Verifies that a comment above the first wrapped fluent call aligns the chain links under the
+    /// chain root token
     /// </summary>
     [TestMethod]
-    public void CommentAboveFirstWrappedCallKeepsChainUnchanged()
+    public void CommentAboveFirstWrappedCallAlignsChainUnderRoot()
     {
         // Arrange
         const string input = """

--- a/Reihitsu.Formatter.Test/Regression/FullPipeline/MethodChainAlignmentFullPipelineTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/FullPipeline/MethodChainAlignmentFullPipelineTests.cs
@@ -215,10 +215,10 @@ public class MethodChainAlignmentFullPipelineTests : FormatterTestsBase
                                     {
                                         return new Builder()
 
-                                            // Keep this step separate.
-                                            .UseLogging()
-                                            .UseValidation()
-                                            .Build();
+                                               // Keep this step separate.
+                                               .UseLogging()
+                                               .UseValidation()
+                                               .Build();
                                     }
 
                                     private sealed class Builder

--- a/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
@@ -302,7 +302,8 @@ public class MethodChainAlignmentTests : FormatterTestsBase
     }
 
     /// <summary>
-    /// Verifies that a chain with a comment directly above the first wrapped call remains unchanged
+    /// Verifies that a chain with a comment directly above the first wrapped call keeps its links
+    /// aligned under the chain root token
     /// </summary>
     [TestMethod]
     public void ChainWithCommentAboveFirstWrappedCallRemainsUnchanged()
@@ -318,9 +319,9 @@ public class MethodChainAlignmentTests : FormatterTestsBase
         const string expected = """
                                 var x = a
 
-                                    // Keep this step separate.
-                                    .Foo()
-                                    .Bar();
+                                        // Keep this step separate.
+                                        .Foo()
+                                        .Bar();
                                 """;
 
         // Act & Assert
@@ -972,6 +973,32 @@ public class MethodChainAlignmentTests : FormatterTestsBase
                                                                      return true;
                                                                  }
                                                  });
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a comment-exempt chain nested in a lambda argument of a conditional access
+    /// chain aligns its links under the chain root instead of the enclosing block (issue #475)
+    /// </summary>
+    [TestMethod]
+    public void CommentExemptChainInsideLambdaArgumentAlignsUnderChainRoot()
+    {
+        // Arrange
+        const string input = """
+                             public class Class
+                             {
+                                 public void M()
+                                 {
+                                     var value = a.List.Find(e => d
+
+                                                                  // Keep this call separate.
+                                                                  .Equals(e.Number))
+                                                       ?.Value;
                                  }
                              }
                              """;

--- a/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
@@ -980,5 +980,94 @@ public class MethodChainAlignmentTests : FormatterTestsBase
         AssertRuleResult(input);
     }
 
+    /// <summary>
+    /// Verifies that a misaligned chain continuation inside a lambda argument is aligned to the
+    /// chain anchor when the outer chain is a conditional access expression (issue #475)
+    /// </summary>
+    [TestMethod]
+    public void MisalignedChainInsideLambdaArgumentOfConditionalAccessIsAligned()
+    {
+        // Arrange
+        const string input = """
+                             public class Class
+                             {
+                                 public void M()
+                                 {
+                                     var value = a.List.Find(e => d.Equals(e.Number.ToString()
+                                         .Trim(),
+                                                                           StringComparison.OrdinalIgnoreCase))
+                                                       ?.Value;
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                public class Class
+                                {
+                                    public void M()
+                                    {
+                                        var value = a.List.Find(e => d.Equals(e.Number.ToString()
+                                                                                      .Trim(),
+                                                                              StringComparison.OrdinalIgnoreCase))
+                                                          ?.Value;
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a wrapped chain continuation inside a plain argument keeps its alignment
+    /// when the outer chain is a conditional access expression (issue #475)
+    /// </summary>
+    [TestMethod]
+    public void ChainInsideArgumentOfConditionalAccessKeepsAlignment()
+    {
+        // Arrange
+        const string input = """
+                             public class Class
+                             {
+                                 public void M()
+                                 {
+                                     var value = a.List.Find(d.Equals(e.Number.ToString()
+                                                                              .Trim()))
+                                                       ?.Value;
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a wrapped chain continuation inside a lambda argument keeps its alignment
+    /// when the outer chain is a conditional access expression (issue #475)
+    /// </summary>
+    [TestMethod]
+    public void ChainInsideLambdaArgumentOfConditionalAccessKeepsAlignment()
+    {
+        // Arrange
+        const string input = """
+                             public class Class
+                             {
+                                 public void M()
+                                 {
+                                     var a = new A();
+                                     var d = string.Empty;
+                                     var value = a.List.Find(e => d.Equals(e.Number.ToString()
+                                                                                   .Trim(),
+                                                                           StringComparison.OrdinalIgnoreCase))
+                                                       ?.Value;
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
     #endregion // Methods
 }

--- a/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
@@ -306,7 +306,7 @@ public class MethodChainAlignmentTests : FormatterTestsBase
     /// aligned under the chain root token
     /// </summary>
     [TestMethod]
-    public void ChainWithCommentAboveFirstWrappedCallRemainsUnchanged()
+    public void ChainWithCommentAboveFirstWrappedCallAlignsUnderChainRoot()
     {
         // Arrange
         const string input = """

--- a/Reihitsu.Formatter.Test/Regression/LineBreaks/ChainInsideConditionalAccessArgumentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/LineBreaks/ChainInsideConditionalAccessArgumentTests.cs
@@ -1,0 +1,90 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Formatter.Test.Helpers;
+
+namespace Reihitsu.Formatter.Test.Regression.LineBreaks;
+
+/// <summary>
+/// Tests for <see cref="Reihitsu.Formatter.Pipeline.FormattingPipeline"/> — chain line breaks inside
+/// an argument or lambda body of a conditional access chain (issue #475)
+/// </summary>
+[TestClass]
+public class ChainInsideConditionalAccessArgumentTests : FormatterTestsBase
+{
+    #region Methods
+
+    /// <summary>
+    /// Verifies that a collapsible chain nested in a lambda argument of a conditional access chain
+    /// is rejoined onto the root line
+    /// </summary>
+    [TestMethod]
+    public void CollapsibleChainInsideLambdaArgumentOfConditionalAccessIsRejoined()
+    {
+        // Arrange
+        const string input = """
+                             public class Class
+                             {
+                                 public void M()
+                                 {
+                                     var value = a.List.Find(e => d
+                                                                   .Equals(e.Number))
+                                                       ?.Value;
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                public class Class
+                                {
+                                    public void M()
+                                    {
+                                        var value = a.List.Find(e => d.Equals(e.Number))
+                                                          ?.Value;
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a wrapped chain nested in a lambda argument of a conditional access chain is
+    /// normalized. The chain has an intermediate member access, so it stays wrapped instead of being
+    /// rejoined, and the trailing link is moved onto its own line and aligned to the first dot
+    /// </summary>
+    [TestMethod]
+    public void WrappedChainInsideLambdaArgumentOfConditionalAccessIsNormalized()
+    {
+        // Arrange
+        const string input = """
+                             public class Class
+                             {
+                                 public void M()
+                                 {
+                                     var value = a.List.Find(e => e.Number
+                                                                   .ToString().Trim())
+                                                       ?.Value;
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                public class Class
+                                {
+                                    public void M()
+                                    {
+                                        var value = a.List.Find(e => e.Number
+                                                                      .ToString()
+                                                                      .Trim())
+                                                          ?.Value;
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Formatter/Pipeline/Indentation/Contributors/MethodChainAlignmentContributor.cs
+++ b/Reihitsu.Formatter/Pipeline/Indentation/Contributors/MethodChainAlignmentContributor.cs
@@ -102,6 +102,21 @@ internal sealed class MethodChainAlignmentContributor : ILayoutContributor
         }
     }
 
+    /// <summary>
+    /// Computes the continuation column for a chain that a preceding comment keeps wrapped. Such a
+    /// chain has no first dot to align against, so the continuation dots line up with the chain root
+    /// token itself. Measuring from the root rather than from the continuation line's block
+    /// indentation keeps the chain under its root even when the root sits far into the line, for
+    /// example inside an argument or a lambda body
+    /// </summary>
+    /// <param name="node">The chain node being laid out</param>
+    /// <param name="model">The layout model</param>
+    /// <returns>The column for the chain's continuation lines</returns>
+    private static int GetCommentExemptContinuationColumn(SyntaxNode node, LayoutModel model)
+    {
+        return LayoutComputer.GetAdjustedColumn(node.GetFirstToken(), model);
+    }
+
     #endregion // Methods
 
     #region ILayoutContributor
@@ -118,7 +133,7 @@ internal sealed class MethodChainAlignmentContributor : ILayoutContributor
 
         if (ShouldKeepFirstWrappedCallOnContinuationLine(dots[0]))
         {
-            var continuationColumn = LayoutComputer.GetAdjustedColumn(dots[0], model) + FormattingContext.IndentSize;
+            var continuationColumn = GetCommentExemptContinuationColumn(node, model);
 
             foreach (var dot in dots)
             {

--- a/Reihitsu.Formatter/Pipeline/Indentation/Contributors/MethodChainAlignmentContributor.cs
+++ b/Reihitsu.Formatter/Pipeline/Indentation/Contributors/MethodChainAlignmentContributor.cs
@@ -102,34 +102,6 @@ internal sealed class MethodChainAlignmentContributor : ILayoutContributor
         }
     }
 
-    /// <summary>
-    /// Determines whether a syntax node is nested inside a <see cref="ConditionalAccessExpressionSyntax"/>.
-    /// Walks up the parent chain until a statement or member declaration is found
-    /// </summary>
-    /// <param name="node">The node to check</param>
-    /// <returns><see langword="true"/> if the node is inside a conditional access expression; otherwise, <see langword="false"/></returns>
-    private static bool IsInsideConditionalAccess(SyntaxNode node)
-    {
-        var current = node.Parent;
-
-        while (current != null)
-        {
-            if (current is ConditionalAccessExpressionSyntax)
-            {
-                return true;
-            }
-
-            if (current is StatementSyntax || current is MemberDeclarationSyntax)
-            {
-                return false;
-            }
-
-            current = current.Parent;
-        }
-
-        return false;
-    }
-
     #endregion // Methods
 
     #region ILayoutContributor
@@ -240,7 +212,7 @@ internal sealed class MethodChainAlignmentContributor : ILayoutContributor
             return true;
         }
 
-        return IsInsideConditionalAccess(invocation);
+        return ChainWalker.IsInsideConditionalAccess(invocation);
     }
 
     /// <summary>

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/ChainWalker.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/ChainWalker.cs
@@ -170,25 +170,6 @@ internal static class ChainWalker
     }
 
     /// <summary>
-    /// Determines whether a syntax node is of a kind that can form a link on an access chain spine.
-    /// This is a type test only: it does not establish that <paramref name="node"/> actually sits on
-    /// a spine, because a node of the same kind is just as reachable through an argument list or a
-    /// lambda body. The positional guarantee belongs to the caller — <see cref="IsInsideConditionalAccess"/>
-    /// only reaches this test by stepping from a known chain link to its own parent, so a step that
-    /// lands anywhere else ends the walk
-    /// </summary>
-    /// <param name="node">The node to check</param>
-    /// <returns><see langword="true"/> if the node is of a chain link kind; otherwise, <see langword="false"/></returns>
-    private static bool IsChainSpineNode(SyntaxNode node)
-    {
-        return node is MemberAccessExpressionSyntax
-                    or MemberBindingExpressionSyntax
-                    or InvocationExpressionSyntax
-                    or ElementAccessExpressionSyntax
-                    or PostfixUnaryExpressionSyntax;
-    }
-
-    /// <summary>
     /// Determines whether a syntax node is an inner link of a <see cref="ConditionalAccessExpressionSyntax"/>
     /// chain. The walk follows the chain spine only, so an expression that merely sits inside an
     /// argument, a lambda body, or another nested construct of a conditional access chain is not
@@ -420,4 +401,27 @@ internal static class ChainWalker
     }
 
     #endregion // Methods
+
+    #region Private methods
+
+    /// <summary>
+    /// Determines whether a syntax node is of a kind that can form a link on an access chain spine.
+    /// This is a type test only: it does not establish that <paramref name="node"/> actually sits on
+    /// a spine, because a node of the same kind is just as reachable through an argument list or a
+    /// lambda body. The positional guarantee belongs to the caller — <see cref="IsInsideConditionalAccess"/>
+    /// only reaches this test by stepping from a known chain link to its own parent, so a step that
+    /// lands anywhere else ends the walk
+    /// </summary>
+    /// <param name="node">The node to check</param>
+    /// <returns><see langword="true"/> if the node is of a chain link kind; otherwise, <see langword="false"/></returns>
+    private static bool IsChainSpineNode(SyntaxNode node)
+    {
+        return node is MemberAccessExpressionSyntax
+                    or MemberBindingExpressionSyntax
+                    or InvocationExpressionSyntax
+                    or ElementAccessExpressionSyntax
+                    or PostfixUnaryExpressionSyntax;
+    }
+
+    #endregion // Private methods
 }

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/ChainWalker.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/ChainWalker.cs
@@ -161,18 +161,25 @@ internal static class ChainWalker
     /// <returns><see langword="true"/> if the node is the outermost chain node; otherwise, <see langword="false"/></returns>
     public static bool IsOutermostChainNode(SyntaxNode node)
     {
-        return node.Parent is not ConditionalAccessExpressionSyntax
-               && IsChainSpineNode(node.Parent) == false;
+        return node.Parent is not MemberAccessExpressionSyntax
+               && node.Parent is not MemberBindingExpressionSyntax
+               && node.Parent is not InvocationExpressionSyntax
+               && node.Parent is not ConditionalAccessExpressionSyntax
+               && node.Parent is not ElementAccessExpressionSyntax
+               && node.Parent is not PostfixUnaryExpressionSyntax;
     }
 
     /// <summary>
-    /// Determines whether a syntax node is a link on an access chain spine. Only the spine positions
-    /// count, so a node reached through an argument list, lambda body, or other nested construct is
-    /// not a spine link
+    /// Determines whether a syntax node is of a kind that can form a link on an access chain spine.
+    /// This is a type test only: it does not establish that <paramref name="node"/> actually sits on
+    /// a spine, because a node of the same kind is just as reachable through an argument list or a
+    /// lambda body. The positional guarantee belongs to the caller — <see cref="IsInsideConditionalAccess"/>
+    /// only reaches this test by stepping from a known chain link to its own parent, so a step that
+    /// lands anywhere else ends the walk
     /// </summary>
     /// <param name="node">The node to check</param>
-    /// <returns><see langword="true"/> if the node is a chain spine link; otherwise, <see langword="false"/></returns>
-    public static bool IsChainSpineNode(SyntaxNode node)
+    /// <returns><see langword="true"/> if the node is of a chain link kind; otherwise, <see langword="false"/></returns>
+    private static bool IsChainSpineNode(SyntaxNode node)
     {
         return node is MemberAccessExpressionSyntax
                     or MemberBindingExpressionSyntax

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/ChainWalker.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/ChainWalker.cs
@@ -161,16 +161,31 @@ internal static class ChainWalker
     /// <returns><see langword="true"/> if the node is the outermost chain node; otherwise, <see langword="false"/></returns>
     public static bool IsOutermostChainNode(SyntaxNode node)
     {
-        return node.Parent is not MemberAccessExpressionSyntax
-               && node.Parent is not MemberBindingExpressionSyntax
-               && node.Parent is not InvocationExpressionSyntax
-               && node.Parent is not ConditionalAccessExpressionSyntax
-               && node.Parent is not ElementAccessExpressionSyntax
-               && node.Parent is not PostfixUnaryExpressionSyntax;
+        return node.Parent is not ConditionalAccessExpressionSyntax
+               && IsChainSpineNode(node.Parent) == false;
     }
 
     /// <summary>
-    /// Determines whether a syntax node is nested inside a <see cref="ConditionalAccessExpressionSyntax"/>
+    /// Determines whether a syntax node is a link on an access chain spine. Only the spine positions
+    /// count, so a node reached through an argument list, lambda body, or other nested construct is
+    /// not a spine link
+    /// </summary>
+    /// <param name="node">The node to check</param>
+    /// <returns><see langword="true"/> if the node is a chain spine link; otherwise, <see langword="false"/></returns>
+    public static bool IsChainSpineNode(SyntaxNode node)
+    {
+        return node is MemberAccessExpressionSyntax
+                    or MemberBindingExpressionSyntax
+                    or InvocationExpressionSyntax
+                    or ElementAccessExpressionSyntax
+                    or PostfixUnaryExpressionSyntax;
+    }
+
+    /// <summary>
+    /// Determines whether a syntax node is an inner link of a <see cref="ConditionalAccessExpressionSyntax"/>
+    /// chain. The walk follows the chain spine only, so an expression that merely sits inside an
+    /// argument, a lambda body, or another nested construct of a conditional access chain is not
+    /// treated as part of that chain (issue #475)
     /// </summary>
     /// <param name="node">The node to check</param>
     /// <returns><see langword="true"/> if the node is inside a conditional access expression; otherwise, <see langword="false"/></returns>
@@ -185,7 +200,7 @@ internal static class ChainWalker
                 return true;
             }
 
-            if (current is StatementSyntax || current is MemberDeclarationSyntax)
+            if (IsChainSpineNode(current) == false)
             {
                 return false;
             }


### PR DESCRIPTION
## Summary

`ChainWalker.IsInsideConditionalAccess` now follows the access-chain spine only instead of walking every parent up to the enclosing statement, so an invocation that merely sits inside an argument or a lambda body of a conditional-access chain is no longer treated as a link of that chain. `MethodChainAlignmentContributor` drops its duplicated copy of the check and reuses the shared helper.

Following review, a comment-exempt chain — one a preceding comment keeps wrapped — now takes its continuation column from the chain root token, so its links line up directly under the root instead of relative to the enclosing statement.

## Why

A wrapped chain continuation nested in a lambda argument lost its indentation and was dedented to method-body level. The alignment contributor skipped the inner invocation because the old walk crossed the argument and lambda boundaries and found the outer `?.` chain, so no contributor claimed the continuation line and only pass-1 block indentation was left on it.

The comment-exempt path had the same failure mode from a different direction: with no first dot to align against, it fell back to the continuation line's block indentation, which loses the chain whenever the root sits far into the line.

## Linked issues

Closes #475

## Review notes

The corrected walk also feeds `ChainWalker.IsOutermostChainInvocation`, which the line-break phase uses, so `CollapseChainToSingleLine` and `NormalizeChain` now run for chains nested in an argument or lambda of a conditional-access chain. Both paths have regression tests in `Regression/LineBreaks/ChainInsideConditionalAccessArgumentTests.cs`.

`IsChainSpineNode` is private to its single caller and `IsOutermostChainNode` keeps its own explicit node list, so widening one walk cannot silently widen the other.

The comment-exempt column change is a behavior change beyond the reported shape: it also moves plain statement-level chains, and the two fixtures that pinned the old statement-relative column were updated to the root-aligned one. The comment-exempt anchor is the root token while the normal path anchors on the first dot; the two columns differ for the same chain, which is deliberate — a comment-exempt chain has no first dot on the root line to align against.

**Known gap, not addressed here.** When a directive sits in the chain gap, a single-link chain still keeps pass-1 block indentation, because it collects one alignment dot and `Contribute` returns at `dots.Count < 2`. This is not specific to conditional compilation — `#if`/`#else` and `#pragma warning disable` in that position both produce the same column-8 continuation. It reproduces byte-identically on the base commit and without the `?.`, so it is independent of this change; closing it would mean defining a continuation column for single-link wrapped chains, which nothing currently pins.

## Follow-up work

- Define the continuation column for single-link chains that cannot be rejoined, covering any directive the rejoin refuses to join across — not `#if` alone.
