### PR TITLE
Align blank-line analyzers with formatter-supported statement lists

### DIFF
--- a/Reihitsu.Analyzer.Test/Formatting/RH5001TryStatementsShouldBePrecededByABlankLineAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH5001TryStatementsShouldBePrecededByABlankLineAnalyzerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 
+using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Reihitsu.Analyzer.CodeFixes.Rules.Layout;
@@ -112,6 +113,27 @@ public class RH5001TryStatementsShouldBePrecededByABlankLineAnalyzerTests : Anal
                                 """;
 
         await Verify(testCode);
+    }
+
+    /// <summary>
+    /// Verifies no diagnostics are reported for top-level try statements because the formatter does not apply
+    /// statement-spacing rules to compilation-unit statement lists
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticForTopLevelTryStatement()
+    {
+        const string testCode = """
+                                System.Console.WriteLine("Before");
+                                try
+                                {
+                                }
+                                catch
+                                {
+                                }
+                                """;
+
+        await Verify(testCode, test => test.TestState.OutputKind = OutputKind.ConsoleApplication);
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer/Base/StatementShouldBePrecededByABlankLineAnalyzerBase{TStatement}.cs
+++ b/Reihitsu.Analyzer/Base/StatementShouldBePrecededByABlankLineAnalyzerBase{TStatement}.cs
@@ -73,16 +73,16 @@ public abstract class StatementShouldBePrecededByABlankLineAnalyzerBase<TStateme
 
     /// <summary>
     /// Check if the statement is a direct member of a statement list where blank-line spacing applies. Statements
-    /// that are the unbraced embedded body of another statement (for example the body of a while/foreach/using/lock/
-    /// fixed statement or an else clause) are never preceded by a blank line by the formatter, so they are excluded
+    /// that are top-level statements or the unbraced embedded body of another statement (for example the body of a
+    /// while/foreach/using/lock/fixed statement or an else clause) are never preceded by a blank line by the formatter,
+    /// so they are excluded
     /// </summary>
     /// <param name="statement">Statement</param>
     /// <returns>Is the statement a direct member of a statement list?</returns>
     private static bool IsWithinStatementList(TStatement statement)
     {
         return statement.Parent?.IsKind(SyntaxKind.Block) == true
-               || statement.Parent?.IsKind(SyntaxKind.SwitchSection) == true
-               || statement.Parent?.IsKind(SyntaxKind.GlobalStatement) == true;
+               || statement.Parent?.IsKind(SyntaxKind.SwitchSection) == true;
     }
 
     /// <summary>

--- a/documentation/rules/RH5001.md
+++ b/documentation/rules/RH5001.md
@@ -11,6 +11,8 @@
 
 This rule checks that `try` statements are preceded by a blank line. The rule does not apply when the `try` statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
 
+The rule applies only to direct members of blocks and switch sections; top-level statements are excluded.
+
 ## Why is this a problem?
 
 Separating statements with blank lines improves code readability by visually grouping related logic. A `try` block marks the beginning of error-handling logic, and a blank line before it makes this transition clear.
@@ -18,6 +20,8 @@ Separating statements with blank lines improves code readability by visually gro
 ## How to fix it
 
 Add a blank line before the `try` statement. The rule does not apply when the statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
+
+No change is required for a top-level statement.
 
 ## Examples
 

--- a/documentation/rules/RH5002.md
+++ b/documentation/rules/RH5002.md
@@ -11,6 +11,8 @@
 
 This rule checks that `if` statements are preceded by a blank line. The rule does not apply when the `if` statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
 
+The rule applies only to direct members of blocks and switch sections; top-level statements are excluded.
+
 ## Why is this a problem?
 
 Separating statements with blank lines improves code readability by visually grouping related logic. A blank line before an `if` statement clearly delineates the start of a conditional block from the preceding code.
@@ -18,6 +20,8 @@ Separating statements with blank lines improves code readability by visually gro
 ## How to fix it
 
 Add a blank line before the `if` statement. The rule does not apply when the statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
+
+No change is required for a top-level statement.
 
 ## Examples
 

--- a/documentation/rules/RH5003.md
+++ b/documentation/rules/RH5003.md
@@ -11,6 +11,8 @@
 
 This rule checks that `while` statements are preceded by a blank line. The rule does not apply when the `while` statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
 
+The rule applies only to direct members of blocks and switch sections; top-level statements are excluded.
+
 ## Why is this a problem?
 
 Separating statements with blank lines improves code readability by visually grouping related logic. A blank line before a `while` loop makes it clear where the loop begins and separates it from preceding setup code.
@@ -18,6 +20,8 @@ Separating statements with blank lines improves code readability by visually gro
 ## How to fix it
 
 Add a blank line before the `while` statement. The rule does not apply when the statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
+
+No change is required for a top-level statement.
 
 ## Examples
 

--- a/documentation/rules/RH5004.md
+++ b/documentation/rules/RH5004.md
@@ -11,6 +11,8 @@
 
 This rule checks that `do` statements are preceded by a blank line. The rule does not apply when the `do` statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
 
+The rule applies only to direct members of blocks and switch sections; top-level statements are excluded.
+
 ## Why is this a problem?
 
 Separating statements with blank lines improves code readability by visually grouping related logic. A blank line before a `do` loop clearly marks the start of the loop construct and separates it from preceding code.
@@ -18,6 +20,8 @@ Separating statements with blank lines improves code readability by visually gro
 ## How to fix it
 
 Add a blank line before the `do` statement. The rule does not apply when the statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
+
+No change is required for a top-level statement.
 
 ## Examples
 

--- a/documentation/rules/RH5005.md
+++ b/documentation/rules/RH5005.md
@@ -11,6 +11,8 @@
 
 This rule checks that `using` statements (for resource disposal) are preceded by a blank line. This applies to `using` statements that manage disposable resources, not `using` directives for namespace imports. The rule does not apply when the `using` statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
 
+The rule applies only to direct members of blocks and switch sections; top-level statements are excluded.
+
 ## Why is this a problem?
 
 Separating statements with blank lines improves code readability by visually grouping related logic. A blank line before a `using` statement highlights the beginning of a resource-management scope.
@@ -18,6 +20,8 @@ Separating statements with blank lines improves code readability by visually gro
 ## How to fix it
 
 Add a blank line before the `using` statement. The rule does not apply when the statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
+
+No change is required for a top-level statement.
 
 ## Examples
 

--- a/documentation/rules/RH5006.md
+++ b/documentation/rules/RH5006.md
@@ -11,6 +11,8 @@
 
 This rule checks that `foreach` statements are preceded by a blank line. The rule does not apply when the `foreach` statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
 
+The rule applies only to direct members of blocks and switch sections; top-level statements are excluded.
+
 ## Why is this a problem?
 
 Separating statements with blank lines improves code readability by visually grouping related logic. A blank line before a `foreach` loop makes it clear where iteration begins and separates it from preceding setup code.
@@ -18,6 +20,8 @@ Separating statements with blank lines improves code readability by visually gro
 ## How to fix it
 
 Add a blank line before the `foreach` statement. The rule does not apply when the statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
+
+No change is required for a top-level statement.
 
 ## Examples
 

--- a/documentation/rules/RH5007.md
+++ b/documentation/rules/RH5007.md
@@ -11,6 +11,8 @@
 
 This rule checks that `for` statements are preceded by a blank line. The rule does not apply when the `for` statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
 
+The rule applies only to direct members of blocks and switch sections; top-level statements are excluded.
+
 ## Why is this a problem?
 
 Separating statements with blank lines improves code readability by visually grouping related logic. A blank line before a `for` loop clearly delineates the loop from preceding initialization or setup code.
@@ -18,6 +20,8 @@ Separating statements with blank lines improves code readability by visually gro
 ## How to fix it
 
 Add a blank line before the `for` statement. The rule does not apply when the statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
+
+No change is required for a top-level statement.
 
 ## Examples
 

--- a/documentation/rules/RH5008.md
+++ b/documentation/rules/RH5008.md
@@ -11,6 +11,8 @@
 
 This rule checks that `return` statements are preceded by a blank line. The rule does not apply when the `return` statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
 
+The rule applies only to direct members of blocks and switch sections; top-level statements are excluded.
+
 ## Why is this a problem?
 
 Separating statements with blank lines improves code readability by visually grouping related logic. A blank line before a `return` statement makes the exit point of a method clearly visible.
@@ -18,6 +20,8 @@ Separating statements with blank lines improves code readability by visually gro
 ## How to fix it
 
 Add a blank line before the `return` statement. The rule does not apply when the statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
+
+No change is required for a top-level statement.
 
 ## Examples
 

--- a/documentation/rules/RH5009.md
+++ b/documentation/rules/RH5009.md
@@ -11,6 +11,8 @@
 
 This rule checks that `goto` statements are preceded by a blank line. The rule does not apply when the `goto` statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
 
+The rule applies only to direct members of blocks and switch sections; top-level statements are excluded.
+
 ## Why is this a problem?
 
 Separating statements with blank lines improves code readability by visually grouping related logic. A blank line before a `goto` statement makes it clear that an unconditional jump is about to occur, drawing attention to the change in control flow.
@@ -18,6 +20,8 @@ Separating statements with blank lines improves code readability by visually gro
 ## How to fix it
 
 Add a blank line before the `goto` statement. The rule does not apply when the statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
+
+No change is required for a top-level statement.
 
 ## Examples
 

--- a/documentation/rules/RH5010.md
+++ b/documentation/rules/RH5010.md
@@ -11,6 +11,8 @@
 
 This rule checks that `break` statements are preceded by a blank line. This commonly applies inside switch cases and loops. The rule does not apply when the `break` statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
 
+The rule applies only to direct members of blocks and switch sections; top-level statements are excluded.
+
 ## Why is this a problem?
 
 Separating statements with blank lines improves code readability by visually grouping related logic. A blank line before a `break` statement makes the termination point of a case or loop iteration clearly visible.
@@ -18,6 +20,8 @@ Separating statements with blank lines improves code readability by visually gro
 ## How to fix it
 
 Add a blank line before the `break` statement. The rule does not apply when the statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
+
+No change is required for a top-level statement.
 
 ## Examples
 

--- a/documentation/rules/RH5012.md
+++ b/documentation/rules/RH5012.md
@@ -11,6 +11,8 @@
 
 This rule checks that `continue` statements are preceded by a blank line. The rule does not apply when the `continue` statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
 
+The rule applies only to direct members of blocks and switch sections; top-level statements are excluded.
+
 ## Why is this a problem?
 
 Separating statements with blank lines improves code readability by visually grouping related logic. A blank line before a `continue` statement clearly indicates that the current loop iteration is about to be skipped.
@@ -18,6 +20,8 @@ Separating statements with blank lines improves code readability by visually gro
 ## How to fix it
 
 Add a blank line before the `continue` statement. The rule does not apply when the statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
+
+No change is required for a top-level statement.
 
 ## Examples
 

--- a/documentation/rules/RH5013.md
+++ b/documentation/rules/RH5013.md
@@ -11,6 +11,8 @@
 
 This rule checks that `throw` statements are preceded by a blank line. The rule does not apply when the `throw` statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
 
+The rule applies only to direct members of blocks and switch sections; top-level statements are excluded.
+
 ## Why is this a problem?
 
 Separating statements with blank lines improves code readability by visually grouping related logic. A blank line before a `throw` statement draws attention to the fact that an exception is about to be raised.
@@ -18,6 +20,8 @@ Separating statements with blank lines improves code readability by visually gro
 ## How to fix it
 
 Add a blank line before the `throw` statement. The rule does not apply when the statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
+
+No change is required for a top-level statement.
 
 ## Examples
 

--- a/documentation/rules/RH5014.md
+++ b/documentation/rules/RH5014.md
@@ -11,6 +11,8 @@
 
 This rule checks that `switch` statements are preceded by a blank line. The rule does not apply when the `switch` statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
 
+The rule applies only to direct members of blocks and switch sections; top-level statements are excluded.
+
 ## Why is this a problem?
 
 Separating statements with blank lines improves code readability by visually grouping related logic. A blank line before a `switch` statement makes it clear where the branching logic begins.
@@ -18,6 +20,8 @@ Separating statements with blank lines improves code readability by visually gro
 ## How to fix it
 
 Add a blank line before the `switch` statement. The rule does not apply when the statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
+
+No change is required for a top-level statement.
 
 ## Examples
 

--- a/documentation/rules/RH5015.md
+++ b/documentation/rules/RH5015.md
@@ -11,6 +11,8 @@
 
 This rule checks that `checked` statements are preceded by a blank line. The rule does not apply when the `checked` statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
 
+The rule applies only to direct members of blocks and switch sections; top-level statements are excluded.
+
 ## Why is this a problem?
 
 Separating statements with blank lines improves code readability by visually grouping related logic. A blank line before a `checked` block makes it clear that overflow checking is being explicitly enabled for a section of code.
@@ -18,6 +20,8 @@ Separating statements with blank lines improves code readability by visually gro
 ## How to fix it
 
 Add a blank line before the `checked` statement. The rule does not apply when the statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
+
+No change is required for a top-level statement.
 
 ## Examples
 

--- a/documentation/rules/RH5016.md
+++ b/documentation/rules/RH5016.md
@@ -11,6 +11,8 @@
 
 This rule checks that `unchecked` statements are preceded by a blank line. The rule does not apply when the `unchecked` statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
 
+The rule applies only to direct members of blocks and switch sections; top-level statements are excluded.
+
 ## Why is this a problem?
 
 Separating statements with blank lines improves code readability by visually grouping related logic. A blank line before an `unchecked` block makes it clear that overflow checking is being explicitly disabled for a section of code.
@@ -18,6 +20,8 @@ Separating statements with blank lines improves code readability by visually gro
 ## How to fix it
 
 Add a blank line before the `unchecked` statement. The rule does not apply when the statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
+
+No change is required for a top-level statement.
 
 ## Examples
 

--- a/documentation/rules/RH5017.md
+++ b/documentation/rules/RH5017.md
@@ -11,6 +11,8 @@
 
 This rule checks that `fixed` statements are preceded by a blank line. The rule does not apply when the `fixed` statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
 
+The rule applies only to direct members of blocks and switch sections; top-level statements are excluded.
+
 ## Why is this a problem?
 
 Separating statements with blank lines improves code readability by visually grouping related logic. A blank line before a `fixed` statement highlights the transition into unsafe memory-pinning code.
@@ -18,6 +20,8 @@ Separating statements with blank lines improves code readability by visually gro
 ## How to fix it
 
 Add a blank line before the `fixed` statement. The rule does not apply when the statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
+
+No change is required for a top-level statement.
 
 ## Examples
 

--- a/documentation/rules/RH5018.md
+++ b/documentation/rules/RH5018.md
@@ -11,6 +11,8 @@
 
 This rule checks that `lock` statements are preceded by a blank line. The rule does not apply when the `lock` statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
 
+The rule applies only to direct members of blocks and switch sections; top-level statements are excluded.
+
 ## Why is this a problem?
 
 Separating statements with blank lines improves code readability by visually grouping related logic. A blank line before a `lock` statement makes it clear where a synchronized section of code begins.
@@ -18,6 +20,8 @@ Separating statements with blank lines improves code readability by visually gro
 ## How to fix it
 
 Add a blank line before the `lock` statement. The rule does not apply when the statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
+
+No change is required for a top-level statement.
 
 ## Examples
 

--- a/documentation/rules/RH5019.md
+++ b/documentation/rules/RH5019.md
@@ -11,6 +11,8 @@
 
 This rule checks that `yield` statements (`yield return` and `yield break`) are preceded by a blank line. The rule does not apply when the `yield` statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
 
+The rule applies only to direct members of blocks and switch sections; top-level statements are excluded.
+
 ## Why is this a problem?
 
 Separating statements with blank lines improves code readability by visually grouping related logic. A blank line before a `yield` statement makes the point where a value is produced or iteration is terminated clearly visible.
@@ -18,6 +20,8 @@ Separating statements with blank lines improves code readability by visually gro
 ## How to fix it
 
 Add a blank line before the `yield` statement. The rule does not apply when the statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
+
+No change is required for a top-level statement.
 
 ## Examples
 

--- a/documentation/rules/RH5021.md
+++ b/documentation/rules/RH5021.md
@@ -11,6 +11,8 @@
 
 This rule checks that local declarations are followed by a blank line when the next statement is a normal expression statement such as a method call.
 
+The rule applies only when the expression statement is a direct member of a block or switch section; top-level statements are excluded.
+
 ## Why is this a problem?
 
 When local declarations are placed directly next to the expression statements that use or follow them, the code becomes harder to scan. Separating declaration blocks from the next action makes the logical structure of the method easier to follow.
@@ -18,6 +20,8 @@ When local declarations are placed directly next to the expression statements th
 ## How to fix it
 
 Add a blank line after the local declaration block before the following expression statement.
+
+No change is required when the statements are top-level.
 
 ## Examples
 

--- a/documentation/rules/RH5029.md
+++ b/documentation/rules/RH5029.md
@@ -11,6 +11,8 @@
 
 This rule checks that a local declaration is preceded by a blank line when it follows another statement. The rule does not apply when the declaration is the first statement in a scope.
 
+The rule applies only when the declaration is a direct member of a block or switch section; top-level statements are excluded.
+
 ## Why is this a problem?
 
 Blank lines help separate actions from a new block of local state. Without that separation, declarations can blend into the preceding logic and make a method harder to scan.
@@ -18,6 +20,8 @@ Blank lines help separate actions from a new block of local state. Without that 
 ## How to fix it
 
 Add a blank line before the local declaration. If the declaration is the first statement in a block or switch section, no blank line is required.
+
+No change is required for a top-level declaration.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

Limit the shared preceding-blank-line analyzers to direct members of blocks and switch sections. Add top-level regression coverage and document the supported scope across all affected rules.

## Why

The formatter leaves compilation-unit statement spacing unchanged, so excluding global statements prevents formatter-stable top-level programs from receiving contradictory diagnostics.

## Linked issues

Closes #539

## Review notes

Existing block and switch-section behavior, including code fixes, is unchanged. Top-level spacing remains intentionally deferred until the formatter supports it.

## Follow-up work

None.