### PR TITLE
Refuse reorder fixes that would relocate a directive scope

### DIFF
--- a/Reihitsu.Analyzer.CodeFixes/Base/TypeMemberOrderingCodeFixProviderBase.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Base/TypeMemberOrderingCodeFixProviderBase.cs
@@ -59,8 +59,9 @@ public abstract class TypeMemberOrderingCodeFixProviderBase : CodeFixProvider
 
     /// <summary>
     /// Determines whether moving the member before the target member preserves the meaning of the code.
-    /// The base implementation refuses moves that would scramble preprocessor directives sitting anywhere in the
-    /// affected span; derived classes can add further restrictions
+    /// The base implementation refuses moves that would relocate a preprocessor directive away from the code it
+    /// governs; a directive pair contained completely in the moved or the crossed half travels intact and is
+    /// allowed. Derived classes can add further restrictions
     /// </summary>
     /// <param name="typeDeclaration">Containing type declaration</param>
     /// <param name="memberDeclaration">Member declaration to move</param>

--- a/Reihitsu.Analyzer.CodeFixes/Base/TypeMemberOrderingCodeFixProviderBase.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Base/TypeMemberOrderingCodeFixProviderBase.cs
@@ -59,8 +59,8 @@ public abstract class TypeMemberOrderingCodeFixProviderBase : CodeFixProvider
 
     /// <summary>
     /// Determines whether moving the member before the target member preserves the meaning of the code.
-    /// The base implementation refuses moves that would scramble preprocessor directives sitting in the
-    /// affected leading trivia; derived classes can add further restrictions
+    /// The base implementation refuses moves that would scramble preprocessor directives sitting anywhere in the
+    /// affected span; derived classes can add further restrictions
     /// </summary>
     /// <param name="typeDeclaration">Containing type declaration</param>
     /// <param name="memberDeclaration">Member declaration to move</param>

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Organization/RH7107PropertyAccessorsMustFollowOrderCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Organization/RH7107PropertyAccessorsMustFollowOrderCodeFixProvider.cs
@@ -102,8 +102,9 @@ public class RH7107PropertyAccessorsMustFollowOrderCodeFixProvider : CodeFixProv
 
     /// <summary>
     /// Determines whether moving the out-of-order accessor preserves the meaning of the code. The move is
-    /// refused when a preprocessor directive sits anywhere in the affected span, since dragging the
-    /// directive along with the accessor would split a conditional-compilation pair
+    /// refused when it would relocate a preprocessor directive away from the code it governs, since that splits a
+    /// conditional-compilation pair; a directive pair contained completely in the moved or the crossed half
+    /// travels intact and is allowed
     /// </summary>
     /// <param name="memberDeclaration">Member declaration</param>
     /// <returns><see langword="true"/> if the move is safe to offer</returns>

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Organization/RH7107PropertyAccessorsMustFollowOrderCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Organization/RH7107PropertyAccessorsMustFollowOrderCodeFixProvider.cs
@@ -102,7 +102,7 @@ public class RH7107PropertyAccessorsMustFollowOrderCodeFixProvider : CodeFixProv
 
     /// <summary>
     /// Determines whether moving the out-of-order accessor preserves the meaning of the code. The move is
-    /// refused when a preprocessor directive sits in the affected leading trivia, since dragging the
+    /// refused when a preprocessor directive sits anywhere in the affected span, since dragging the
     /// directive along with the accessor would split a conditional-compilation pair
     /// </summary>
     /// <param name="memberDeclaration">Member declaration</param>

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Organization/RH7108EventAccessorsMustFollowOrderCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Organization/RH7108EventAccessorsMustFollowOrderCodeFixProvider.cs
@@ -61,8 +61,9 @@ public class RH7108EventAccessorsMustFollowOrderCodeFixProvider : CodeFixProvide
 
     /// <summary>
     /// Determines whether moving the out-of-order accessor preserves the meaning of the code. The move is
-    /// refused when a preprocessor directive sits anywhere in the affected span, since dragging the
-    /// directive along with the accessor would split a conditional-compilation pair
+    /// refused when it would relocate a preprocessor directive away from the code it governs, since that splits a
+    /// conditional-compilation pair; a directive pair contained completely in the moved or the crossed half
+    /// travels intact and is allowed
     /// </summary>
     /// <param name="eventDeclaration">Event declaration</param>
     /// <returns><see langword="true"/> if the move is safe to offer</returns>

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Organization/RH7108EventAccessorsMustFollowOrderCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Organization/RH7108EventAccessorsMustFollowOrderCodeFixProvider.cs
@@ -61,7 +61,7 @@ public class RH7108EventAccessorsMustFollowOrderCodeFixProvider : CodeFixProvide
 
     /// <summary>
     /// Determines whether moving the out-of-order accessor preserves the meaning of the code. The move is
-    /// refused when a preprocessor directive sits in the affected leading trivia, since dragging the
+    /// refused when a preprocessor directive sits anywhere in the affected span, since dragging the
     /// directive along with the accessor would split a conditional-compilation pair
     /// </summary>
     /// <param name="eventDeclaration">Event declaration</param>

--- a/Reihitsu.Analyzer.Test/Ordering/RH7102ConstantsMustAppearBeforeFieldsAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Ordering/RH7102ConstantsMustAppearBeforeFieldsAnalyzerTests.cs
@@ -46,7 +46,7 @@ public class RH7102ConstantsMustAppearBeforeFieldsAnalyzerTests : AnalyzerTestsB
 
     /// <summary>
     /// Verifying no code fix is offered when the move would separate a preprocessor directive from its partner,
-    /// leaving the region opened around the target member but closed after the moved member
+    /// with the region opening in the moved field's own leading trivia and closing after it
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
     [TestMethod]

--- a/Reihitsu.Analyzer.Test/Ordering/RH7102ConstantsMustAppearBeforeFieldsAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Ordering/RH7102ConstantsMustAppearBeforeFieldsAnalyzerTests.cs
@@ -45,7 +45,8 @@ public class RH7102ConstantsMustAppearBeforeFieldsAnalyzerTests : AnalyzerTestsB
     }
 
     /// <summary>
-    /// Verifying no code fix is offered when preprocessor directives sit in the affected leading trivia
+    /// Verifying no code fix is offered when the move would separate a preprocessor directive from its partner,
+    /// leaving the region opened around the target member but closed after the moved member
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
     [TestMethod]

--- a/Reihitsu.Analyzer.Test/Ordering/RH7103StaticElementsMustAppearBeforeInstanceElementsAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Ordering/RH7103StaticElementsMustAppearBeforeInstanceElementsAnalyzerTests.cs
@@ -161,6 +161,77 @@ public class RH7103StaticElementsMustAppearBeforeInstanceElementsAnalyzerTests :
     }
 
     /// <summary>
+    /// Verifying no code fix is offered when a preprocessor directive sits between the attribute list and the declaration keyword,
+    /// since the directive attaches to a later token and moving the member would split the conditional-compilation pair
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task NoCodeFixWhenDirectiveFollowsAttributeList()
+    {
+        const string testCode = """
+                                public class TestClass
+                                {
+                                    public void Run()
+                                    {
+                                    }
+
+                                    [System.Obsolete]
+                                #if DEBUG
+                                    public static void Create()
+                                    {
+                                    }
+                                #endif
+                                }
+                                """;
+
+        var actions = await GetCodeFixActionsAsync(testCode,
+                                                   RH7103StaticElementsMustAppearBeforeInstanceElementsAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<MethodDeclarationSyntax>()
+                                                               .Single(method => method.Identifier.ValueText == "Create")
+                                                               .Identifier
+                                                               .GetLocation(),
+                                                   "DEBUG");
+
+        Assert.IsEmpty(actions);
+    }
+
+    /// <summary>
+    /// Verifying no code fix is offered when a preprocessor directive sits between two modifiers of the moved member
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task NoCodeFixWhenDirectiveFollowsModifier()
+    {
+        const string testCode = """
+                                public class TestClass
+                                {
+                                    public void Run()
+                                    {
+                                    }
+
+                                    public
+                                #if DEBUG
+                                    static void Create()
+                                    {
+                                    }
+                                #endif
+                                }
+                                """;
+
+        var actions = await GetCodeFixActionsAsync(testCode,
+                                                   RH7103StaticElementsMustAppearBeforeInstanceElementsAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<MethodDeclarationSyntax>()
+                                                               .Single(method => method.Identifier.ValueText == "Create")
+                                                               .Identifier
+                                                               .GetLocation(),
+                                                   "DEBUG");
+
+        Assert.IsEmpty(actions);
+    }
+
+    /// <summary>
     /// Verifying RH7103 does not compare a static member against an instance member when they live in separate regions
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer.Test/Ordering/RH7103StaticElementsMustAppearBeforeInstanceElementsAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Ordering/RH7103StaticElementsMustAppearBeforeInstanceElementsAnalyzerTests.cs
@@ -197,6 +197,84 @@ public class RH7103StaticElementsMustAppearBeforeInstanceElementsAnalyzerTests :
     }
 
     /// <summary>
+    /// Verifying the code fix stays available when a crossed member carries a conditional directive pair completely
+    /// inside its own body, since the pair stays intact and the moved member is outside it before and after the move
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task CodeFixIsOfferedWhenCrossedMemberBodyContainsBalancedConditional()
+    {
+        const string testCode = """
+                                public class TestClass
+                                {
+                                    public void Run()
+                                    {
+                                #if DEBUG
+                                        System.Console.WriteLine();
+                                #endif
+                                    }
+
+                                    public static void {|#0:Create|}()
+                                    {
+                                    }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 public class TestClass
+                                 {
+                                     public static void Create()
+                                     {
+                                     }
+                                     public void Run()
+                                     {
+                                 #if DEBUG
+                                         System.Console.WriteLine();
+                                 #endif
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH7103StaticElementsMustAppearBeforeInstanceElementsAnalyzer.DiagnosticId, AnalyzerResources.RH7103MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying the code fix stays available when the crossed member's conditional directive pair is active,
+    /// so the guard decides on the directive trivia rather than on whether the enclosed code is compiled
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task CodeFixIsOfferedWhenCrossedMemberBodyContainsActiveBalancedConditional()
+    {
+        const string testCode = """
+                                public class TestClass
+                                {
+                                    public void Run()
+                                    {
+                                #if DEBUG
+                                        System.Console.WriteLine();
+                                #endif
+                                    }
+
+                                    public static void Create()
+                                    {
+                                    }
+                                }
+                                """;
+
+        var actions = await GetCodeFixActionsAsync(testCode,
+                                                   RH7103StaticElementsMustAppearBeforeInstanceElementsAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<MethodDeclarationSyntax>()
+                                                               .Single(method => method.Identifier.ValueText == "Create")
+                                                               .Identifier
+                                                               .GetLocation(),
+                                                   "DEBUG");
+
+        Assert.HasCount(1, actions);
+    }
+
+    /// <summary>
     /// Verifying no code fix is offered when a preprocessor directive sits between two modifiers of the moved member
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer.Test/Ordering/RH7103StaticElementsMustAppearBeforeInstanceElementsAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Ordering/RH7103StaticElementsMustAppearBeforeInstanceElementsAnalyzerTests.cs
@@ -133,7 +133,8 @@ public class RH7103StaticElementsMustAppearBeforeInstanceElementsAnalyzerTests :
     }
 
     /// <summary>
-    /// Verifying no code fix is offered when preprocessor directives sit in the affected leading trivia
+    /// Verifying no code fix is offered when the move would separate a preprocessor directive from its partner,
+    /// leaving the region opened around the target member but closed after the moved member
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
     [TestMethod]

--- a/Reihitsu.Analyzer.Test/Ordering/RH7107PropertyAccessorsMustFollowOrderAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Ordering/RH7107PropertyAccessorsMustFollowOrderAnalyzerTests.cs
@@ -63,8 +63,8 @@ public class RH7107PropertyAccessorsMustFollowOrderAnalyzerTests : AnalyzerTests
     }
 
     /// <summary>
-    /// Verifying no code fix is offered when a preprocessor directive sits in the affected leading trivia,
-    /// since moving the accessor would split the conditional-compilation pair
+    /// Verifying no code fix is offered when the move would separate a preprocessor directive from its partner,
+    /// with the conditional opened around the target accessor and closed before the moved accessor
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
     [TestMethod]

--- a/Reihitsu.Analyzer.Test/Ordering/RH7107PropertyAccessorsMustFollowOrderAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Ordering/RH7107PropertyAccessorsMustFollowOrderAnalyzerTests.cs
@@ -100,5 +100,45 @@ public class RH7107PropertyAccessorsMustFollowOrderAnalyzerTests : AnalyzerTests
         Assert.IsEmpty(actions);
     }
 
+    /// <summary>
+    /// Verifying no code fix is offered when a preprocessor directive sits between the accessor attribute list and the
+    /// accessor keyword, since the directive attaches to a later token and moving the accessor would split the pair
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task NoCodeFixWhenDirectiveFollowsAccessorAttributeList()
+    {
+        const string testCode = """
+                                public class TestClass
+                                {
+                                    public int X
+                                    {
+                                        set
+                                        {
+                                        }
+
+                                        [System.Obsolete]
+                                #if DEBUG
+                                        get
+                                        {
+                                            return 0;
+                                        }
+                                #endif
+                                    }
+                                }
+                                """;
+
+        var actions = await GetCodeFixActionsAsync(testCode,
+                                                   RH7107PropertyAccessorsMustFollowOrderAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<AccessorDeclarationSyntax>()
+                                                               .Single(accessor => accessor.Kind() == SyntaxKind.GetAccessorDeclaration)
+                                                               .Keyword
+                                                               .GetLocation(),
+                                                   "DEBUG");
+
+        Assert.IsEmpty(actions);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Ordering/RH7108EventAccessorsMustFollowOrderAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Ordering/RH7108EventAccessorsMustFollowOrderAnalyzerTests.cs
@@ -115,5 +115,50 @@ public class RH7108EventAccessorsMustFollowOrderAnalyzerTests : AnalyzerTestsBas
         Assert.IsEmpty(actions);
     }
 
+    /// <summary>
+    /// Verifying no code fix is offered when a preprocessor directive sits between the accessor attribute list and the
+    /// accessor keyword, since the directive attaches to a later token and moving the accessor would split the pair
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task NoCodeFixWhenDirectiveFollowsAccessorAttributeList()
+    {
+        const string testCode = """
+                                using System;
+
+                                public class TestClass
+                                {
+                                    private EventHandler _changed;
+
+                                    public event EventHandler Changed
+                                    {
+                                        remove
+                                        {
+                                            _changed -= value;
+                                        }
+
+                                        [Obsolete]
+                                #if DEBUG
+                                        add
+                                        {
+                                            _changed += value;
+                                        }
+                                #endif
+                                    }
+                                }
+                                """;
+
+        var actions = await GetCodeFixActionsAsync(testCode,
+                                                   RH7108EventAccessorsMustFollowOrderAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<AccessorDeclarationSyntax>()
+                                                               .Single(accessor => accessor.Kind() == SyntaxKind.AddAccessorDeclaration)
+                                                               .Keyword
+                                                               .GetLocation(),
+                                                   "DEBUG");
+
+        Assert.IsEmpty(actions);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Ordering/RH7108EventAccessorsMustFollowOrderAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Ordering/RH7108EventAccessorsMustFollowOrderAnalyzerTests.cs
@@ -73,8 +73,8 @@ public class RH7108EventAccessorsMustFollowOrderAnalyzerTests : AnalyzerTestsBas
     }
 
     /// <summary>
-    /// Verifying no code fix is offered when a preprocessor directive sits in the affected leading trivia,
-    /// since moving the accessor would split the conditional-compilation pair
+    /// Verifying no code fix is offered when the move would separate a preprocessor directive from its partner,
+    /// with the conditional opened around the target accessor and closed before the moved accessor
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
     [TestMethod]

--- a/Reihitsu.Analyzer.Test/Ordering/RH7109ReadonlyElementsMustAppearBeforeNonReadonlyElementsAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Ordering/RH7109ReadonlyElementsMustAppearBeforeNonReadonlyElementsAnalyzerTests.cs
@@ -102,7 +102,8 @@ public class RH7109ReadonlyElementsMustAppearBeforeNonReadonlyElementsAnalyzerTe
     }
 
     /// <summary>
-    /// Verifying no code fix is offered when preprocessor directives sit in the affected leading trivia
+    /// Verifying no code fix is offered when the move would separate a preprocessor directive from its partner,
+    /// leaving the region opened around the target member but closed after the moved member
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
     [TestMethod]

--- a/Reihitsu.Analyzer.Test/Ordering/RH7109ReadonlyElementsMustAppearBeforeNonReadonlyElementsAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Ordering/RH7109ReadonlyElementsMustAppearBeforeNonReadonlyElementsAnalyzerTests.cs
@@ -103,7 +103,7 @@ public class RH7109ReadonlyElementsMustAppearBeforeNonReadonlyElementsAnalyzerTe
 
     /// <summary>
     /// Verifying no code fix is offered when the move would separate a preprocessor directive from its partner,
-    /// leaving the region opened around the target member but closed after the moved member
+    /// with the region opening in the moved field's own leading trivia and closing after it
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
     [TestMethod]

--- a/Reihitsu.Core.Test/AccessorOrderingUtilitiesTests.cs
+++ b/Reihitsu.Core.Test/AccessorOrderingUtilitiesTests.cs
@@ -156,7 +156,42 @@ public class AccessorOrderingUtilitiesTests
     }
 
     /// <summary>
-    /// Verifies that a preprocessor directive inside the body of a crossed accessor is detected
+    /// Verifies that a conditional directive pair contained completely inside the body of a crossed accessor does
+    /// not block the move
+    /// </summary>
+    [TestMethod]
+    public void MoveRangeContainsDirectivesReturnsFalseWhenCrossedAccessorBodyContainsBalancedConditional()
+    {
+        var accessorList = CoreSyntaxTestHelper.GetSingleNode<AccessorListSyntax>("""
+                                                                                  internal class Sample
+                                                                                  {
+                                                                                      public int Value
+                                                                                      {
+                                                                                          set
+                                                                                          {
+                                                                                  #if DEBUG
+                                                                                              Log(value);
+                                                                                  #endif
+                                                                                          }
+
+                                                                                          get
+                                                                                          {
+                                                                                              return 0;
+                                                                                          }
+                                                                                      }
+                                                                                  }
+                                                                                  """);
+        var setAccessor = accessorList.Accessors[0];
+        var getAccessor = accessorList.Accessors[1];
+
+        var result = AccessorOrderingUtilities.MoveRangeContainsDirectives(accessorList, getAccessor, setAccessor);
+
+        Assert.IsFalse(result);
+    }
+
+    /// <summary>
+    /// Verifies that a position sensitive directive inside the body of a crossed accessor is detected.
+    /// <c>#pragma</c> applies from its own position onwards, so the guard cannot prove the move keeps its coverage
     /// </summary>
     [TestMethod]
     public void MoveRangeContainsDirectivesReturnsTrueWhenCrossedAccessorBodyContainsDirective()

--- a/Reihitsu.Core.Test/AccessorOrderingUtilitiesTests.cs
+++ b/Reihitsu.Core.Test/AccessorOrderingUtilitiesTests.cs
@@ -122,6 +122,73 @@ public class AccessorOrderingUtilitiesTests
     }
 
     /// <summary>
+    /// Verifies that a preprocessor directive placed between an accessor attribute list and the accessor keyword is detected.
+    /// The directive attaches to a token after the first token of the accessor, so it is invisible to a leading-trivia-only scan
+    /// </summary>
+    [TestMethod]
+    public void MoveRangeContainsDirectivesReturnsTrueWhenDirectiveFollowsAttributeList()
+    {
+        var accessorList = CoreSyntaxTestHelper.GetSingleNode<AccessorListSyntax>("""
+                                                                                  internal class Sample
+                                                                                  {
+                                                                                      public int Value
+                                                                                      {
+                                                                                          set
+                                                                                          {
+                                                                                          }
+
+                                                                                          [System.Obsolete]
+                                                                                  #if !DEBUG
+                                                                                          get
+                                                                                          {
+                                                                                              return 0;
+                                                                                          }
+                                                                                  #endif
+                                                                                      }
+                                                                                  }
+                                                                                  """);
+        var setAccessor = accessorList.Accessors[0];
+        var getAccessor = accessorList.Accessors[1];
+
+        var result = AccessorOrderingUtilities.MoveRangeContainsDirectives(accessorList, getAccessor, setAccessor);
+
+        Assert.IsTrue(result);
+    }
+
+    /// <summary>
+    /// Verifies that a preprocessor directive inside the body of a crossed accessor is detected
+    /// </summary>
+    [TestMethod]
+    public void MoveRangeContainsDirectivesReturnsTrueWhenCrossedAccessorBodyContainsDirective()
+    {
+        var accessorList = CoreSyntaxTestHelper.GetSingleNode<AccessorListSyntax>("""
+                                                                                  internal class Sample
+                                                                                  {
+                                                                                      public int Value
+                                                                                      {
+                                                                                          set
+                                                                                          {
+                                                                                  #pragma warning disable CS0219
+                                                                                              var unused = value;
+                                                                                  #pragma warning restore CS0219
+                                                                                          }
+
+                                                                                          get
+                                                                                          {
+                                                                                              return 0;
+                                                                                          }
+                                                                                      }
+                                                                                  }
+                                                                                  """);
+        var setAccessor = accessorList.Accessors[0];
+        var getAccessor = accessorList.Accessors[1];
+
+        var result = AccessorOrderingUtilities.MoveRangeContainsDirectives(accessorList, getAccessor, setAccessor);
+
+        Assert.IsTrue(result);
+    }
+
+    /// <summary>
     /// Verifies that an accessor list without preprocessor directives is reported as safe to move
     /// </summary>
     [TestMethod]

--- a/Reihitsu.Core.Test/OrderingDeclarationUtilitiesTests.cs
+++ b/Reihitsu.Core.Test/OrderingDeclarationUtilitiesTests.cs
@@ -228,8 +228,131 @@ public class OrderingDeclarationUtilitiesTests
     }
 
     /// <summary>
-    /// Verifies that a preprocessor directive inside the body of a crossed member is detected.
-    /// The member is jumped over by the move, so the moved member changes sides relative to the directive
+    /// Verifies that a conditional directive pair contained completely inside the body of a crossed member does not
+    /// block the move. The pair stays intact and the moved member is outside it before and after the move
+    /// </summary>
+    [TestMethod]
+    public void MoveRangeContainsDirectivesReturnsFalseWhenCrossedMemberBodyContainsBalancedConditional()
+    {
+        var typeDeclaration = CoreSyntaxTestHelper.GetSingleTypeDeclaration("""
+                                                                            internal class Sample
+                                                                            {
+                                                                                private void First()
+                                                                                {
+                                                                            #if DEBUG
+                                                                                    Log();
+                                                                            #endif
+                                                                                }
+
+                                                                                private static void Second()
+                                                                                {
+                                                                                }
+                                                                            }
+                                                                            """);
+        var firstMethod = typeDeclaration.Members[0];
+        var secondMethod = typeDeclaration.Members[1];
+
+        var result = OrderingDeclarationUtilities.MoveRangeContainsDirectives(typeDeclaration, secondMethod, firstMethod);
+
+        Assert.IsFalse(result);
+    }
+
+    /// <summary>
+    /// Verifies that a conditional directive pair contained completely inside the body of the moved member does not
+    /// block the move, since the pair travels together with the member
+    /// </summary>
+    [TestMethod]
+    public void MoveRangeContainsDirectivesReturnsFalseWhenMovedMemberBodyContainsBalancedConditional()
+    {
+        var typeDeclaration = CoreSyntaxTestHelper.GetSingleTypeDeclaration("""
+                                                                            internal class Sample
+                                                                            {
+                                                                                private void First()
+                                                                                {
+                                                                                }
+
+                                                                                private static void Second()
+                                                                                {
+                                                                            #if DEBUG
+                                                                                    Log();
+                                                                            #endif
+                                                                                }
+                                                                            }
+                                                                            """);
+        var firstMethod = typeDeclaration.Members[0];
+        var secondMethod = typeDeclaration.Members[1];
+
+        var result = OrderingDeclarationUtilities.MoveRangeContainsDirectives(typeDeclaration, secondMethod, firstMethod);
+
+        Assert.IsFalse(result);
+    }
+
+    /// <summary>
+    /// Verifies that a region pair contained completely inside a crossed nested type does not block the move
+    /// </summary>
+    [TestMethod]
+    public void MoveRangeContainsDirectivesReturnsFalseWhenCrossedMemberContainsBalancedRegion()
+    {
+        var typeDeclaration = CoreSyntaxTestHelper.GetSingleTypeDeclaration("""
+                                                                            internal class Sample
+                                                                            {
+                                                                                private void First()
+                                                                                {
+                                                                            #region Body
+
+                                                                                    Log();
+
+                                                                            #endregion
+                                                                                }
+
+                                                                                private static void Second()
+                                                                                {
+                                                                                }
+                                                                            }
+                                                                            """);
+        var firstMethod = typeDeclaration.Members[0];
+        var secondMethod = typeDeclaration.Members[1];
+
+        var result = OrderingDeclarationUtilities.MoveRangeContainsDirectives(typeDeclaration, secondMethod, firstMethod);
+
+        Assert.IsFalse(result);
+    }
+
+    /// <summary>
+    /// Verifies that a conditional directive whose partner sits outside the moved member blocks the move
+    /// </summary>
+    [TestMethod]
+    public void MoveRangeContainsDirectivesReturnsTrueWhenMovedMemberBodyContainsUnbalancedConditional()
+    {
+        var typeDeclaration = CoreSyntaxTestHelper.GetSingleTypeDeclaration("""
+                                                                            internal class Sample
+                                                                            {
+                                                                                private void First()
+                                                                                {
+                                                                                }
+
+                                                                                private static void Second()
+                                                                                {
+                                                                            #if !DEBUG
+                                                                                }
+
+                                                                                private void Third()
+                                                                                {
+                                                                                }
+                                                                            #endif
+                                                                            }
+                                                                            """);
+        var firstMethod = typeDeclaration.Members[0];
+        var secondMethod = typeDeclaration.Members[1];
+
+        var result = OrderingDeclarationUtilities.MoveRangeContainsDirectives(typeDeclaration, secondMethod, firstMethod);
+
+        Assert.IsTrue(result);
+    }
+
+    /// <summary>
+    /// Verifies that a position sensitive directive inside the body of a crossed member is detected.
+    /// <c>#pragma</c> applies from its own position onwards, so the guard cannot prove the move keeps its coverage
     /// </summary>
     [TestMethod]
     public void MoveRangeContainsDirectivesReturnsTrueWhenCrossedMemberBodyContainsDirective()

--- a/Reihitsu.Core.Test/OrderingDeclarationUtilitiesTests.cs
+++ b/Reihitsu.Core.Test/OrderingDeclarationUtilitiesTests.cs
@@ -143,6 +143,181 @@ public class OrderingDeclarationUtilitiesTests
     }
 
     /// <summary>
+    /// Verifies that a preprocessor directive in the leading trivia of a crossed member is detected
+    /// </summary>
+    [TestMethod]
+    public void MoveRangeContainsDirectivesReturnsTrueWhenLeadingTriviaContainsDirective()
+    {
+        var typeDeclaration = CoreSyntaxTestHelper.GetSingleTypeDeclaration("""
+                                                                            internal class Sample
+                                                                            {
+                                                                            #region Fields
+
+                                                                                private int _instance;
+
+                                                                                private static int _static;
+
+                                                                            #endregion
+                                                                            }
+                                                                            """);
+        var instanceField = typeDeclaration.Members[0];
+        var staticField = typeDeclaration.Members[1];
+
+        var result = OrderingDeclarationUtilities.MoveRangeContainsDirectives(typeDeclaration, staticField, instanceField);
+
+        Assert.IsTrue(result);
+    }
+
+    /// <summary>
+    /// Verifies that a preprocessor directive placed between an attribute list and the declaration keyword is detected.
+    /// The directive attaches to a token after the first token of the member, so it is invisible to a leading-trivia-only scan
+    /// </summary>
+    [TestMethod]
+    public void MoveRangeContainsDirectivesReturnsTrueWhenDirectiveFollowsAttributeList()
+    {
+        var typeDeclaration = CoreSyntaxTestHelper.GetSingleTypeDeclaration("""
+                                                                            internal class Sample
+                                                                            {
+                                                                                private void First()
+                                                                                {
+                                                                                }
+
+                                                                                [System.Obsolete]
+                                                                            #if !DEBUG
+                                                                                private static void Second()
+                                                                                {
+                                                                                }
+                                                                            #endif
+                                                                            }
+                                                                            """);
+        var firstMethod = typeDeclaration.Members[0];
+        var secondMethod = typeDeclaration.Members[1];
+
+        var result = OrderingDeclarationUtilities.MoveRangeContainsDirectives(typeDeclaration, secondMethod, firstMethod);
+
+        Assert.IsTrue(result);
+    }
+
+    /// <summary>
+    /// Verifies that a preprocessor directive placed between two modifiers is detected
+    /// </summary>
+    [TestMethod]
+    public void MoveRangeContainsDirectivesReturnsTrueWhenDirectiveFollowsModifier()
+    {
+        var typeDeclaration = CoreSyntaxTestHelper.GetSingleTypeDeclaration("""
+                                                                            internal class Sample
+                                                                            {
+                                                                                private void First()
+                                                                                {
+                                                                                }
+
+                                                                                private
+                                                                            #region Second
+                                                                                static void Second()
+                                                                                {
+                                                                                }
+                                                                            #endregion
+                                                                            }
+                                                                            """);
+        var firstMethod = typeDeclaration.Members[0];
+        var secondMethod = typeDeclaration.Members[1];
+
+        var result = OrderingDeclarationUtilities.MoveRangeContainsDirectives(typeDeclaration, secondMethod, firstMethod);
+
+        Assert.IsTrue(result);
+    }
+
+    /// <summary>
+    /// Verifies that a preprocessor directive inside the body of a crossed member is detected.
+    /// The member is jumped over by the move, so the moved member changes sides relative to the directive
+    /// </summary>
+    [TestMethod]
+    public void MoveRangeContainsDirectivesReturnsTrueWhenCrossedMemberBodyContainsDirective()
+    {
+        var typeDeclaration = CoreSyntaxTestHelper.GetSingleTypeDeclaration("""
+                                                                            internal class Sample
+                                                                            {
+                                                                                private void First()
+                                                                                {
+                                                                            #pragma warning disable CS0219
+                                                                                    var unused = 0;
+                                                                            #pragma warning restore CS0219
+                                                                                }
+
+                                                                                private static void Second()
+                                                                                {
+                                                                                }
+                                                                            }
+                                                                            """);
+        var firstMethod = typeDeclaration.Members[0];
+        var secondMethod = typeDeclaration.Members[1];
+
+        var result = OrderingDeclarationUtilities.MoveRangeContainsDirectives(typeDeclaration, secondMethod, firstMethod);
+
+        Assert.IsTrue(result);
+    }
+
+    /// <summary>
+    /// Verifies that a directive on a member outside the moved range does not block the move,
+    /// so the widened scan stays limited to the members the move actually touches
+    /// </summary>
+    [TestMethod]
+    public void MoveRangeContainsDirectivesReturnsFalseWhenDirectiveSitsOutsideTheMovedRange()
+    {
+        var typeDeclaration = CoreSyntaxTestHelper.GetSingleTypeDeclaration("""
+                                                                            internal class Sample
+                                                                            {
+                                                                                private void First()
+                                                                                {
+                                                                                }
+
+                                                                                private static void Second()
+                                                                                {
+                                                                                }
+
+                                                                            #region Untouched
+
+                                                                                private int _untouched;
+
+                                                                            #endregion
+                                                                            }
+                                                                            """);
+        var firstMethod = typeDeclaration.Members[0];
+        var secondMethod = typeDeclaration.Members[1];
+
+        var result = OrderingDeclarationUtilities.MoveRangeContainsDirectives(typeDeclaration, secondMethod, firstMethod);
+
+        Assert.IsFalse(result);
+    }
+
+    /// <summary>
+    /// Verifies that a type declaration without preprocessor directives is reported as safe to reorder
+    /// </summary>
+    [TestMethod]
+    public void MoveRangeContainsDirectivesReturnsFalseWhenNoDirectivesArePresent()
+    {
+        var typeDeclaration = CoreSyntaxTestHelper.GetSingleTypeDeclaration("""
+                                                                            internal class Sample
+                                                                            {
+                                                                                [System.Obsolete]
+                                                                                private void First()
+                                                                                {
+                                                                                }
+
+                                                                                private static void Second()
+                                                                                {
+                                                                                }
+                                                                            }
+                                                                            """);
+        var firstMethod = typeDeclaration.Members[0];
+        var secondMethod = typeDeclaration.Members[1];
+
+        var result = OrderingDeclarationUtilities.MoveRangeContainsDirectives(typeDeclaration, secondMethod, firstMethod);
+
+        Assert.IsFalse(result);
+    }
+
+    /// <summary>
     /// Verifies that moving a static member past a static event field initializer is flagged as changing initializer execution order
     /// </summary>
     [TestMethod]

--- a/Reihitsu.Core.Test/SyntaxTriviaUtilitiesTests.cs
+++ b/Reihitsu.Core.Test/SyntaxTriviaUtilitiesTests.cs
@@ -308,6 +308,62 @@ public class SyntaxTriviaUtilitiesTests
     }
 
     /// <summary>
+    /// Verifies that a region directive pair contained in the span is treated as balanced
+    /// </summary>
+    [TestMethod]
+    public void ContainsUnbalancedRegionDirectivesReturnsFalseForCompletePair()
+    {
+        const string source = "class C\n{\n#region Methods\n    void M()\n    {\n    }\n#endregion\n}\n";
+
+        var start = source.IndexOf("#region", StringComparison.Ordinal);
+        var end = source.IndexOf("#endregion", StringComparison.Ordinal) + "#endregion".Length;
+
+        Assert.IsFalse(ContainsUnbalancedRegionDirectives(source, start, end));
+    }
+
+    /// <summary>
+    /// Verifies that a span without any region directive is treated as balanced
+    /// </summary>
+    [TestMethod]
+    public void ContainsUnbalancedRegionDirectivesReturnsFalseWithoutRegionDirectives()
+    {
+        const string source = "class C\n{\n#if DEBUG\n    void M()\n    {\n    }\n#endif\n}\n";
+
+        Assert.IsFalse(ContainsUnbalancedRegionDirectives(source, 0, source.Length));
+    }
+
+    /// <summary>
+    /// Verifies that an opening region directive without its closing partner is reported
+    /// </summary>
+    [TestMethod]
+    public void ContainsUnbalancedRegionDirectivesReturnsTrueForUnclosedRegionDirective()
+    {
+        const string source = "class C\n{\n#region Methods\n    void M()\n    {\n    }\n#endregion\n}\n";
+
+        Assert.IsTrue(ContainsUnbalancedRegionDirectives(source, source.IndexOf("#region", StringComparison.Ordinal), source.IndexOf("#endregion", StringComparison.Ordinal)));
+    }
+
+    /// <summary>
+    /// Verifies that a closing region directive without its opening partner is reported
+    /// </summary>
+    [TestMethod]
+    public void ContainsUnbalancedRegionDirectivesReturnsTrueForUnopenedEndRegionDirective()
+    {
+        const string source = "class C\n{\n#region Methods\n    void M()\n    {\n    }\n#endregion\n}\n";
+
+        Assert.IsTrue(ContainsUnbalancedRegionDirectives(source, source.IndexOf("void", StringComparison.Ordinal), source.Length));
+    }
+
+    /// <summary>
+    /// Verifies that an unusable root refuses the move instead of reporting balanced region directives
+    /// </summary>
+    [TestMethod]
+    public void ContainsUnbalancedRegionDirectivesReturnsTrueForMissingRoot()
+    {
+        Assert.IsTrue(SyntaxTriviaUtilities.ContainsUnbalancedRegionDirectives(null, TextSpan.FromBounds(0, 1)));
+    }
+
+    /// <summary>
     /// Verifies that a pragma warning directive is reported as position sensitive
     /// </summary>
     [TestMethod]
@@ -543,6 +599,18 @@ public class SyntaxTriviaUtilitiesTests
     private static bool ContainsUnbalancedConditionalDirectives(string source, int start, int end)
     {
         return SyntaxTriviaUtilities.ContainsUnbalancedConditionalDirectives(GetRoot(source), TextSpan.FromBounds(start, end));
+    }
+
+    /// <summary>
+    /// Parses the source and checks the requested span for unbalanced region directives
+    /// </summary>
+    /// <param name="source">Source text</param>
+    /// <param name="start">Start of the span to inspect</param>
+    /// <param name="end">End of the span to inspect</param>
+    /// <returns><see langword="true"/> if the span contains an unbalanced region directive</returns>
+    private static bool ContainsUnbalancedRegionDirectives(string source, int start, int end)
+    {
+        return SyntaxTriviaUtilities.ContainsUnbalancedRegionDirectives(GetRoot(source), TextSpan.FromBounds(start, end));
     }
 
     /// <summary>

--- a/Reihitsu.Core.Test/SyntaxTriviaUtilitiesTests.cs
+++ b/Reihitsu.Core.Test/SyntaxTriviaUtilitiesTests.cs
@@ -355,6 +355,18 @@ public class SyntaxTriviaUtilitiesTests
     }
 
     /// <summary>
+    /// Verifies that a conditional branch directive detached from its opener does not trip the region predicate.
+    /// Regions have no <c>#elif</c>/<c>#else</c> equivalent, so the detached-branch refusal is conditional-only
+    /// </summary>
+    [TestMethod]
+    public void ContainsUnbalancedRegionDirectivesReturnsFalseForDetachedElseDirective()
+    {
+        const string source = "class C\n{\n#if DEBUG\n    void M()\n    {\n    }\n#else\n    void N()\n    {\n    }\n#endif\n}\n";
+
+        Assert.IsFalse(ContainsUnbalancedRegionDirectives(source, source.IndexOf("#else", StringComparison.Ordinal), source.Length));
+    }
+
+    /// <summary>
     /// Verifies that an unusable root refuses the move instead of reporting balanced region directives
     /// </summary>
     [TestMethod]

--- a/Reihitsu.Core/AccessorOrderingUtilities.cs
+++ b/Reihitsu.Core/AccessorOrderingUtilities.cs
@@ -79,40 +79,18 @@ public static class AccessorOrderingUtilities
     }
 
     /// <summary>
-    /// Determines whether a preprocessor directive sits anywhere in the span affected by moving an accessor.
-    /// The accessor is moved together with its trivia and jumps over every accessor in between, so directives such as
-    /// <c>#if</c> or <c>#endif</c> would otherwise be dragged to the new position or end up on the other side of the
-    /// moved accessor, splitting a conditional-compilation pair.
-    /// The whole span of each accessor in the range is inspected rather than only the leading trivia of its first
-    /// token, because a directive placed after an attribute list or a modifier attaches to a later token and would
-    /// otherwise stay invisible to the guard
+    /// Determines whether moving an accessor before another accessor would relocate a preprocessor directive away
+    /// from the code it governs, splitting a conditional-compilation pair or scrambling region structure.
+    /// The analysis is shared with the type member guard through
+    /// <see cref="OrderingMoveSafety.MoveRangeContainsDirectives{TNode}"/>
     /// </summary>
     /// <param name="accessorList">Accessor list</param>
     /// <param name="accessorToMove">Accessor to move</param>
     /// <param name="targetAccessor">Target accessor</param>
-    /// <returns><see langword="true"/> if a preprocessor directive sits in the affected span</returns>
+    /// <returns><see langword="true"/> if the move would relocate a preprocessor directive</returns>
     public static bool MoveRangeContainsDirectives(AccessorListSyntax accessorList, AccessorDeclarationSyntax accessorToMove, AccessorDeclarationSyntax targetAccessor)
     {
-        var accessorDeclarations = accessorList.Accessors;
-        var accessorToMoveIndex = accessorDeclarations.IndexOf(accessorToMove);
-        var targetAccessorIndex = accessorDeclarations.IndexOf(targetAccessor);
-
-        if (accessorToMoveIndex < 0
-            || targetAccessorIndex < 0
-            || accessorToMoveIndex <= targetAccessorIndex)
-        {
-            return false;
-        }
-
-        for (var index = targetAccessorIndex; index <= accessorToMoveIndex; index++)
-        {
-            if (accessorDeclarations[index].ContainsDirectives)
-            {
-                return true;
-            }
-        }
-
-        return false;
+        return OrderingMoveSafety.MoveRangeContainsDirectives(accessorList, accessorList.Accessors, accessorToMove, targetAccessor);
     }
 
     #endregion // Methods

--- a/Reihitsu.Core/AccessorOrderingUtilities.cs
+++ b/Reihitsu.Core/AccessorOrderingUtilities.cs
@@ -79,14 +79,18 @@ public static class AccessorOrderingUtilities
     }
 
     /// <summary>
-    /// Determines whether a preprocessor directive sits in the leading trivia affected by moving an accessor.
-    /// The accessor is moved together with its leading trivia, so directives such as <c>#if</c> or <c>#endif</c>
-    /// would otherwise be dragged to the new position, splitting a conditional-compilation pair
+    /// Determines whether a preprocessor directive sits anywhere in the span affected by moving an accessor.
+    /// The accessor is moved together with its trivia and jumps over every accessor in between, so directives such as
+    /// <c>#if</c> or <c>#endif</c> would otherwise be dragged to the new position or end up on the other side of the
+    /// moved accessor, splitting a conditional-compilation pair.
+    /// The whole span of each accessor in the range is inspected rather than only the leading trivia of its first
+    /// token, because a directive placed after an attribute list or a modifier attaches to a later token and would
+    /// otherwise stay invisible to the guard
     /// </summary>
     /// <param name="accessorList">Accessor list</param>
     /// <param name="accessorToMove">Accessor to move</param>
     /// <param name="targetAccessor">Target accessor</param>
-    /// <returns><see langword="true"/> if a preprocessor directive sits in the affected leading trivia</returns>
+    /// <returns><see langword="true"/> if a preprocessor directive sits in the affected span</returns>
     public static bool MoveRangeContainsDirectives(AccessorListSyntax accessorList, AccessorDeclarationSyntax accessorToMove, AccessorDeclarationSyntax targetAccessor)
     {
         var accessorDeclarations = accessorList.Accessors;
@@ -102,7 +106,7 @@ public static class AccessorOrderingUtilities
 
         for (var index = targetAccessorIndex; index <= accessorToMoveIndex; index++)
         {
-            if (accessorDeclarations[index].GetLeadingTrivia().Any(trivia => trivia.IsDirective))
+            if (accessorDeclarations[index].ContainsDirectives)
             {
                 return true;
             }

--- a/Reihitsu.Core/OrderingDeclarationUtilities.cs
+++ b/Reihitsu.Core/OrderingDeclarationUtilities.cs
@@ -229,41 +229,18 @@ public static class OrderingDeclarationUtilities
     }
 
     /// <summary>
-    /// Determines whether a preprocessor directive sits anywhere in the span affected by moving a member.
-    /// The member is moved together with its trivia and jumps over every member in between, so directives such as
-    /// <c>#region</c>, <c>#endregion</c>, <c>#if</c> or <c>#endif</c> would otherwise be dragged to the new position
-    /// or end up on the other side of the moved member, scrambling region structure or splitting
-    /// conditional-compilation pairs.
-    /// The whole span of each member in the range is inspected rather than only the leading trivia of its first
-    /// token, because a directive placed after an attribute list or a modifier attaches to a later token and would
-    /// otherwise stay invisible to the guard
+    /// Determines whether moving a member before another member would relocate a preprocessor directive away from
+    /// the code it governs, splitting a conditional-compilation pair or scrambling region structure.
+    /// The analysis is shared with the accessor guard through
+    /// <see cref="OrderingMoveSafety.MoveRangeContainsDirectives{TNode}"/>
     /// </summary>
     /// <param name="typeDeclaration">Type declaration</param>
     /// <param name="memberToMove">Member to move</param>
     /// <param name="targetMember">Target member</param>
-    /// <returns><see langword="true"/> if a preprocessor directive sits in the affected span</returns>
+    /// <returns><see langword="true"/> if the move would relocate a preprocessor directive</returns>
     public static bool MoveRangeContainsDirectives(TypeDeclarationSyntax typeDeclaration, MemberDeclarationSyntax memberToMove, MemberDeclarationSyntax targetMember)
     {
-        var members = typeDeclaration.Members;
-        var memberToMoveIndex = members.IndexOf(memberToMove);
-        var targetMemberIndex = members.IndexOf(targetMember);
-
-        if (memberToMoveIndex < 0
-            || targetMemberIndex < 0
-            || memberToMoveIndex <= targetMemberIndex)
-        {
-            return false;
-        }
-
-        for (var index = targetMemberIndex; index <= memberToMoveIndex; index++)
-        {
-            if (members[index].ContainsDirectives)
-            {
-                return true;
-            }
-        }
-
-        return false;
+        return OrderingMoveSafety.MoveRangeContainsDirectives(typeDeclaration, typeDeclaration.Members, memberToMove, targetMember);
     }
 
     /// <summary>

--- a/Reihitsu.Core/OrderingDeclarationUtilities.cs
+++ b/Reihitsu.Core/OrderingDeclarationUtilities.cs
@@ -229,15 +229,19 @@ public static class OrderingDeclarationUtilities
     }
 
     /// <summary>
-    /// Determines whether a preprocessor directive sits in the leading trivia affected by moving a member.
-    /// The member is moved together with its leading trivia, so directives such as <c>#region</c>,
-    /// <c>#endregion</c>, <c>#if</c> or <c>#endif</c> would otherwise be dragged to the new position,
-    /// scrambling region structure or splitting conditional-compilation pairs
+    /// Determines whether a preprocessor directive sits anywhere in the span affected by moving a member.
+    /// The member is moved together with its trivia and jumps over every member in between, so directives such as
+    /// <c>#region</c>, <c>#endregion</c>, <c>#if</c> or <c>#endif</c> would otherwise be dragged to the new position
+    /// or end up on the other side of the moved member, scrambling region structure or splitting
+    /// conditional-compilation pairs.
+    /// The whole span of each member in the range is inspected rather than only the leading trivia of its first
+    /// token, because a directive placed after an attribute list or a modifier attaches to a later token and would
+    /// otherwise stay invisible to the guard
     /// </summary>
     /// <param name="typeDeclaration">Type declaration</param>
     /// <param name="memberToMove">Member to move</param>
     /// <param name="targetMember">Target member</param>
-    /// <returns><see langword="true"/> if a preprocessor directive sits in the affected leading trivia</returns>
+    /// <returns><see langword="true"/> if a preprocessor directive sits in the affected span</returns>
     public static bool MoveRangeContainsDirectives(TypeDeclarationSyntax typeDeclaration, MemberDeclarationSyntax memberToMove, MemberDeclarationSyntax targetMember)
     {
         var members = typeDeclaration.Members;
@@ -253,7 +257,7 @@ public static class OrderingDeclarationUtilities
 
         for (var index = targetMemberIndex; index <= memberToMoveIndex; index++)
         {
-            if (members[index].GetLeadingTrivia().Any(trivia => trivia.IsDirective))
+            if (members[index].ContainsDirectives)
             {
                 return true;
             }

--- a/Reihitsu.Core/OrderingMoveSafety.cs
+++ b/Reihitsu.Core/OrderingMoveSafety.cs
@@ -1,0 +1,64 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Reihitsu.Core;
+
+/// <summary>
+/// Safety checks shared by the declaration and accessor reordering guards
+/// </summary>
+public static class OrderingMoveSafety
+{
+    #region Methods
+
+    /// <summary>
+    /// Determines whether moving a node in front of an earlier node of the same list would relocate a preprocessor
+    /// directive away from the code it governs.
+    /// The move relocates the whole span of the moved node in front of the nodes it jumps over, so both halves are
+    /// inspected separately: a directive whose partner lies outside the moved span would be torn away from it, and a
+    /// directive whose partner lies outside the crossed span means the moved node changes sides of a conditional or
+    /// region boundary. A directive pair that sits complete inside either half travels intact and is therefore safe.
+    /// The whole span of each half is inspected rather than the leading trivia of its first token, because a
+    /// directive placed after an attribute list or a modifier attaches to a later token
+    /// </summary>
+    /// <typeparam name="TNode">List node type</typeparam>
+    /// <param name="root">Syntax node containing the list</param>
+    /// <param name="nodes">List the move operates on</param>
+    /// <param name="nodeToMove">Node to move</param>
+    /// <param name="targetNode">Node the moved node should precede</param>
+    /// <returns><see langword="true"/> if the move would relocate a preprocessor directive</returns>
+    public static bool MoveRangeContainsDirectives<TNode>(SyntaxNode root, SyntaxList<TNode> nodes, TNode nodeToMove, TNode targetNode)
+        where TNode : SyntaxNode
+    {
+        var nodeToMoveIndex = nodes.IndexOf(nodeToMove);
+        var targetNodeIndex = nodes.IndexOf(targetNode);
+
+        if (nodeToMoveIndex < 0
+            || targetNodeIndex < 0
+            || nodeToMoveIndex <= targetNodeIndex)
+        {
+            return false;
+        }
+
+        var movedSpan = nodes[nodeToMoveIndex].FullSpan;
+        var crossedSpan = TextSpan.FromBounds(nodes[targetNodeIndex].FullSpan.Start, movedSpan.Start);
+
+        return RelocationChangesDirectiveScope(root, crossedSpan)
+               || RelocationChangesDirectiveScope(root, movedSpan);
+    }
+
+    /// <summary>
+    /// Determines whether relocating the specified span as one block would change which code a preprocessor
+    /// directive governs
+    /// </summary>
+    /// <param name="root">Syntax node containing the span</param>
+    /// <param name="span">Span to inspect</param>
+    /// <returns><see langword="true"/> if relocating the span would change a directive scope</returns>
+    private static bool RelocationChangesDirectiveScope(SyntaxNode root, TextSpan span)
+    {
+        return SyntaxTriviaUtilities.ContainsUnbalancedConditionalDirectives(root, span)
+               || SyntaxTriviaUtilities.ContainsUnbalancedRegionDirectives(root, span)
+               || SyntaxTriviaUtilities.ContainsPositionSensitiveDirectives(root, span);
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Core/OrderingMoveSafety.cs
+++ b/Reihitsu.Core/OrderingMoveSafety.cs
@@ -39,6 +39,15 @@ public static class OrderingMoveSafety
             return false;
         }
 
+        // The span analysis below walks the trivia of both halves. Most declarations carry no directive at all, so
+        // the green-node flag answers those without a walk. A null root falls through and is refused by the
+        // predicates, which cannot inspect the spans without it
+        if (root != null
+            && root.ContainsDirectives == false)
+        {
+            return false;
+        }
+
         var movedSpan = nodes[nodeToMoveIndex].FullSpan;
         var crossedSpan = TextSpan.FromBounds(nodes[targetNodeIndex].FullSpan.Start, movedSpan.Start);
 

--- a/Reihitsu.Core/OrderingMoveSafety.cs
+++ b/Reihitsu.Core/OrderingMoveSafety.cs
@@ -39,8 +39,9 @@ public static class OrderingMoveSafety
             return false;
         }
 
-        // The span analysis below walks the trivia of both halves. Most declarations carry no directive at all, so
-        // the green-node flag answers those without a walk. A null root falls through and is refused by the
+        // The span analysis below walks the trivia of both halves. The green-node flag answers containers that hold
+        // no directive at all without walking anything; note that a single #region anywhere in the container already
+        // defeats it, so this only spares directive-free code. A null root falls through and is refused by the
         // predicates, which cannot inspect the spans without it
         if (root != null
             && root.ContainsDirectives == false)

--- a/Reihitsu.Core/SyntaxTriviaUtilities.cs
+++ b/Reihitsu.Core/SyntaxTriviaUtilities.cs
@@ -263,6 +263,55 @@ public static class SyntaxTriviaUtilities
     }
 
     /// <summary>
+    /// Determines whether the specified span contains a <c>#region</c> or <c>#endregion</c> directive whose partner
+    /// directive lies outside the span. Rewrites that relocate a span as one block — for example a member reorder
+    /// that lifts a declaration over its neighbours — would carry such a directive away from its partner, leaving
+    /// the surrounding declarations in a different region than the author wrote.
+    /// <see cref="ContainsPositionSensitiveDirectives"/> deliberately ignores region directives because a region
+    /// reorder relocates them on purpose; a member reorder must not, so it pairs that predicate with this one
+    /// </summary>
+    /// <param name="root">Syntax node containing the span</param>
+    /// <param name="span">Span to inspect</param>
+    /// <returns>
+    /// <see langword="true"/> if the span contains an unbalanced region directive, or when
+    /// <paramref name="root"/> is <see langword="null"/> and the span therefore cannot be inspected; otherwise,
+    /// <see langword="false"/>
+    /// </returns>
+    public static bool ContainsUnbalancedRegionDirectives(SyntaxNode root, TextSpan span)
+    {
+        if (root == null)
+        {
+            return true;
+        }
+
+        var nestingLevel = 0;
+
+        foreach (var trivia in root.DescendantTrivia(span, descendIntoTrivia: true))
+        {
+            if (span.Contains(trivia.SpanStart) == false)
+            {
+                continue;
+            }
+
+            if (trivia.IsKind(SyntaxKind.RegionDirectiveTrivia))
+            {
+                nestingLevel++;
+            }
+            else if (trivia.IsKind(SyntaxKind.EndRegionDirectiveTrivia))
+            {
+                nestingLevel--;
+
+                if (nestingLevel < 0)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return nestingLevel != 0;
+    }
+
+    /// <summary>
     /// Determines whether the specified span contains a preprocessor directive whose effect is bound to where it
     /// sits rather than to the block around it. <c>#pragma warning</c>, <c>#nullable</c> and <c>#line</c> all
     /// apply from their own position onwards, so a rewrite that relocates the surrounding block silently changes

--- a/Reihitsu.Core/SyntaxTriviaUtilities.cs
+++ b/Reihitsu.Core/SyntaxTriviaUtilities.cs
@@ -258,63 +258,6 @@ public static class SyntaxTriviaUtilities
     }
 
     /// <summary>
-    /// Determines whether the specified span contains a directive-nesting pair whose partner directive lies outside
-    /// the span. Shared by the conditional and the region predicate, which differ only in the directive kinds that
-    /// open and close a level and in whether a branch directive detached from its opener has to be refused
-    /// </summary>
-    /// <param name="root">Syntax node containing the span</param>
-    /// <param name="span">Span to inspect</param>
-    /// <param name="openKind">Directive kind that opens a nesting level</param>
-    /// <param name="closeKind">Directive kind that closes a nesting level</param>
-    /// <param name="refuseDetachedBranches">
-    /// Whether an <c>#elif</c> or <c>#else</c> outside any nesting level has to be refused
-    /// </param>
-    /// <returns>
-    /// <see langword="true"/> if the span contains an unbalanced directive, or when <paramref name="root"/> is
-    /// <see langword="null"/> and the span therefore cannot be inspected; otherwise, <see langword="false"/>
-    /// </returns>
-    private static bool ContainsUnbalancedDirectives(SyntaxNode root, TextSpan span, SyntaxKind openKind, SyntaxKind closeKind, bool refuseDetachedBranches)
-    {
-        if (root == null)
-        {
-            return true;
-        }
-
-        var nestingLevel = 0;
-
-        foreach (var trivia in root.DescendantTrivia(span, descendIntoTrivia: true))
-        {
-            if (span.Contains(trivia.SpanStart) == false)
-            {
-                continue;
-            }
-
-            if (trivia.IsKind(openKind))
-            {
-                nestingLevel++;
-            }
-            else if (trivia.IsKind(closeKind))
-            {
-                nestingLevel--;
-
-                if (nestingLevel < 0)
-                {
-                    return true;
-                }
-            }
-            else if (refuseDetachedBranches
-                     && nestingLevel == 0
-                     && (trivia.IsKind(SyntaxKind.ElifDirectiveTrivia)
-                         || trivia.IsKind(SyntaxKind.ElseDirectiveTrivia)))
-            {
-                return true;
-            }
-        }
-
-        return nestingLevel != 0;
-    }
-
-    /// <summary>
     /// Determines whether the specified span contains a preprocessor directive whose effect is bound to where it
     /// sits rather than to the block around it. <c>#pragma warning</c>, <c>#nullable</c> and <c>#line</c> all
     /// apply from their own position onwards, so a rewrite that relocates the surrounding block silently changes
@@ -450,6 +393,63 @@ public static class SyntaxTriviaUtilities
         }
 
         return SyntaxFactory.TriviaList(indentation);
+    }
+
+    /// <summary>
+    /// Determines whether the specified span contains a directive-nesting pair whose partner directive lies outside
+    /// the span. Shared by the conditional and the region predicate, which differ only in the directive kinds that
+    /// open and close a level and in whether a branch directive detached from its opener has to be refused
+    /// </summary>
+    /// <param name="root">Syntax node containing the span</param>
+    /// <param name="span">Span to inspect</param>
+    /// <param name="openKind">Directive kind that opens a nesting level</param>
+    /// <param name="closeKind">Directive kind that closes a nesting level</param>
+    /// <param name="refuseDetachedBranches">
+    /// Whether an <c>#elif</c> or <c>#else</c> outside any nesting level has to be refused
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if the span contains an unbalanced directive, or when <paramref name="root"/> is
+    /// <see langword="null"/> and the span therefore cannot be inspected; otherwise, <see langword="false"/>
+    /// </returns>
+    private static bool ContainsUnbalancedDirectives(SyntaxNode root, TextSpan span, SyntaxKind openKind, SyntaxKind closeKind, bool refuseDetachedBranches)
+    {
+        if (root == null)
+        {
+            return true;
+        }
+
+        var nestingLevel = 0;
+
+        foreach (var trivia in root.DescendantTrivia(span, descendIntoTrivia: true))
+        {
+            if (span.Contains(trivia.SpanStart) == false)
+            {
+                continue;
+            }
+
+            if (trivia.IsKind(openKind))
+            {
+                nestingLevel++;
+            }
+            else if (trivia.IsKind(closeKind))
+            {
+                nestingLevel--;
+
+                if (nestingLevel < 0)
+                {
+                    return true;
+                }
+            }
+            else if (refuseDetachedBranches
+                     && nestingLevel == 0
+                     && (trivia.IsKind(SyntaxKind.ElifDirectiveTrivia)
+                         || trivia.IsKind(SyntaxKind.ElseDirectiveTrivia)))
+            {
+                return true;
+            }
+        }
+
+        return nestingLevel != 0;
     }
 
     /// <summary>

--- a/Reihitsu.Core/SyntaxTriviaUtilities.cs
+++ b/Reihitsu.Core/SyntaxTriviaUtilities.cs
@@ -224,42 +224,11 @@ public static class SyntaxTriviaUtilities
     /// </returns>
     public static bool ContainsUnbalancedConditionalDirectives(SyntaxNode root, TextSpan span)
     {
-        if (root == null)
-        {
-            return true;
-        }
-
-        var nestingLevel = 0;
-
-        foreach (var trivia in root.DescendantTrivia(span, descendIntoTrivia: true))
-        {
-            if (span.Contains(trivia.SpanStart) == false)
-            {
-                continue;
-            }
-
-            if (trivia.IsKind(SyntaxKind.IfDirectiveTrivia))
-            {
-                nestingLevel++;
-            }
-            else if (trivia.IsKind(SyntaxKind.EndIfDirectiveTrivia))
-            {
-                nestingLevel--;
-
-                if (nestingLevel < 0)
-                {
-                    return true;
-                }
-            }
-            else if (nestingLevel == 0
-                     && (trivia.IsKind(SyntaxKind.ElifDirectiveTrivia)
-                         || trivia.IsKind(SyntaxKind.ElseDirectiveTrivia)))
-            {
-                return true;
-            }
-        }
-
-        return nestingLevel != 0;
+        return ContainsUnbalancedDirectives(root,
+                                            span,
+                                            SyntaxKind.IfDirectiveTrivia,
+                                            SyntaxKind.EndIfDirectiveTrivia,
+                                            refuseDetachedBranches: true);
     }
 
     /// <summary>
@@ -268,7 +237,9 @@ public static class SyntaxTriviaUtilities
     /// that lifts a declaration over its neighbours — would carry such a directive away from its partner, leaving
     /// the surrounding declarations in a different region than the author wrote.
     /// <see cref="ContainsPositionSensitiveDirectives"/> deliberately ignores region directives because a region
-    /// reorder relocates them on purpose; a member reorder must not, so it pairs that predicate with this one
+    /// reorder relocates them on purpose; a member reorder must not, so it pairs that predicate with this one.
+    /// Unlike the conditional variant there is no detached-branch case to refuse, because regions have no
+    /// <c>#elif</c>/<c>#else</c> equivalent
     /// </summary>
     /// <param name="root">Syntax node containing the span</param>
     /// <param name="span">Span to inspect</param>
@@ -278,6 +249,31 @@ public static class SyntaxTriviaUtilities
     /// <see langword="false"/>
     /// </returns>
     public static bool ContainsUnbalancedRegionDirectives(SyntaxNode root, TextSpan span)
+    {
+        return ContainsUnbalancedDirectives(root,
+                                            span,
+                                            SyntaxKind.RegionDirectiveTrivia,
+                                            SyntaxKind.EndRegionDirectiveTrivia,
+                                            refuseDetachedBranches: false);
+    }
+
+    /// <summary>
+    /// Determines whether the specified span contains a directive-nesting pair whose partner directive lies outside
+    /// the span. Shared by the conditional and the region predicate, which differ only in the directive kinds that
+    /// open and close a level and in whether a branch directive detached from its opener has to be refused
+    /// </summary>
+    /// <param name="root">Syntax node containing the span</param>
+    /// <param name="span">Span to inspect</param>
+    /// <param name="openKind">Directive kind that opens a nesting level</param>
+    /// <param name="closeKind">Directive kind that closes a nesting level</param>
+    /// <param name="refuseDetachedBranches">
+    /// Whether an <c>#elif</c> or <c>#else</c> outside any nesting level has to be refused
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if the span contains an unbalanced directive, or when <paramref name="root"/> is
+    /// <see langword="null"/> and the span therefore cannot be inspected; otherwise, <see langword="false"/>
+    /// </returns>
+    private static bool ContainsUnbalancedDirectives(SyntaxNode root, TextSpan span, SyntaxKind openKind, SyntaxKind closeKind, bool refuseDetachedBranches)
     {
         if (root == null)
         {
@@ -293,11 +289,11 @@ public static class SyntaxTriviaUtilities
                 continue;
             }
 
-            if (trivia.IsKind(SyntaxKind.RegionDirectiveTrivia))
+            if (trivia.IsKind(openKind))
             {
                 nestingLevel++;
             }
-            else if (trivia.IsKind(SyntaxKind.EndRegionDirectiveTrivia))
+            else if (trivia.IsKind(closeKind))
             {
                 nestingLevel--;
 
@@ -305,6 +301,13 @@ public static class SyntaxTriviaUtilities
                 {
                     return true;
                 }
+            }
+            else if (refuseDetachedBranches
+                     && nestingLevel == 0
+                     && (trivia.IsKind(SyntaxKind.ElifDirectiveTrivia)
+                         || trivia.IsKind(SyntaxKind.ElseDirectiveTrivia)))
+            {
+                return true;
             }
         }
 

--- a/documentation/rules/RH7102.md
+++ b/documentation/rules/RH7102.md
@@ -19,6 +19,13 @@ Constants represent fixed values and are typically treated differently from ordi
 
 Move constant fields above the regular fields in the same access group.
 
+The code fix moves the field together with its trivia and lifts it over the fields in between, so it is not offered when that would relocate a preprocessor directive away from the code it governs. Two cases are withheld:
+
+- A conditional or region pair with one end inside the moved field and the other outside it, or one end among the fields it jumps over and the other outside them. Moving the field would carry one half of the pair away and leave the other behind, producing unmatched directives (CS1027/CS1028) or a field that silently changed region.
+- A position-sensitive directive such as `#pragma warning`, `#nullable` or `#line` in the moved field or in the fields it jumps over. These apply from where they sit onwards, so relocating the surrounding text changes which code they cover.
+
+Directives that keep their meaning are unaffected and still get the fix: a pair contained wholly inside the moved field, or wholly inside one of the fields it jumps over. A pair that opens above the whole range — around the entire type, say — is unaffected too, but note that a `#region` written directly above the first field of the range belongs to that field's leading trivia and therefore counts as inside it. Where the fix is withheld, reorder the fields by hand.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH7103.md
+++ b/documentation/rules/RH7103.md
@@ -19,6 +19,13 @@ Placing static and instance members in a predictable order makes the public shap
 
 Move static members above the matching instance members in the same group.
 
+The code fix moves the member together with its trivia and lifts it over the members in between, so it is not offered when that would relocate a preprocessor directive away from the code it governs. Two cases are withheld:
+
+- A conditional or region pair with one end inside the moved member and the other outside it, or one end among the members it jumps over and the other outside them. Moving the member would carry one half of the pair away and leave the other behind, producing unmatched directives (CS1027/CS1028) or a member that silently changed region.
+- A position-sensitive directive such as `#pragma warning`, `#nullable` or `#line` in the moved member or in the members it jumps over. These apply from where they sit onwards, so relocating the surrounding text changes which code they cover.
+
+Directives that keep their meaning are unaffected and still get the fix: a pair contained wholly inside the moved member, or wholly inside one of the members it jumps over. A pair that opens above the whole range — around the entire type, say — is unaffected too, but note that a `#region` written directly above the first member of the range belongs to that member's leading trivia and therefore counts as inside it. Where the fix is withheld, reorder the members by hand.
+
 ## Region scope
 
 When a type uses top-level `#region` blocks, the ordering is evaluated within each region independently. Static members in one region are not compared against instance members in a different region, so per-region groupings such as `#region Lifecycle` and `#region Factories` can coexist without conflicting with this rule. A type without regions continues to be evaluated as a single body.

--- a/documentation/rules/RH7107.md
+++ b/documentation/rules/RH7107.md
@@ -19,6 +19,13 @@ Property declarations are easier to read when accessors appear in a familiar ord
 
 Move `get` above `set` or `init`.
 
+The code fix moves the accessor together with its trivia and lifts it over the accessor in between, so it is not offered when that would relocate a preprocessor directive away from the code it governs. Two cases are withheld:
+
+- A conditional or region pair with one end inside the moved accessor and the other outside it, or one end in the accessor it jumps over and the other outside it. Moving the accessor would carry one half of the pair away and leave the other behind, producing unmatched directives (CS1027/CS1028).
+- A position-sensitive directive such as `#pragma warning`, `#nullable` or `#line` in either accessor. These apply from where they sit onwards, so relocating the surrounding text changes which code they cover.
+
+Directives that keep their meaning are unaffected and still get the fix: a pair contained wholly inside one accessor body, or opened outside the accessor list altogether. Note that a directive written directly above the first accessor belongs to that accessor's leading trivia and therefore counts as inside the list. Where the fix is withheld, reorder the accessors by hand.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH7108.md
+++ b/documentation/rules/RH7108.md
@@ -19,6 +19,13 @@ Explicit event accessors are easier to read when they follow a consistent order.
 
 Move `add` above `remove`.
 
+The code fix moves the accessor together with its trivia and lifts it over the accessor in between, so it is not offered when that would relocate a preprocessor directive away from the code it governs. Two cases are withheld:
+
+- A conditional or region pair with one end inside the moved accessor and the other outside it, or one end in the accessor it jumps over and the other outside it. Moving the accessor would carry one half of the pair away and leave the other behind, producing unmatched directives (CS1027/CS1028).
+- A position-sensitive directive such as `#pragma warning`, `#nullable` or `#line` in either accessor. These apply from where they sit onwards, so relocating the surrounding text changes which code they cover.
+
+Directives that keep their meaning are unaffected and still get the fix: a pair contained wholly inside one accessor body, or opened outside the accessor list altogether. Note that a directive written directly above the first accessor belongs to that accessor's leading trivia and therefore counts as inside the list. Where the fix is withheld, reorder the accessors by hand.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH7109.md
+++ b/documentation/rules/RH7109.md
@@ -19,6 +19,13 @@ Placing immutable fields first makes it easier to see which parts of an object's
 
 Move `readonly` fields above the matching non-readonly fields.
 
+The code fix moves the field together with its trivia and lifts it over the fields in between, so it is not offered when that would relocate a preprocessor directive away from the code it governs. Two cases are withheld:
+
+- A conditional or region pair with one end inside the moved field and the other outside it, or one end among the fields it jumps over and the other outside them. Moving the field would carry one half of the pair away and leave the other behind, producing unmatched directives (CS1027/CS1028) or a field that silently changed region.
+- A position-sensitive directive such as `#pragma warning`, `#nullable` or `#line` in the moved field or in the fields it jumps over. These apply from where they sit onwards, so relocating the surrounding text changes which code they cover.
+
+Directives that keep their meaning are unaffected and still get the fix: a pair contained wholly inside the moved field, or wholly inside one of the fields it jumps over. A pair that opens above the whole range — around the entire type, say — is unaffected too, but note that a `#region` written directly above the first field of the range belongs to that field's leading trivia and therefore counts as inside it. Where the fix is withheld, reorder the fields by hand.
+
 ## Examples
 
 ### Violation


### PR DESCRIPTION
## Summary

The reorder directive guards no longer decide on the leading trivia of a node's first token. `OrderingMoveSafety.MoveRangeContainsDirectives` inspects the **crossed span** and the **moved span** separately and refuses the move only when a directive in either half would change what it governs:

- a conditional or region directive whose partner lies outside its own half (`SyntaxTriviaUtilities.ContainsUnbalancedConditionalDirectives`, plus the new `ContainsUnbalancedRegionDirectives`);
- any position-sensitive directive — `#pragma`, `#nullable`, `#line` and unknown kinds — which has no partner to balance against.

A pair contained completely inside either half travels intact and is allowed. Both `OrderingDeclarationUtilities` (RH7102/RH7103/RH7109) and `AccessorOrderingUtilities` (RH7107/RH7108) are now thin wrappers over that single shared scan, and all five rule docs describe when the fix is withheld.

## Why

`SyntaxNode.GetLeadingTrivia()` returns the leading trivia of the node's **first** token only. A directive placed between an attribute list (or a modifier) and the declaration keyword attaches to a *later* token, so the guard never saw it and the reorder dragged the enclosed `#if`/`#region` away from its partner — CS1027/CS1028, the exact failure the guard exists to prevent.

```cs
class C
{
    void First()
    {
    }

    [Obsolete]
#if DEBUG
    static void Second()   // RH7103 offered the fix here
    {
    }
#endif
}
```

## Linked issues

Closes #508

## Review notes

- **Why not `ContainsDirectives`.** The first cut used the whole-node flag and withheld the fix whenever *any* directive sat anywhere in the range. That is safe but withholds it for the most common real shape — a balanced `#if DEBUG` inside a crossed member's body, which the move cannot break. The span-pair analysis keeps the issue's shape refused and that one offered.
- **Why the split into two spans.** Only the moved node is relocated, so the two halves must balance independently: a pair straddling the boundary is exactly the case that gets torn apart. A pair enclosing the whole range from outside touches neither half and stays allowed.
- **Region balance is new.** `ContainsPositionSensitiveDirectives` deliberately ignores `#region`, because RH7309's region reorder relocates regions on purpose. A member reorder must not, so `ContainsUnbalancedRegionDirectives` is its counterpart; every directive kind is still covered by exactly one of the three predicates. Both balance predicates share one private nesting walk, parameterized by the opening and closing kind, with the detached `#elif`/`#else` refusal as a conditional-only flag.
- **Verified red-then-green.** The four balanced-pair tests fail against the previous `ContainsDirectives` guard and pass against this one; the directive-blind-spot tests from the original fix fail against `main` and pass here.
- **Docs name the counter-intuitive case.** A `#region` written directly above the first member of the range belongs to that member's leading trivia, so it counts as inside the range and the fix is withheld — the shape `NoCodeFixWhenDirectivesAreInLeadingTrivia` pins. Each rule doc says so explicitly rather than leaving it to contradict the tests.
- `MoveRangeContainsDirectivesReturnsFalseWhenDirectiveSitsOutsideTheMovedRange` pins that the analysed range is still `[target … memberToMove]`.
- The span analysis walks trivia where the old guard read a flag. `OrderingMoveSafety` short-circuits on `root.ContainsDirectives`, but note a single `#region` anywhere in the container already defeats that, so it only spares directive-free code.
- Sibling guards were checked and do not carry the blind spot: `ModifierOrderingCodeFixProviderBase.ReorderingWouldDropCommentOrDirective` already walks every modifier's leading *and* trailing trivia, `UsingDirectiveOrderingSafety` scans the whole using block's `ToFullString()`, and RH7309 uses the span-based predicates. RH7110 ships no code fix.

## Follow-up work

RH7105 and RH7106 also withhold their code fix — `ModifierOrderingCodeFixProviderBase` refuses when a comment or directive sits between modifiers — and their rule docs do not mention it. That guard is untouched here and works differently from the span-pair analysis, so documenting it is left out of this PR.

`#pragma`/`#nullable`/`#line` still refuse in either half, so a self-contained `#pragma warning disable`/`restore` pair inside a body blocks the fix. Allowing it needs disable/restore pairing semantics — per-warning-code lists, `#nullable` targeting annotations vs warnings, `#line default` — that no existing `Reihitsu.Core` predicate models.

`RelocationChangesDirectiveScope` makes three `DescendantTrivia` walks per half. Collapsing them into one combined pass would halve the work, but the single-purpose predicates stay in place for RH7309, so the nesting logic would then exist twice. Left as-is until `FixAll` on large types is actually measured.

`TypeMemberOrderingCodeFixProviderBase.ApplyCodeFixAsync` formats the whole type after a single member move, which widens the fix diff with unrelated edits (visible in the RH7103 expected output: an added `#endregion` comment and a property collapse). Pre-existing and untouched here; narrowing it the way #558 did for RH5109/RH7101 has no reusable member-move transform to delegate to, so it is its own change.
