### PR TITLE
Preserve documentation boundaries in blank-line cleanup

### DIFF
--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH8302ElementDocumentationHeadersMustNotBeFollowedByBlankLineFormatterTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH8302ElementDocumentationHeadersMustNotBeFollowedByBlankLineFormatterTests.cs
@@ -51,5 +51,115 @@ public class RH8302ElementDocumentationHeadersMustNotBeFollowedByBlankLineFormat
                                  Diagnostics(RH8302ElementDocumentationHeadersMustNotBeFollowedByBlankLineAnalyzer.DiagnosticId, AnalyzerResources.RH8302MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies that the formatter removes a blank line after a multi-line documentation comment
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFormatterFixesMultiLineDocumentationViolation()
+    {
+        const string input = """
+                             internal class Example
+                             {
+                                 /** <summary>
+                                  * Summary.
+                                  * </summary> */
+                             {|#0:
+                             |}    void Method()
+                                 {
+                                 }
+                             }
+                             """;
+        const string fixedData = """
+                                 internal class Example
+                                 {
+                                     /** <summary>
+                                      * Summary.
+                                      * </summary> */
+                                     void Method()
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await VerifyFormatterFix(input,
+                                 fixedData,
+                                 Diagnostics(RH8302ElementDocumentationHeadersMustNotBeFollowedByBlankLineAnalyzer.DiagnosticId, AnalyzerResources.RH8302MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that the formatter removes blank lines after every stacked multi-line documentation comment
+    /// and remains stable under LF and CRLF line endings
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFormatterFixesStackedMultiLineDocumentationViolations()
+    {
+        const string input = """
+                             internal class Example
+                             {
+                                 /** <summary>First.</summary> */
+                             {|#0:
+                             |}    /** <summary>Second.</summary> */
+                             {|#1:
+                             |}    void Method()
+                                 {
+                                 }
+                             }
+                             """;
+        const string fixedData = """
+                                 internal class Example
+                                 {
+                                     /** <summary>First.</summary> */
+                                     /** <summary>Second.</summary> */
+                                     void Method()
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await VerifyFormatterFixAndIdempotency(input,
+                                               fixedData,
+                                               Diagnostics(RH8302ElementDocumentationHeadersMustNotBeFollowedByBlankLineAnalyzer.DiagnosticId, AnalyzerResources.RH8302MessageFormat, 2));
+    }
+
+    /// <summary>
+    /// Verifies that the formatter removes blank lines after mixed documentation-comment forms
+    /// and remains stable under LF and CRLF line endings
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFormatterFixesMixedDocumentationViolations()
+    {
+        const string input = """
+                             internal class Example
+                             {
+                                 /** <summary>First.</summary> */
+                             {|#0:
+                             |}    /// <summary>Second.</summary>
+                             {|#1:
+                             |}    void Method()
+                                 {
+                                 }
+                             }
+                             """;
+        const string fixedData = """
+                                 internal class Example
+                                 {
+                                     /** <summary>First.</summary> */
+                                     /// <summary>
+                                     /// Second.
+                                     /// </summary>
+                                     void Method()
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await VerifyFormatterFixAndIdempotency(input,
+                                               fixedData,
+                                               Diagnostics(RH8302ElementDocumentationHeadersMustNotBeFollowedByBlankLineAnalyzer.DiagnosticId, AnalyzerResources.RH8302MessageFormat, 2));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatting/RH8302ElementDocumentationHeadersMustNotBeFollowedByBlankLineAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH8302ElementDocumentationHeadersMustNotBeFollowedByBlankLineAnalyzerTests.cs
@@ -39,6 +39,54 @@ public class RH8302ElementDocumentationHeadersMustNotBeFollowedByBlankLineAnalyz
     }
 
     /// <summary>
+    /// Verifies that a multi-line documentation comment directly attached to its declaration is clean
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForCleanMultiLineDocumentation()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    /** <summary>
+                                     * Summary.
+                                     * </summary> */
+                                    void Method()
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that a dangling multi-line documentation comment followed by an LF does not produce a
+    /// zero-length diagnostic at the end of the file
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDanglingMultiLineDocumentationWithLfDoesNotProduceDiagnostic()
+    {
+        const string testData = "/** <summary>Dangling.</summary> */\n";
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that a dangling multi-line documentation comment followed by a CRLF does not produce a
+    /// zero-length diagnostic at the end of the file
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDanglingMultiLineDocumentationWithCrlfDoesNotProduceDiagnostic()
+    {
+        const string testData = "/** <summary>Dangling.</summary> */\r\n";
+
+        await Verify(testData);
+    }
+
+    /// <summary>
     /// Verifies that the issue is detected and fixed
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
@@ -70,6 +118,121 @@ public class RH8302ElementDocumentationHeadersMustNotBeFollowedByBlankLineAnalyz
                                  """;
 
         await Verify(testData, fixedData, Diagnostics(RH8302ElementDocumentationHeadersMustNotBeFollowedByBlankLineAnalyzer.DiagnosticId, AnalyzerResources.RH8302MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that a blank line after a multi-line documentation comment is detected and fixed
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyMultiLineDocumentationIssueIsDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    /** <summary>
+                                     * Summary.
+                                     * </summary> */
+                                {|#0:
+                                |}    void Method()
+                                    {
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     /** <summary>
+                                      * Summary.
+                                      * </summary> */
+                                     void Method()
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH8302ElementDocumentationHeadersMustNotBeFollowedByBlankLineAnalyzer.DiagnosticId, AnalyzerResources.RH8302MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that one code-fix action removes a complete run of blank lines after documentation
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyMultipleBlankLinesAreRemovedByOneCodeFix()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    /** <summary>Summary.</summary> */
+
+
+                                    void Method()
+                                    {
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     /** <summary>Summary.</summary> */
+                                     void Method()
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        var actual = await ApplyCodeFixAsync(testData);
+
+        Assert.AreEqual(fixedData, actual);
+        await Verify(actual);
+    }
+
+    /// <summary>
+    /// Verifies that Fix All removes complete blank-line runs after both documentation-comment forms
+    /// in one iteration
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyMultipleDocumentationBlankLineRunsAreFixedInOneFixAllIteration()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    /// <summary>First.</summary>
+                                {|#0:
+
+                                |}    void First()
+                                    {
+                                    }
+
+                                    /** <summary>Second.</summary> */
+                                {|#1:
+
+                                |}    void Second()
+                                    {
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     /// <summary>First.</summary>
+                                     void First()
+                                     {
+                                     }
+
+                                     /** <summary>Second.</summary> */
+                                     void Second()
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData,
+                     fixedData,
+                     static config => config.NumberOfFixAllIterations = 1,
+                     Diagnostics(RH8302ElementDocumentationHeadersMustNotBeFollowedByBlankLineAnalyzer.DiagnosticId, AnalyzerResources.RH8302MessageFormat, 2));
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer/Rules/Documentation/RH8302ElementDocumentationHeadersMustNotBeFollowedByBlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH8302ElementDocumentationHeadersMustNotBeFollowedByBlankLineAnalyzer.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
 
@@ -39,6 +40,96 @@ public class RH8302ElementDocumentationHeadersMustNotBeFollowedByBlankLineAnalyz
     #region Methods
 
     /// <summary>
+    /// Tries to get the complete contiguous run of blank lines beginning at the specified line
+    /// </summary>
+    /// <param name="sourceText">Source text</param>
+    /// <param name="firstLineIndex">Index of the first possible blank line</param>
+    /// <param name="blankLineRun">Span of the complete blank-line run</param>
+    /// <returns><see langword="true"/> if a blank-line run was found; otherwise, <see langword="false"/></returns>
+    private static bool TryGetBlankLineRun(SourceText sourceText,
+                                           int firstLineIndex,
+                                           out TextSpan blankLineRun)
+    {
+        blankLineRun = default;
+
+        if (firstLineIndex >= sourceText.Lines.Count
+            || FormattingTextAnalysisUtilities.IsBlankLine(sourceText, firstLineIndex) == false)
+        {
+            return false;
+        }
+
+        var firstLine = sourceText.Lines[firstLineIndex];
+
+        if (firstLine.EndIncludingLineBreak == firstLine.End)
+        {
+            return false;
+        }
+
+        var lastLineIndex = firstLineIndex;
+
+        while (lastLineIndex + 1 < sourceText.Lines.Count
+               && FormattingTextAnalysisUtilities.IsBlankLine(sourceText, lastLineIndex + 1))
+        {
+            lastLineIndex++;
+        }
+
+        blankLineRun = TextSpan.FromBounds(firstLine.Start,
+                                           sourceText.Lines[lastLineIndex].EndIncludingLineBreak);
+
+        return true;
+    }
+
+    /// <summary>
+    /// Reports a diagnostic for the complete blank-line run that begins at the specified line
+    /// </summary>
+    /// <param name="context">Context</param>
+    /// <param name="sourceText">Source text</param>
+    /// <param name="firstLineIndex">Index of the first possible blank line</param>
+    private void ReportFollowingBlankLineRun(SyntaxTreeAnalysisContext context,
+                                             SourceText sourceText,
+                                             int firstLineIndex)
+    {
+        if (TryGetBlankLineRun(sourceText, firstLineIndex, out var blankLineRun))
+        {
+            context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, blankLineRun)));
+        }
+    }
+
+    /// <summary>
+    /// Reports blank lines that immediately follow multi-line documentation comments
+    /// </summary>
+    /// <param name="context">Context</param>
+    /// <param name="root">Syntax root</param>
+    /// <param name="sourceText">Source text</param>
+    private void AnalyzeMultiLineDocumentationComments(SyntaxTreeAnalysisContext context,
+                                                       SyntaxNode root,
+                                                       SourceText sourceText)
+    {
+        foreach (var token in root.DescendantTokens())
+        {
+            foreach (var documentationComment in token.LeadingTrivia)
+            {
+                if (documentationComment.IsKind(SyntaxKind.MultiLineDocumentationCommentTrivia) == false)
+                {
+                    continue;
+                }
+
+                var commentEnd = documentationComment.FullSpan.End;
+                var commentEndLine = sourceText.Lines.GetLineFromPosition(commentEnd - 1);
+
+                if (string.IsNullOrWhiteSpace(sourceText.ToString(TextSpan.FromBounds(commentEnd, commentEndLine.End))) == false)
+                {
+                    continue;
+                }
+
+                var nextLineIndex = commentEndLine.LineNumber + 1;
+
+                ReportFollowingBlankLineRun(context, sourceText, nextLineIndex);
+            }
+        }
+    }
+
+    /// <summary>
     /// Analyzes the syntax tree
     /// </summary>
     /// <param name="context">Context</param>
@@ -77,16 +168,12 @@ public class RH8302ElementDocumentationHeadersMustNotBeFollowedByBlankLineAnalyz
                 nextLineIndex++;
             }
 
-            if (nextLineIndex < sourceText.Lines.Count
-                && FormattingTextAnalysisUtilities.IsBlankLine(sourceText, nextLineIndex))
-            {
-                var blankLine = sourceText.Lines[nextLineIndex];
-
-                context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, TextSpan.FromBounds(blankLine.Start, blankLine.EndIncludingLineBreak))));
-            }
+            ReportFollowingBlankLineRun(context, sourceText, nextLineIndex);
 
             lineIndex = nextLineIndex;
         }
+
+        AnalyzeMultiLineDocumentationComments(context, root, sourceText);
     }
 
     #endregion // Methods

--- a/Reihitsu.Formatter.Test/Regression/FullPipeline/BlankLineStructureFullPipelineTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/FullPipeline/BlankLineStructureFullPipelineTests.cs
@@ -73,5 +73,38 @@ public class BlankLineStructureFullPipelineTests : FormatterTestsBase
         AssertRuleResult(input, expected);
     }
 
+    /// <summary>
+    /// Verifies that trailing whitespace after a multi-line documentation comment does not defer
+    /// removal of the following blank line to a second formatting pass
+    /// </summary>
+    [TestMethod]
+    public void RemovesDocumentationBlankLineWithTrailingWhitespaceInOnePass()
+    {
+        // Arrange
+        const string inputTemplate = """
+                                     public class C
+                                     {
+                                         /** <summary>Does something.</summary> */<TRAILING>
+
+                                         public void M()
+                                         {
+                                         }
+                                     }
+                                     """;
+        const string expected = """
+                                public class C
+                                {
+                                    /** <summary>Does something.</summary> */
+                                    public void M()
+                                    {
+                                    }
+                                }
+                                """;
+        var input = inputTemplate.Replace("<TRAILING>", " \t");
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
     #endregion // Methods
 }

--- a/Reihitsu.Formatter.Test/Unit/BlankLines/BlankLinePhaseTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/BlankLines/BlankLinePhaseTests.cs
@@ -401,6 +401,217 @@ public class BlankLinePhaseTests
     }
 
     /// <summary>
+    /// Verifies that the mandatory line break after a multi-line documentation comment is preserved
+    /// when no blank line separates the comment from its declaration
+    /// </summary>
+    [TestMethod]
+    public void PreservesLineBreakAfterMultiLineDocumentationComment()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 /** <summary>
+                                  * Does something.
+                                  * </summary> */
+                                 void M()
+                                 {
+                                 }
+                             }
+                             """;
+
+        // Act
+        var actual = ApplyRewriter(input);
+
+        // Assert
+        Assert.AreEqual(input, actual);
+    }
+
+    /// <summary>
+    /// Verifies that the mandatory CRLF after a multi-line documentation comment is preserved
+    /// when no blank line separates the comment from its declaration
+    /// </summary>
+    [TestMethod]
+    public void PreservesCrlfAfterMultiLineDocumentationComment()
+    {
+        // Arrange
+        const string inputWithLf = """
+                                   class C
+                                   {
+                                       /** <summary>
+                                        * Does something.
+                                        * </summary> */
+                                       void M()
+                                       {
+                                       }
+                                   }
+                                   """;
+        var input = inputWithLf.ReplaceLineEndings("\r\n");
+
+        // Act
+        var actual = ApplyRewriter(input);
+
+        // Assert
+        Assert.AreEqual(input, actual);
+    }
+
+    /// <summary>
+    /// Verifies that a genuine blank line after a multi-line documentation comment is removed
+    /// while the mandatory line break before the declaration is preserved
+    /// </summary>
+    [TestMethod]
+    public void RemovesBlankLineAfterMultiLineDocumentationComment()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 /** <summary>
+                                  * Does something.
+                                  * </summary> */
+
+                                 void M()
+                                 {
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                class C
+                                {
+                                    /** <summary>
+                                     * Does something.
+                                     * </summary> */
+                                    void M()
+                                    {
+                                    }
+                                }
+                                """;
+
+        // Act
+        var actual = ApplyRewriter(input);
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+        Assert.AreEqual(expected, ApplyRewriter(actual));
+    }
+
+    /// <summary>
+    /// Verifies that a genuine blank line after a single-line documentation comment is still removed
+    /// </summary>
+    [TestMethod]
+    public void RemovesBlankLineAfterSingleLineDocumentationComment()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 /// <summary>
+                                 /// Does something.
+                                 /// </summary>
+
+                                 void M()
+                                 {
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                class C
+                                {
+                                    /// <summary>
+                                    /// Does something.
+                                    /// </summary>
+                                    void M()
+                                    {
+                                    }
+                                }
+                                """;
+
+        // Act
+        var actual = ApplyRewriter(input);
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    /// <summary>
+    /// Verifies that removing a blank line after a documentation comment preserves an ordinary comment
+    /// in the gap before the declaration
+    /// </summary>
+    [TestMethod]
+    public void PreservesCommentAfterDocumentationBlankLine()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 /** <summary>Does something.</summary> */
+
+                                 // Keep this comment.
+                                 void M()
+                                 {
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                class C
+                                {
+                                    /** <summary>Does something.</summary> */
+                                    // Keep this comment.
+                                    void M()
+                                    {
+                                    }
+                                }
+                                """;
+
+        // Act
+        var actual = ApplyRewriter(input);
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+        Assert.AreEqual(expected, ApplyRewriter(actual));
+    }
+
+    /// <summary>
+    /// Verifies that removing a blank line after a documentation comment preserves a preprocessor directive
+    /// in the gap before the declaration
+    /// </summary>
+    [TestMethod]
+    public void PreservesDirectiveAfterDocumentationBlankLine()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 /** <summary>Does something.</summary> */
+
+                             #if DEBUG
+                                 void M()
+                                 {
+                                 }
+                             #endif
+                             }
+                             """;
+        const string expected = """
+                                class C
+                                {
+                                    /** <summary>Does something.</summary> */
+                                #if DEBUG
+                                    void M()
+                                    {
+                                    }
+                                #endif
+                                }
+                                """;
+
+        // Act
+        var actual = ApplyRewriter(input);
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+        Assert.AreEqual(expected, ApplyRewriter(actual));
+    }
+
+    /// <summary>
     /// Verifies that no duplicate blank line is inserted when one already exists before a statement
     /// </summary>
     [TestMethod]

--- a/Reihitsu.Formatter/Pipeline/BlankLines/BlankLineCollapser.cs
+++ b/Reihitsu.Formatter/Pipeline/BlankLines/BlankLineCollapser.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -53,7 +52,7 @@ internal sealed class BlankLineCollapser : CSharpSyntaxRewriter
         {
             currentLine.Add(triviaItem);
 
-            if (triviaItem.IsKind(SyntaxKind.EndOfLineTrivia) || EndsWithEmbeddedLineBreak(triviaItem))
+            if (triviaItem.IsKind(SyntaxKind.EndOfLineTrivia) || BlankLineTriviaUtilities.EndsWithLineBreak(triviaItem))
             {
                 lines.Add(currentLine);
                 currentLine = [];
@@ -86,26 +85,6 @@ internal sealed class BlankLineCollapser : CSharpSyntaxRewriter
         FlushBlankLines(blankLineBuffer, result);
 
         return SyntaxFactory.TriviaList(result);
-    }
-
-    /// <summary>
-    /// Determines whether the specified trivia is a preprocessor directive or documentation comment whose
-    /// structured trivia embeds its own terminating end-of-line, rather than exposing it as a separate
-    /// top-level <see cref="SyntaxKind.EndOfLineTrivia"/> entry in the enclosing trivia list
-    /// </summary>
-    /// <param name="trivia">The trivia to inspect</param>
-    /// <returns><see langword="true"/> if the trivia's own text ends with a line break; otherwise, <see langword="false"/></returns>
-    private static bool EndsWithEmbeddedLineBreak(SyntaxTrivia trivia)
-    {
-        if (SyntaxTriviaUtilities.IsDirectiveOrDisabledTextTrivia(trivia) == false
-            && SyntaxTriviaUtilities.IsDocumentationCommentTrivia(trivia) == false)
-        {
-            return false;
-        }
-
-        var text = trivia.ToFullString();
-
-        return text.EndsWith("\n", StringComparison.Ordinal) || text.EndsWith("\r", StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/Reihitsu.Formatter/Pipeline/BlankLines/BlankLineTokenCleanupRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/BlankLines/BlankLineTokenCleanupRewriter.cs
@@ -206,7 +206,7 @@ internal sealed class BlankLineTokenCleanupRewriter : CSharpSyntaxRewriter
             }
         }
 
-        var endRegionEndsWithLineBreak = trivia[endRegionIndex].ToFullString().EndsWith("\n", StringComparison.Ordinal);
+        var endRegionEndsWithLineBreak = BlankLineTriviaUtilities.EndsWithLineBreak(trivia[endRegionIndex]);
         var requiredLineBreaks = endRegionEndsWithLineBreak ? 0 : 1;
 
         if (endOfLineCount <= requiredLineBreaks)
@@ -232,30 +232,42 @@ internal sealed class BlankLineTokenCleanupRewriter : CSharpSyntaxRewriter
     }
 
     /// <summary>
-    /// Removes blank lines that appear after leading documentation comments
+    /// Removes blank lines that appear after a documentation comment in leading trivia
     /// </summary>
-    /// <param name="token">The token to update</param>
-    /// <returns>The updated token</returns>
-    private static SyntaxToken RemoveBlankLinesAfterLeadingDocumentationComments(SyntaxToken token)
+    /// <param name="trivia">The leading trivia to update</param>
+    /// <param name="documentationCommentIndex">The documentation comment index</param>
+    /// <returns>The updated leading trivia</returns>
+    private static SyntaxTriviaList RemoveBlankLinesAfterDocumentationComment(SyntaxTriviaList trivia,
+                                                                              int documentationCommentIndex)
     {
-        var trivia = token.LeadingTrivia;
-        var lastDocumentationCommentIndex = GetLastDocumentationCommentIndex(trivia);
-
-        if (lastDocumentationCommentIndex < 0 || lastDocumentationCommentIndex == trivia.Count - 1)
+        if (documentationCommentIndex == trivia.Count - 1)
         {
-            return token;
+            return trivia;
         }
 
-        if (TryGetDocumentationBlankLineRun(trivia, lastDocumentationCommentIndex, out var removeUntil, out var indentationTrivia) == false)
+        var documentationCommentEndsWithLineBreak = BlankLineTriviaUtilities.EndsWithLineBreak(trivia[documentationCommentIndex]);
+
+        if (TryGetDocumentationBlankLineRun(trivia,
+                                            documentationCommentIndex,
+                                            documentationCommentEndsWithLineBreak,
+                                            out var firstEndOfLineIndex,
+                                            out var removeUntil,
+                                            out var indentationTrivia) == false)
         {
-            return token;
+            return trivia;
         }
 
-        var newTrivia = new List<SyntaxTrivia>(trivia.Count - (removeUntil - lastDocumentationCommentIndex));
+        var preservedLineBreakCount = documentationCommentEndsWithLineBreak ? 0 : 1;
+        var newTrivia = new List<SyntaxTrivia>(trivia.Count - (removeUntil - documentationCommentIndex) + preservedLineBreakCount);
 
-        for (var triviaIndex = 0; triviaIndex <= lastDocumentationCommentIndex; triviaIndex++)
+        for (var triviaIndex = 0; triviaIndex <= documentationCommentIndex; triviaIndex++)
         {
             newTrivia.Add(trivia[triviaIndex]);
+        }
+
+        if (documentationCommentEndsWithLineBreak == false)
+        {
+            newTrivia.Add(trivia[firstEndOfLineIndex]);
         }
 
         newTrivia.AddRange(indentationTrivia);
@@ -265,48 +277,64 @@ internal sealed class BlankLineTokenCleanupRewriter : CSharpSyntaxRewriter
             newTrivia.Add(trivia[triviaIndex]);
         }
 
-        return token.WithLeadingTrivia(SyntaxFactory.TriviaList(newTrivia));
+        return SyntaxFactory.TriviaList(newTrivia);
     }
 
     /// <summary>
-    /// Gets the last documentation comment trivia index in the provided list
+    /// Removes blank lines that appear after every documentation comment in a token's leading trivia
     /// </summary>
-    /// <param name="trivia">The trivia list to inspect</param>
-    /// <returns>The last documentation comment index, or <c>-1</c> when none exists</returns>
-    private static int GetLastDocumentationCommentIndex(SyntaxTriviaList trivia)
+    /// <param name="token">The token to update</param>
+    /// <returns>The updated token</returns>
+    private static SyntaxToken RemoveBlankLinesAfterLeadingDocumentationComments(SyntaxToken token)
     {
-        for (var triviaIndex = trivia.Count - 1; triviaIndex >= 0; triviaIndex--)
+        var trivia = token.LeadingTrivia;
+
+        for (var documentationCommentIndex = trivia.Count - 1; documentationCommentIndex >= 0; documentationCommentIndex--)
         {
-            if (SyntaxTriviaUtilities.IsDocumentationCommentTrivia(trivia[triviaIndex]))
+            if (SyntaxTriviaUtilities.IsDocumentationCommentTrivia(trivia[documentationCommentIndex]))
             {
-                return triviaIndex;
+                trivia = RemoveBlankLinesAfterDocumentationComment(trivia, documentationCommentIndex);
             }
         }
 
-        return -1;
+        return token.WithLeadingTrivia(trivia);
     }
 
     /// <summary>
-    /// Tries to locate the blank-line run that follows the last documentation comment
+    /// Tries to locate the blank-line run that follows the specified documentation comment
     /// </summary>
     /// <param name="trivia">The trivia list to inspect</param>
-    /// <param name="lastDocumentationCommentIndex">The last documentation comment index</param>
+    /// <param name="documentationCommentIndex">The documentation comment index</param>
+    /// <param name="documentationCommentEndsWithLineBreak">Whether the documentation comment embeds its terminating line break</param>
+    /// <param name="firstEndOfLineIndex">The index of the first explicit end-of-line after the documentation comment</param>
     /// <param name="removeUntil">The final trivia index that belongs to the removable run</param>
     /// <param name="indentationTrivia">Indentation trivia that should be preserved for the next line</param>
     /// <returns><see langword="true"/> when removable blank-line trivia was found; otherwise, <see langword="false"/></returns>
     private static bool TryGetDocumentationBlankLineRun(SyntaxTriviaList trivia,
-                                                        int lastDocumentationCommentIndex,
+                                                        int documentationCommentIndex,
+                                                        bool documentationCommentEndsWithLineBreak,
+                                                        out int firstEndOfLineIndex,
                                                         out int removeUntil,
                                                         out List<SyntaxTrivia> indentationTrivia)
     {
-        var eolIndex = lastDocumentationCommentIndex + 1;
+        var endOfLineCount = 1;
+        firstEndOfLineIndex = documentationCommentIndex + 1;
         indentationTrivia = [];
-        removeUntil = eolIndex;
+        removeUntil = firstEndOfLineIndex;
 
-        if (eolIndex >= trivia.Count || trivia[eolIndex].IsKind(SyntaxKind.EndOfLineTrivia) == false)
+        while (firstEndOfLineIndex < trivia.Count
+               && trivia[firstEndOfLineIndex].IsKind(SyntaxKind.WhitespaceTrivia))
+        {
+            firstEndOfLineIndex++;
+        }
+
+        if (firstEndOfLineIndex >= trivia.Count
+            || trivia[firstEndOfLineIndex].IsKind(SyntaxKind.EndOfLineTrivia) == false)
         {
             return false;
         }
+
+        removeUntil = firstEndOfLineIndex;
 
         while (removeUntil + 1 < trivia.Count
                && (trivia[removeUntil + 1].IsKind(SyntaxKind.EndOfLineTrivia)
@@ -316,6 +344,7 @@ internal sealed class BlankLineTokenCleanupRewriter : CSharpSyntaxRewriter
 
             if (trivia[removeUntil].IsKind(SyntaxKind.EndOfLineTrivia))
             {
+                endOfLineCount++;
                 indentationTrivia.Clear();
             }
             else if (trivia[removeUntil].IsKind(SyntaxKind.WhitespaceTrivia))
@@ -324,7 +353,9 @@ internal sealed class BlankLineTokenCleanupRewriter : CSharpSyntaxRewriter
             }
         }
 
-        return removeUntil != eolIndex;
+        var requiredEndOfLineCount = documentationCommentEndsWithLineBreak ? 0 : 1;
+
+        return endOfLineCount > requiredEndOfLineCount;
     }
 
     #endregion // Methods

--- a/Reihitsu.Formatter/Pipeline/BlankLines/BlankLineTriviaUtilities.cs
+++ b/Reihitsu.Formatter/Pipeline/BlankLines/BlankLineTriviaUtilities.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.CodeAnalysis;
+
+using Reihitsu.Core;
+
+namespace Reihitsu.Formatter.Pipeline.BlankLines;
+
+/// <summary>
+/// Shared helpers for blank-line trivia analysis
+/// </summary>
+internal static class BlankLineTriviaUtilities
+{
+    #region Methods
+
+    /// <summary>
+    /// Determines whether the specified trivia embeds its terminating line break
+    /// </summary>
+    /// <param name="trivia">The trivia to inspect</param>
+    /// <returns><see langword="true"/> if the trivia text ends with a line break; otherwise, <see langword="false"/></returns>
+    internal static bool EndsWithLineBreak(SyntaxTrivia trivia)
+    {
+        if (SyntaxTriviaUtilities.IsDirectiveOrDisabledTextTrivia(trivia) == false
+            && SyntaxTriviaUtilities.IsDocumentationCommentTrivia(trivia) == false)
+        {
+            return false;
+        }
+
+        var text = trivia.ToFullString();
+
+        return text.EndsWith("\n", StringComparison.Ordinal) || text.EndsWith("\r", StringComparison.Ordinal);
+    }
+
+    #endregion // Methods
+}

--- a/documentation/rules/RH8302.md
+++ b/documentation/rules/RH8302.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-A `///` documentation block must not be separated from the member it documents by a blank line.
+A `///` or `/** */` documentation block must not be separated from the member it documents by a blank line.
 
 ## Why is this a problem?
 
@@ -44,6 +44,20 @@ internal class TestClass
     /// <summary>
     /// Summary.
     /// </summary>
+    void Method()
+    {
+    }
+}
+```
+
+The same rule applies to multi-line documentation comments:
+
+```cs
+internal class TestClass
+{
+    /** <summary>
+     * Summary.
+     * </summary> */
     void Method()
     {
     }


### PR DESCRIPTION
## Summary

Preserve the mandatory line break after multi-line documentation comments while removing genuine blank-line runs in one pass, including trailing whitespace and repeated documentation blocks. Centralize embedded line-break detection, preserve intervening comments and directives, and align RH8302 analyzer, code-fix, formatter parity, and rule documentation with `/** */` comments.

## Why

Multi-line documentation comments expose their terminating line break as separate trivia, so blank-line cleanup could join declarations, defer cleanup to a second pass, or leave earlier gaps between stacked comments. RH8302 previously recognized only `///` and removed only one line per action, leaving formatter parity and fix convergence incomplete.

## Linked issues

Closes #526

## Review notes

RH8302 now reports the complete contiguous blank-line run after either documentation-comment form, so one code-fix or Fix All iteration converges. Formatter cleanup processes every documentation trivia in a token, counts explicit line breaks relative to embedded terminators, scans past trailing spaces and tabs, and retains ordinary comments or preprocessor directives in the affected gap.

Review follow-up excludes synthetic or unterminated EOF lines from RH8302 spans, covers LF and CRLF convergence, and retains the cheap trivia-kind guard before materializing trivia text.

## Follow-up work

None.