### PR TITLE
Align attribute placement analysis with safe joins

### DIFF
--- a/Reihitsu.Analyzer.CodeFixes/Base/TargetAttributePlacementCodeFixProviderBase.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Base/TargetAttributePlacementCodeFixProviderBase.cs
@@ -139,7 +139,7 @@ public abstract class TargetAttributePlacementCodeFixProviderBase : CodeFixProvi
             || IsAttributeListInScope(attributeList, target) == false
             || AttributeTargetUtilities.TryGetTokenAfterAttributeList(attributeList, out var tokenAfter) == false
             || SyntaxNodeUtilities.HasCommentsOrDirectives(attributeList)
-            || tokenAfter.LeadingTrivia.Any(SyntaxNodeUtilities.IsCommentOrDirective))
+            || SyntaxTriviaUtilities.WouldJoinAcrossUnjoinableTrivia(attributeList.CloseBracketToken, tokenAfter))
         {
             return false;
         }

--- a/Reihitsu.Analyzer.Test/Formatting/RH5523ParameterAttributesMustFollowPlacementRulesAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH5523ParameterAttributesMustFollowPlacementRulesAnalyzerTests.cs
@@ -127,17 +127,89 @@ public class RH5523ParameterAttributesMustFollowPlacementRulesAnalyzerTests : An
     }
 
     /// <summary>
-    /// Verifies that violations are still reported without offering an unsafe code fix when a preprocessor directive
-    /// sits between the attribute list and the parameter
+    /// Verifies that no diagnostic is reported when a comment prevents the parameter from being joined to its
+    /// attribute list
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
     [TestMethod]
-    public async Task VerifyDiagnosticWithoutCodeFixWhenDirectivesArePresent()
+    public async Task VerifyNoDiagnosticWhenCommentBlocksJoin()
     {
         const string testData = """
                                 internal class Example
                                 {
-                                    internal void M({|#0:[First]|}
+                                    internal void M([First]
+                                                    // Legacy callers pass null.
+                                                    int value) { }
+                                }
+                                sealed class FirstAttribute : System.Attribute
+                                {
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that no diagnostic is reported when a trailing comment would absorb the joined parameter
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticWhenTrailingCommentBlocksJoin()
+    {
+        const string testData = """
+                                internal class Example
+                                {
+                                    internal void M([First] // Keep this explanation.
+                                                    int value) { }
+                                }
+                                sealed class FirstAttribute : System.Attribute
+                                {
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that a stale diagnostic does not offer a code fix when a trailing comment blocks the join
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoCodeFixWhenTrailingCommentBlocksJoin()
+    {
+        const string testData = """
+                                internal class Example
+                                {
+                                    internal void M([First] // Keep this explanation.
+                                                    int value) { }
+                                }
+                                sealed class FirstAttribute : System.Attribute
+                                {
+                                }
+                                """;
+
+        var actions = await GetCodeFixActionsAsync(testData,
+                                                   RH5523ParameterAttributesMustFollowPlacementRulesAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<AttributeListSyntax>()
+                                                               .First()
+                                                               .GetLocation());
+
+        Assert.IsEmpty(actions);
+    }
+
+    /// <summary>
+    /// Verifies that no diagnostic is reported when a preprocessor directive prevents the parameter from being
+    /// joined to its attribute list
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticWhenDirectiveBlocksJoin()
+    {
+        const string testData = """
+                                internal class Example
+                                {
+                                    internal void M([First]
                                 #if FEATURE
                                 #endif
                                                     int value) { }
@@ -149,33 +221,8 @@ public class RH5523ParameterAttributesMustFollowPlacementRulesAnalyzerTests : An
                                 {
                                 }
                                 """;
-        const string codeFixData = """
-                                   internal class Example
-                                   {
-                                       internal void M([First]
-                                   #if FEATURE
-                                   #endif
-                                                       int value) { }
-                                   }
-                                   sealed class FirstAttribute : System.Attribute
-                                   {
-                                   }
-                                   sealed class SecondAttribute : System.Attribute
-                                   {
-                                   }
-                                   """;
 
-        await Verify(testData,
-                     Diagnostics(RH5523ParameterAttributesMustFollowPlacementRulesAnalyzer.DiagnosticId, AnalyzerResources.RH5523MessageFormat));
-
-        var actions = await GetCodeFixActionsAsync(codeFixData,
-                                                   RH5523ParameterAttributesMustFollowPlacementRulesAnalyzer.DiagnosticId,
-                                                   root => root.DescendantNodes()
-                                                               .OfType<AttributeListSyntax>()
-                                                               .First()
-                                                               .GetLocation());
-
-        Assert.IsEmpty(actions);
+        await Verify(testData);
     }
 
     #endregion // Tests

--- a/Reihitsu.Analyzer/Base/TargetAttributePlacementAnalyzerBase.cs
+++ b/Reihitsu.Analyzer/Base/TargetAttributePlacementAnalyzerBase.cs
@@ -75,8 +75,10 @@ public abstract class TargetAttributePlacementAnalyzerBase : AttributeTargetRule
         var hasViolation = expectedMode == TargetAttributePlacementMode.SeparateLine
                                ? closeLine == nextLine
                                : closeLine != nextLine;
+        var isBlockedSingleLineJoin = expectedMode == TargetAttributePlacementMode.SingleLine
+                                      && SyntaxTriviaUtilities.WouldJoinAcrossUnjoinableTrivia(attributeList.CloseBracketToken, tokenAfter);
 
-        if (hasViolation)
+        if (hasViolation && isBlockedSingleLineJoin == false)
         {
             context.ReportDiagnostic(CreateDiagnostic(attributeList.GetLocation()));
         }

--- a/documentation/rules/RH5523.md
+++ b/documentation/rules/RH5523.md
@@ -9,7 +9,9 @@
 
 ## Description
 
-Parameter attributes must stay inline with the parameter declaration.
+Parameter attributes must stay inline with the parameter declaration. When a comment, preprocessor directive,
+or disabled text separates the attribute list from the parameter, the rule leaves the existing line break in
+place because joining the tokens would alter or invalidate that trivia.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

Align single-line attribute-placement analysis with the formatter's safe-join behavior by exempting token gaps blocked by comments, directives, or disabled text. The code-fix base now uses the same shared Core predicate, and RH5523 has focused regression coverage plus updated documentation.

## Why

The formatter deliberately preserves trivia-blocked line breaks, but RH5523 previously continued to flag those preserved shapes even though no safe automated correction was available.

## Linked issues

Closes #488

## Review notes

The exemption applies only when a single-line placement would cross unjoinable trivia. Normal multiline parameter attributes remain diagnostic and fixable, while comments contained inside an attribute list retain their existing diagnostic-without-fix behavior.

## Follow-up work

None