### PR TITLE
Brace multi-line switch sections ending in return or throw

### DIFF
--- a/Reihitsu.Analyzer/Rules/Spacing/RH6023AssignmentOperatorsMustBeSpacedCorrectlyAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Spacing/RH6023AssignmentOperatorsMustBeSpacedCorrectlyAnalyzer.cs
@@ -48,24 +48,32 @@ public class RH6023AssignmentOperatorsMustBeSpacedCorrectlyAnalyzer : Diagnostic
         switch (node)
         {
             case AssignmentExpressionSyntax assignmentExpression:
-                operatorToken = assignmentExpression.OperatorToken;
+                {
+                    operatorToken = assignmentExpression.OperatorToken;
 
-                return true;
+                    return true;
+                }
 
             case EqualsValueClauseSyntax equalsValueClause:
-                operatorToken = equalsValueClause.EqualsToken;
+                {
+                    operatorToken = equalsValueClause.EqualsToken;
 
-                return true;
+                    return true;
+                }
 
             case NameEqualsSyntax nameEquals:
-                operatorToken = nameEquals.EqualsToken;
+                {
+                    operatorToken = nameEquals.EqualsToken;
 
-                return true;
+                    return true;
+                }
 
             default:
-                operatorToken = default;
+                {
+                    operatorToken = default;
 
-                return false;
+                    return false;
+                }
         }
     }
 

--- a/Reihitsu.Formatter.Test/Regression/Structural/SwitchCaseBracesTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Structural/SwitchCaseBracesTests.cs
@@ -205,6 +205,114 @@ public class SwitchCaseBracesTests : FormatterTestsBase
     }
 
     /// <summary>
+    /// Verifies under LF and CRLF that a statement followed by return receives braces and remains
+    /// unchanged on a second formatting pass
+    /// </summary>
+    [TestMethod]
+    public void StatementFollowedByReturnAddsBracesAndIsIdempotent()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 int M(int value)
+                                 {
+                                     switch (value)
+                                     {
+                                         case 1:
+                                             var result = 1;
+
+                                             return result;
+
+                                         default:
+                                             return 0;
+                                     }
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    int M(int value)
+                                    {
+                                        switch (value)
+                                        {
+                                            case 1:
+                                                {
+                                                    var result = 1;
+
+                                                    return result;
+                                                }
+
+                                            default:
+                                                {
+                                                    return 0;
+                                                }
+                                        }
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies under LF and CRLF that a statement followed by throw receives braces and remains
+    /// unchanged on a second formatting pass
+    /// </summary>
+    [TestMethod]
+    public void StatementFollowedByThrowAddsBracesAndIsIdempotent()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 int M(int value)
+                                 {
+                                     switch (value)
+                                     {
+                                         case 1:
+                                             var exception = new Exception();
+
+                                             throw exception;
+
+                                         default:
+                                             return 0;
+                                     }
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    int M(int value)
+                                    {
+                                        switch (value)
+                                        {
+                                            case 1:
+                                                {
+                                                    var exception = new Exception();
+
+                                                    throw exception;
+                                                }
+
+                                            default:
+                                                {
+                                                    return 0;
+                                                }
+                                        }
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
     /// Verifies that the label trailing comment and the first statement's leading comment are
     /// preserved when braces are added to a switch section
     /// </summary>

--- a/Reihitsu.Formatter.Test/Unit/SwitchCaseBraces/SwitchCaseBraceRewriterTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/SwitchCaseBraces/SwitchCaseBraceRewriterTests.cs
@@ -373,6 +373,54 @@ public class SwitchCaseBraceRewriterTests
     }
 
     /// <summary>
+    /// Verifies that a single non-terminal statement followed by return makes the switch multi-line
+    /// and adds braces to every non-fall-through section
+    /// </summary>
+    [TestMethod]
+    public void AddsBracesWhenSingleNonTerminalStatementIsFollowedByReturn()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 bool TryGet(int value, out int result)
+                                 {
+                                     switch (value)
+                                     {
+                                         case 1:
+                                             result = 1;
+
+                                             return true;
+                                         default:
+                                             result = 0;
+
+                                             return false;
+                                     }
+                                 }
+                             }
+                             """;
+
+        // Act
+        var actual = ApplyPhase(input);
+
+        // Assert
+        var tree = CSharpSyntaxTree.ParseText(actual, cancellationToken: TestContext.CancellationToken);
+        var root = tree.GetRoot(TestContext.CancellationToken);
+        var switchStatement = root.DescendantNodes().OfType<SwitchStatementSyntax>().Single();
+
+        foreach (var section in switchStatement.Sections)
+        {
+            Assert.AreEqual(1, section.Statements.Count, "Section should have only the block.");
+            Assert.IsInstanceOfType<BlockSyntax>(section.Statements[0], "Statement should be a block.");
+
+            var block = (BlockSyntax)section.Statements[0];
+
+            Assert.AreEqual(2, block.Statements.Count, "Block should contain the assignment and return.");
+            Assert.IsInstanceOfType<ReturnStatementSyntax>(block.Statements[1], "Return should remain inside the block.");
+        }
+    }
+
+    /// <summary>
     /// Verifies that a trailing comment on the last label (for example "case 1: // note") is
     /// preserved when braces are added
     /// </summary>

--- a/Reihitsu.Formatter.Test/Unit/SwitchCaseBraces/SwitchCaseBraceRewriterTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/SwitchCaseBraces/SwitchCaseBraceRewriterTests.cs
@@ -488,6 +488,100 @@ public class SwitchCaseBraceRewriterTests
     }
 
     /// <summary>
+    /// Verifies that labels with the same name inside separate local functions are not mistaken for
+    /// cross-section goto targets
+    /// </summary>
+    [TestMethod]
+    public void AddBracesIgnoresGotoTargetsInsideLocalFunctions()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 int M(int value)
+                                 {
+                                     switch (value)
+                                     {
+                                         case 0:
+                                             int F()
+                                             {
+                                                 goto done;
+                                                 done:
+                                                 return 0;
+                                             }
+
+                                             return F();
+                                         case 1:
+                                             int G()
+                                             {
+                                                 goto done;
+                                                 done:
+                                                 return 1;
+                                             }
+
+                                             return G();
+                                     }
+                                 }
+                             }
+                             """;
+
+        // Act
+        var actual = ApplyPhase(input);
+
+        // Assert
+        var switchStatement = GetSwitchStatement(actual);
+
+        Assert.IsTrue(switchStatement.Sections.All(section => section.Statements.Single() is BlockSyntax));
+    }
+
+    /// <summary>
+    /// Verifies that labels with the same name inside separate lambdas are not mistaken for
+    /// cross-section goto targets
+    /// </summary>
+    [TestMethod]
+    public void AddBracesIgnoresGotoTargetsInsideLambdas()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 int M(int value)
+                                 {
+                                     switch (value)
+                                     {
+                                         case 0:
+                                             System.Func<int> f = () =>
+                                             {
+                                                 goto done;
+                                                 done:
+                                                 return 0;
+                                             };
+
+                                             return f();
+                                         case 1:
+                                             System.Func<int> g = () =>
+                                             {
+                                                 goto done;
+                                                 done:
+                                                 return 1;
+                                             };
+
+                                             return g();
+                                     }
+                                 }
+                             }
+                             """;
+
+        // Act
+        var actual = ApplyPhase(input);
+
+        // Assert
+        var switchStatement = GetSwitchStatement(actual);
+
+        Assert.IsTrue(switchStatement.Sections.All(section => section.Statements.Single() is BlockSyntax));
+    }
+
+    /// <summary>
     /// Verifies that a trailing comment on the last label (for example "case 1: // note") is
     /// preserved when braces are added
     /// </summary>

--- a/Reihitsu.Formatter.Test/Unit/SwitchCaseBraces/SwitchCaseBraceRewriterTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/SwitchCaseBraces/SwitchCaseBraceRewriterTests.cs
@@ -488,6 +488,51 @@ public class SwitchCaseBraceRewriterTests
     }
 
     /// <summary>
+    /// Verifies that braces are not added when a goto inside a nested switch targets a label in
+    /// another section of the outer switch
+    /// </summary>
+    [TestMethod]
+    public void DoesNotAddBracesWhenNestedSwitchGotoTargetsLabelInAnotherSection()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 int M(int value, int nestedValue)
+                                 {
+                                     switch (value)
+                                     {
+                                         case 0:
+                                             switch (nestedValue)
+                                             {
+                                                 case 0:
+                                                     goto done;
+                                                 default:
+                                                     break;
+                                             }
+
+                                             break;
+                                         case 1:
+                                             var result = 1;
+                                             return result;
+                                         default:
+                                             done:
+                                             return 0;
+                                     }
+
+                                     return -1;
+                                 }
+                             }
+                             """;
+
+        // Act
+        var actual = ApplyPhase(input);
+
+        // Assert
+        Assert.AreEqual(input, actual, "Nested-switch goto targets must prevent outer brace insertion.");
+    }
+
+    /// <summary>
     /// Verifies that labels with the same name inside separate local functions are not mistaken for
     /// cross-section goto targets
     /// </summary>

--- a/Reihitsu.Formatter.Test/Unit/SwitchCaseBraces/SwitchCaseBraceRewriterTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/SwitchCaseBraces/SwitchCaseBraceRewriterTests.cs
@@ -453,6 +453,41 @@ public class SwitchCaseBraceRewriterTests
     }
 
     /// <summary>
+    /// Verifies that braces are not added when a goto statement targets a label in another switch
+    /// section because wrapping both sections would make the target unreachable
+    /// </summary>
+    [TestMethod]
+    public void DoesNotAddBracesWhenGotoTargetsLabelInAnotherSection()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 int M(int value)
+                                 {
+                                     switch (value)
+                                     {
+                                         case 0:
+                                             goto done;
+                                         case 1:
+                                             var result = 1;
+                                             return result;
+                                         default:
+                                             done:
+                                             return 0;
+                                     }
+                                 }
+                             }
+                             """;
+
+        // Act
+        var actual = ApplyPhase(input);
+
+        // Assert
+        Assert.AreEqual(input, actual, "Cross-section goto targets must prevent brace insertion.");
+    }
+
+    /// <summary>
     /// Verifies that a trailing comment on the last label (for example "case 1: // note") is
     /// preserved when braces are added
     /// </summary>

--- a/Reihitsu.Formatter.Test/Unit/SwitchCaseBraces/SwitchCaseBraceRewriterTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/SwitchCaseBraces/SwitchCaseBraceRewriterTests.cs
@@ -421,6 +421,38 @@ public class SwitchCaseBraceRewriterTests
     }
 
     /// <summary>
+    /// Verifies that a single return statement remains brace-free when its expression spans
+    /// multiple lines
+    /// </summary>
+    [TestMethod]
+    public void DoesNotAddBracesToSingleMultiLineReturnStatement()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 bool M(int value)
+                                 {
+                                     switch (value)
+                                     {
+                                         case 1:
+                                             return value == 1
+                                                    || value == 2;
+                                         default:
+                                             return false;
+                                     }
+                                 }
+                             }
+                             """;
+
+        // Act
+        var actual = ApplyPhase(input);
+
+        // Assert — no extra braces should be added beyond the class, method, and switch
+        Assert.AreEqual(3, CountOccurrences(actual, "{"), "A single return statement should remain brace-free.");
+    }
+
+    /// <summary>
     /// Verifies that a trailing comment on the last label (for example "case 1: // note") is
     /// preserved when braces are added
     /// </summary>

--- a/Reihitsu.Formatter/Pipeline/SwitchCaseBraces/SwitchCaseBraceRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/SwitchCaseBraces/SwitchCaseBraceRewriter.cs
@@ -55,8 +55,9 @@ internal sealed class SwitchCaseBraceRewriter : CSharpSyntaxRewriter
     /// <summary>
     /// Determines whether a switch section is multi-line.
     /// A section is multi-line if its label contains a multi-line delimited pattern, it has more
-    /// than one non-break statement, a single non-break statement that spans multiple lines,
-    /// or any statement containing a multi-line switch expression
+    /// than one non-terminal statement, a single non-terminal statement that spans multiple lines,
+    /// a non-terminal statement followed by return or throw on a later line, or any statement
+    /// containing a multi-line switch expression
     /// </summary>
     /// <param name="section">The switch section to check</param>
     /// <returns><see langword="true"/> if the section is multi-line; otherwise, <see langword="false"/></returns>
@@ -67,7 +68,7 @@ internal sealed class SwitchCaseBraceRewriter : CSharpSyntaxRewriter
             return true;
         }
 
-        var statements = GetNonBreakStatements(section);
+        var statements = GetNonTerminalStatements(section);
 
         if (statements.Count > 1)
         {
@@ -76,10 +77,38 @@ internal sealed class SwitchCaseBraceRewriter : CSharpSyntaxRewriter
 
         if (statements.Count == 1)
         {
-            return SpansMultipleLines(statements[0]);
+            return SpansMultipleLines(statements[0])
+                   || HasMultiLineBodyEndingInReturnOrThrow(section);
         }
 
         return ContainsMultiLineSwitchExpression(section);
+    }
+
+    /// <summary>
+    /// Determines whether a switch section has multiple statements on separate lines and ends in
+    /// return or throw. A trailing break is intentionally excluded because it remains outside an
+    /// inserted brace block
+    /// </summary>
+    /// <param name="section">The switch section to check</param>
+    /// <returns><see langword="true"/> if the section ends in return or throw on a later line; otherwise, <see langword="false"/></returns>
+    private static bool HasMultiLineBodyEndingInReturnOrThrow(SwitchSectionSyntax section)
+    {
+        if (section.Statements.Count < 2)
+        {
+            return false;
+        }
+
+        var lastStatement = section.Statements[section.Statements.Count - 1];
+
+        if (lastStatement is not ReturnStatementSyntax and not ThrowStatementSyntax)
+        {
+            return false;
+        }
+
+        var firstStatementSpan = section.Statements[0].GetLocation().GetLineSpan();
+        var lastStatementSpan = lastStatement.GetLocation().GetLineSpan();
+
+        return firstStatementSpan.StartLinePosition.Line != lastStatementSpan.EndLinePosition.Line;
     }
 
     /// <summary>
@@ -124,16 +153,27 @@ internal sealed class SwitchCaseBraceRewriter : CSharpSyntaxRewriter
     }
 
     /// <summary>
-    /// Gets the statements that would be placed inside braces for multi-line detection.
-    /// A trailing break remains outside an inserted block, so break statements are excluded
+    /// Gets the non-terminal statements from a switch section (excludes break, return, and throw)
     /// </summary>
     /// <param name="section">The switch section</param>
-    /// <returns>A list of non-break statements</returns>
-    private static List<StatementSyntax> GetNonBreakStatements(SwitchSectionSyntax section)
+    /// <returns>A list of non-terminal statements</returns>
+    private static List<StatementSyntax> GetNonTerminalStatements(SwitchSectionSyntax section)
     {
         return section.Statements
-                      .Where(statement => statement is not BreakStatementSyntax)
+                      .Where(statement => IsTerminalStatement(statement) == false)
                       .ToList();
+    }
+
+    /// <summary>
+    /// Determines whether a statement is a terminal statement (break, return, or throw)
+    /// </summary>
+    /// <param name="statement">The statement to check</param>
+    /// <returns><see langword="true"/> if the statement is terminal; otherwise, <see langword="false"/></returns>
+    private static bool IsTerminalStatement(StatementSyntax statement)
+    {
+        return statement is BreakStatementSyntax
+               || statement is ReturnStatementSyntax
+               || statement is ThrowStatementSyntax;
     }
 
     /// <summary>

--- a/Reihitsu.Formatter/Pipeline/SwitchCaseBraces/SwitchCaseBraceRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/SwitchCaseBraces/SwitchCaseBraceRewriter.cs
@@ -138,7 +138,6 @@ internal sealed class SwitchCaseBraceRewriter : CSharpSyntaxRewriter
             {
                 if (gotoStatement.IsKind(SyntaxKind.GotoStatement)
                     && gotoStatement.Expression is IdentifierNameSyntax identifierName
-                    && gotoStatement.Ancestors().OfType<SwitchSectionSyntax>().FirstOrDefault() == section
                     && labelSections.TryGetValue(identifierName.Identifier.ValueText, out var targetSection)
                     && targetSection != section)
                 {

--- a/Reihitsu.Formatter/Pipeline/SwitchCaseBraces/SwitchCaseBraceRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/SwitchCaseBraces/SwitchCaseBraceRewriter.cs
@@ -55,7 +55,7 @@ internal sealed class SwitchCaseBraceRewriter : CSharpSyntaxRewriter
     /// <summary>
     /// Determines whether a switch section is multi-line.
     /// A section is multi-line if its label contains a multi-line delimited pattern, it has more
-    /// than one non-terminal statement, a single non-terminal statement that spans multiple lines,
+    /// than one non-break statement, a single non-break statement that spans multiple lines,
     /// or any statement containing a multi-line switch expression
     /// </summary>
     /// <param name="section">The switch section to check</param>
@@ -67,7 +67,7 @@ internal sealed class SwitchCaseBraceRewriter : CSharpSyntaxRewriter
             return true;
         }
 
-        var statements = GetNonTerminalStatements(section);
+        var statements = GetNonBreakStatements(section);
 
         if (statements.Count > 1)
         {
@@ -124,27 +124,16 @@ internal sealed class SwitchCaseBraceRewriter : CSharpSyntaxRewriter
     }
 
     /// <summary>
-    /// Gets the non-terminal statements from a switch section (excludes break, return, and throw)
+    /// Gets the statements that would be placed inside braces for multi-line detection.
+    /// A trailing break remains outside an inserted block, so break statements are excluded
     /// </summary>
     /// <param name="section">The switch section</param>
-    /// <returns>A list of non-terminal statements</returns>
-    private static List<StatementSyntax> GetNonTerminalStatements(SwitchSectionSyntax section)
+    /// <returns>A list of non-break statements</returns>
+    private static List<StatementSyntax> GetNonBreakStatements(SwitchSectionSyntax section)
     {
         return section.Statements
-                      .Where(statement => IsTerminalStatement(statement) == false)
+                      .Where(statement => statement is not BreakStatementSyntax)
                       .ToList();
-    }
-
-    /// <summary>
-    /// Determines whether a statement is a terminal statement (break, return, or throw)
-    /// </summary>
-    /// <param name="statement">The statement to check</param>
-    /// <returns><see langword="true"/> if the statement is terminal; otherwise, <see langword="false"/></returns>
-    private static bool IsTerminalStatement(StatementSyntax statement)
-    {
-        return statement is BreakStatementSyntax
-               || statement is ReturnStatementSyntax
-               || statement is ThrowStatementSyntax;
     }
 
     /// <summary>

--- a/Reihitsu.Formatter/Pipeline/SwitchCaseBraces/SwitchCaseBraceRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/SwitchCaseBraces/SwitchCaseBraceRewriter.cs
@@ -123,7 +123,7 @@ internal sealed class SwitchCaseBraceRewriter : CSharpSyntaxRewriter
 
         foreach (var section in node.Sections)
         {
-            foreach (var labeledStatement in section.DescendantNodes().OfType<LabeledStatementSyntax>())
+            foreach (var labeledStatement in GetExecutableScopeDescendants(section).OfType<LabeledStatementSyntax>())
             {
                 if (labeledStatement.Ancestors().OfType<SwitchSectionSyntax>().FirstOrDefault() == section)
                 {
@@ -134,7 +134,7 @@ internal sealed class SwitchCaseBraceRewriter : CSharpSyntaxRewriter
 
         foreach (var section in node.Sections)
         {
-            foreach (var gotoStatement in section.DescendantNodes().OfType<GotoStatementSyntax>())
+            foreach (var gotoStatement in GetExecutableScopeDescendants(section).OfType<GotoStatementSyntax>())
             {
                 if (gotoStatement.IsKind(SyntaxKind.GotoStatement)
                     && gotoStatement.Expression is IdentifierNameSyntax identifierName
@@ -148,6 +148,18 @@ internal sealed class SwitchCaseBraceRewriter : CSharpSyntaxRewriter
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Gets descendants that belong to a switch section's executable scope. Local functions and
+    /// anonymous functions own independent label scopes and are not traversed
+    /// </summary>
+    /// <param name="section">The switch section whose descendants should be enumerated</param>
+    /// <returns>The descendants in the section's executable scope</returns>
+    private static IEnumerable<SyntaxNode> GetExecutableScopeDescendants(SwitchSectionSyntax section)
+    {
+        return section.DescendantNodes(static node =>
+        node is not LocalFunctionStatementSyntax && node is not AnonymousFunctionExpressionSyntax);
     }
 
     /// <summary>

--- a/Reihitsu.Formatter/Pipeline/SwitchCaseBraces/SwitchCaseBraceRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/SwitchCaseBraces/SwitchCaseBraceRewriter.cs
@@ -112,6 +112,45 @@ internal sealed class SwitchCaseBraceRewriter : CSharpSyntaxRewriter
     }
 
     /// <summary>
+    /// Determines whether an ordinary goto statement targets a label owned by another section of
+    /// the same switch. Adding blocks in that case would make the target unreachable
+    /// </summary>
+    /// <param name="node">The switch statement to check</param>
+    /// <returns><see langword="true"/> if a goto targets a label in another section; otherwise, <see langword="false"/></returns>
+    private static bool HasCrossSectionGotoTarget(SwitchStatementSyntax node)
+    {
+        var labelSections = new Dictionary<string, SwitchSectionSyntax>();
+
+        foreach (var section in node.Sections)
+        {
+            foreach (var labeledStatement in section.DescendantNodes().OfType<LabeledStatementSyntax>())
+            {
+                if (labeledStatement.Ancestors().OfType<SwitchSectionSyntax>().FirstOrDefault() == section)
+                {
+                    labelSections[labeledStatement.Identifier.ValueText] = section;
+                }
+            }
+        }
+
+        foreach (var section in node.Sections)
+        {
+            foreach (var gotoStatement in section.DescendantNodes().OfType<GotoStatementSyntax>())
+            {
+                if (gotoStatement.IsKind(SyntaxKind.GotoStatement)
+                    && gotoStatement.Expression is IdentifierNameSyntax identifierName
+                    && gotoStatement.Ancestors().OfType<SwitchSectionSyntax>().FirstOrDefault() == section
+                    && labelSections.TryGetValue(identifierName.Identifier.ValueText, out var targetSection)
+                    && targetSection != section)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Determines whether a switch section's label contains a multi-line delimited pattern
     /// (recursive, list, or parenthesized). Combinator chains and guard clauses that merely wrap
     /// across lines do not count
@@ -502,6 +541,11 @@ internal sealed class SwitchCaseBraceRewriter : CSharpSyntaxRewriter
 
                 break;
             }
+        }
+
+        if (anyMultiLine && HasCrossSectionGotoTarget(node))
+        {
+            return node;
         }
 
         var newSections = new List<SwitchSectionSyntax>(sections.Count);


### PR DESCRIPTION
## Summary

Recognize switch sections as multi-line when a non-terminal statement is followed by `return` or `throw` on a later line, then brace non-fall-through sections consistently. Preserve cross-section `goto` targets, add LF/CRLF second-pass coverage for both terminal forms, and update the affected self-hosted analyzer source.

## Why

Terminal statements were omitted from the section-size decision, causing assignment-plus-return bodies to remain unbraced despite spanning multiple lines. Brace insertion also needs to preserve valid control flow when an ordinary `goto` targets a label owned by another switch section.

## Linked issues

Closes #476

## Review notes

A lone multi-line return and `statement + break` sections retain their existing brace-free behavior. Switches with cross-section label jumps are left unchanged; jumps inside nested switches are included when they target an outer-section label, while `goto case` and `goto default` are unaffected. Cross-section lookup ignores labels and jumps inside local functions and lambdas because they have independent executable scopes.

## Follow-up work

None.