### PR TITLE
Correct RH1001 and RH1002 equality rule documentation

### DIFF
--- a/documentation/rules/RH1001.md
+++ b/documentation/rules/RH1001.md
@@ -1,48 +1,69 @@
-﻿# RH1001 — Types used as dictionary keys or in hash sets must implement equality members
+# RH1001 — Types used as dictionary keys or in hash sets must implement equality members
 
-| Property     | Value        |
-|--------------|--------------|
-| **ID**       | RH1001       |
+| Property | Value |
+|----------|-------|
+| **ID** | RH1001 |
 | **Category** | Performance |
-| **Severity** | Warning      |
-| **Code Fix** | ✗            |
+| **Severity** | Warning |
+| **Code Fix** | ❌ |
 
 ## Description
 
-Types used as keys in `Dictionary<TKey, TValue>` or as elements in `HashSet<T>` must implement proper equality members. This rule flags types that are used in hash-based collections without overriding `Equals` and `GetHashCode`.
+Structs used as dictionary keys or set elements must provide efficient equality members.
+
+The rule covers:
+
+- `Dictionary<TKey, TValue>` and `HashSet<T>`
+- `ConcurrentDictionary<TKey, TValue>`
+- `ImmutableDictionary<TKey, TValue>` and `ImmutableHashSet<T>`
+- `FrozenDictionary<TKey, TValue>` and `FrozenSet<T>`
+
+For dictionary types, only the key type is checked. A struct used only as a dictionary value does not trigger the rule.
 
 ## Why is this a problem?
 
-Without proper `Equals` and `GetHashCode` implementations, hash-based collections fall back to reference equality. This leads to incorrect lookup behavior where logically equal objects are treated as different keys, causing duplicate entries and failed lookups. It also degrades performance due to poor hash distribution.
+A struct without its own equality implementation falls back to the default `ValueType` behavior. Hash-based collections can invoke equality and hash-code calculations many times, so boxing or runtime field inspection can add significant overhead.
 
 ## How to fix it
 
-Implement `Equals(object)`, `GetHashCode()`, and optionally `IEquatable<T>` on the type used as a dictionary key or hash set element.
+Implement `IEquatable<T>`, or override both `Equals(object)` and `GetHashCode()` on the struct used as a dictionary key or set element.
 
 ## Examples
 
 ### Violation
 
 ```cs
-public class Key
+public readonly struct CustomerId
 {
-    public int Id { get; set; }
+    public CustomerId(int value)
+    {
+        Value = value;
+    }
+
+    public int Value { get; }
 }
 
-var dict = new Dictionary<Key, string>();
+var customers = new Dictionary<CustomerId, Customer>();
 ```
 
 ### Correction
 
 ```cs
-public class Key : IEquatable<Key>
+public readonly struct CustomerId : IEquatable<CustomerId>
 {
-    public int Id { get; set; }
+    public CustomerId(int value)
+    {
+        Value = value;
+    }
 
-    public override bool Equals(object obj) => Equals(obj as Key);
+    public int Value { get; }
 
-    public bool Equals(Key other) => other != null && Id == other.Id;
+    public bool Equals(CustomerId other) => Value == other.Value;
 
-    public override int GetHashCode() => Id.GetHashCode();
+    public override bool Equals(object obj) => obj is CustomerId other && Equals(other);
+
+    public override int GetHashCode() => Value.GetHashCode();
 }
+
+var customers = new Dictionary<CustomerId, Customer>();
 ```

--- a/documentation/rules/RH1002.md
+++ b/documentation/rules/RH1002.md
@@ -1,54 +1,66 @@
-﻿# RH1002 — Types used for equality comparison must implement equality members
+# RH1002 — Types used for equality comparison must implement equality members
 
-| Property     | Value        |
-|--------------|--------------|
-| **ID**       | RH1002       |
+| Property | Value |
+|----------|-------|
+| **ID** | RH1002 |
 | **Category** | Performance |
-| **Severity** | Warning      |
-| **Code Fix** | ✗            |
+| **Severity** | Warning |
+| **Code Fix** | ❌ |
 
 ## Description
 
-Types used for equality comparison via `==`, `!=`, or `.Equals()` must implement proper equality members. This rule flags types that are compared for equality without overriding `Equals` and `GetHashCode`.
+Structs used as equality keys by hash-based LINQ and collection operations must provide efficient equality members. For selector-based overloads, this rule checks the projected key type rather than the source element type.
+
+The rule covers:
+
+- `Distinct`, `DistinctBy`, `Union`, `UnionBy`, `Intersect`, `IntersectBy`, `Except`, and `ExceptBy`
+- `ToHashSet`, `ToLookup`, `ToDictionary`, `GroupBy`, `Join`, and `GroupJoin`
+- `ToImmutableHashSet`, `ToImmutableDictionary`, `ToFrozenSet`, and `ToFrozenDictionary`
 
 ## Why is this a problem?
 
-Using `==` or `.Equals()` on types without proper equality implementations results in reference comparison instead of value comparison. This leads to subtle bugs where two logically equal objects are considered different, causing incorrect branching and hard-to-diagnose issues.
+A struct without its own equality implementation falls back to the default `ValueType` behavior. Hash-based operations can invoke equality and hash-code calculations many times, so boxing or runtime field inspection can add significant overhead.
 
 ## How to fix it
 
-Implement `Equals(object)`, `GetHashCode()`, and optionally `IEquatable<T>`. Define `operator ==` and `operator !=` for natural equality syntax.
+Implement `IEquatable<T>`, or override both `Equals(object)` and `GetHashCode()` on the struct used for equality comparison. Alternatively, pass an explicit, non-null `IEqualityComparer<T>` to the operation. Passing `null` or `default` still uses the struct's own equality behavior and does not suppress the diagnostic.
 
 ## Examples
 
 ### Violation
 
 ```cs
-public class Point
+public readonly struct CustomerId
 {
-    public int X { get; set; }
-    public int Y { get; set; }
+    public CustomerId(int value)
+    {
+        Value = value;
+    }
+
+    public int Value { get; }
 }
 
-if (point1 == point2) { } // reference comparison
+var uniqueIds = customerIds.Distinct();
 ```
 
 ### Correction
 
 ```cs
-public class Point : IEquatable<Point>
+public readonly struct CustomerId : IEquatable<CustomerId>
 {
-    public int X { get; set; }
-    public int Y { get; set; }
+    public CustomerId(int value)
+    {
+        Value = value;
+    }
 
-    public override bool Equals(object obj) => Equals(obj as Point);
+    public int Value { get; }
 
-    public bool Equals(Point other) => other != null && X == other.X && Y == other.Y;
+    public bool Equals(CustomerId other) => Value == other.Value;
 
-    public override int GetHashCode() => HashCode.Combine(X, Y);
+    public override bool Equals(object obj) => obj is CustomerId other && Equals(other);
 
-    public static bool operator ==(Point left, Point right) => Equals(left, right);
-
-    public static bool operator !=(Point left, Point right) => !Equals(left, right);
+    public override int GetHashCode() => Value.GetHashCode();
 }
+
+var uniqueIds = customerIds.Distinct();
 ```


### PR DESCRIPTION
## Summary

Correct the RH1001 and RH1002 rule pages to describe their actual struct equality-performance diagnostics. The pages now list the supported collection and API families, explain the relevant key and comparer behavior, and use matching `IEquatable<T>` struct examples.

## Why

Developers need the help pages to explain when these diagnostics are emitted and how to avoid repeated default value-type equality work in hash-based collections and operations.

## Linked issues

Closes #540

## Review notes

This is documentation-only; analyzer behavior is unchanged. RH1001 checks struct keys and set elements in seven supported collection types. RH1002 checks the equality type selected by its supported operations and exempts calls with an explicit non-null `IEqualityComparer<T>`.

## Follow-up work

None.