### PR TITLE
Exempt RH1001 collection constructions that supply a custom equality comparer

### DIFF
--- a/Reihitsu.Analyzer.Test/Performance/RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Performance/RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzerTests.cs
@@ -218,6 +218,53 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzerTests : An
                                                                 }
                                                                 """;
 
+    /// <summary>
+    /// Test data for verifying that an identical collection type referenced inside a constructor argument is not
+    /// mistaken for the collection type being constructed
+    /// </summary>
+    private const string RepeatedCollectionTypeArgumentTestData = """
+                                                                  using System.Collections.Generic;
+
+                                                                  namespace Reihitsu.Analyzer.Test.Performance.Resources;
+
+                                                                  internal struct NotImplementedStruct;
+
+                                                                  internal class RH1001
+                                                                  {
+                                                                      private object CreateDictionary() => new Dictionary<NotImplementedStruct, int>(
+                                                                          typeof(Dictionary<{|#0:NotImplementedStruct|}, int>).Name.Length,
+                                                                          EqualityComparer<NotImplementedStruct>.Default);
+                                                                  }
+                                                                  """;
+
+    /// <summary>
+    /// Test data for verifying that wrapped <see langword="null"/> comparer arguments do not exempt collection
+    /// constructions
+    /// </summary>
+    private const string WrappedNullComparerConstructionTestData = """
+                                                                   using System.Collections.Concurrent;
+                                                                   using System.Collections.Generic;
+
+                                                                   namespace Reihitsu.Analyzer.Test.Performance.Resources;
+
+                                                                   internal struct NotImplementedStruct;
+
+                                                                   internal class RH1001
+                                                                   {
+                                                                       private object CreateDictionaryWithCast() => new Dictionary<{|#0:NotImplementedStruct|}, int>(
+                                                                           comparer: (IEqualityComparer<NotImplementedStruct>)null);
+
+                                                                       private object CreateHashSetWithParentheses() => new HashSet<{|#1:NotImplementedStruct|}>(
+                                                                           comparer: ((IEqualityComparer<NotImplementedStruct>)null));
+
+                                                                       private object CreateConcurrentDictionaryWithNullForgiving() => new ConcurrentDictionary<{|#2:NotImplementedStruct|}, int>(
+                                                                           comparer: ((IEqualityComparer<NotImplementedStruct>)null)!);
+
+                                                                       private object CreateDictionaryWithConversions() => new Dictionary<{|#3:NotImplementedStruct|}, int>(
+                                                                           comparer: (IEqualityComparer<NotImplementedStruct>)(object)null);
+                                                                   }
+                                                                   """;
+
     #endregion // Constants
 
     #region Methods
@@ -284,6 +331,26 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzerTests : An
     public async Task VerifyNestedCollectionTypeArgumentIsStillFlagged()
     {
         await Verify(NestedCollectionTypeArgumentTestData, Diagnostics(RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer.DiagnosticId, AnalyzerResources.RH1001MessageFormat, 1));
+    }
+
+    /// <summary>
+    /// Verifying that an identical collection type referenced inside a constructor argument is not exempt
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyRepeatedCollectionTypeInsideConstructorArgumentIsStillFlagged()
+    {
+        await Verify(RepeatedCollectionTypeArgumentTestData, Diagnostics(RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer.DiagnosticId, AnalyzerResources.RH1001MessageFormat, 1));
+    }
+
+    /// <summary>
+    /// Verifying that wrapped <see langword="null"/> comparer arguments do not exempt collection constructions
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCollectionConstructionsWithWrappedNullComparerAreFlagged()
+    {
+        await Verify(WrappedNullComparerConstructionTestData, Diagnostics(RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer.DiagnosticId, AnalyzerResources.RH1001MessageFormat, 4));
     }
 
     #endregion // Methods

--- a/Reihitsu.Analyzer.Test/Performance/RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Performance/RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzerTests.cs
@@ -140,6 +140,84 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzerTests : An
                                                }
                                                """;
 
+    /// <summary>
+    /// Test data for verifying that collection constructions receiving an explicit custom
+    /// <c>IEqualityComparer&lt;T&gt;</c> are exempt, since the comparer bypasses the key type's own equality members
+    /// </summary>
+    private const string CustomComparerConstructionTestData = """
+                                                              using System.Collections.Concurrent;
+                                                              using System.Collections.Generic;
+
+                                                              namespace Reihitsu.Analyzer.Test.Performance.Resources;
+
+                                                              internal struct NotImplementedStruct;
+
+                                                              internal class NotImplementedStructComparer : IEqualityComparer<NotImplementedStruct>
+                                                              {
+                                                                  public bool Equals(NotImplementedStruct x, NotImplementedStruct y) => true;
+                                                                  public int GetHashCode(NotImplementedStruct obj) => 0;
+                                                              }
+
+                                                              internal class RH1001
+                                                              {
+                                                                  private static readonly IEqualityComparer<NotImplementedStruct> _comparer = new NotImplementedStructComparer();
+
+                                                                  private object CreateDictionary() => new System.Collections.Generic.Dictionary<NotImplementedStruct, string>(_comparer);
+                                                                  private object CreateHashSet() => new HashSet<NotImplementedStruct>(comparer: _comparer);
+                                                                  private object CreateConcurrentDictionary() => new ConcurrentDictionary<NotImplementedStruct, string>(
+                                                                      capacity: 1,
+                                                                      concurrencyLevel: 1,
+                                                                      comparer: _comparer);
+                                                              }
+                                                              """;
+
+    /// <summary>
+    /// Test data for verifying that a <see langword="null"/> or default comparer argument is treated like an
+    /// omitted comparer and does not exempt the diagnostic
+    /// </summary>
+    private const string NullLikeComparerConstructionTestData = """
+                                                                using System.Collections.Concurrent;
+                                                                using System.Collections.Generic;
+
+                                                                namespace Reihitsu.Analyzer.Test.Performance.Resources;
+
+                                                                internal struct NotImplementedStruct;
+
+                                                                internal class RH1001
+                                                                {
+                                                                    private object CreateDictionary() => new Dictionary<{|#0:NotImplementedStruct|}, string>(comparer: null);
+                                                                    private object CreateHashSet() => new HashSet<{|#1:NotImplementedStruct|}>(comparer: default);
+                                                                    private object CreateConcurrentDictionary() => new ConcurrentDictionary<{|#2:NotImplementedStruct|}, string>(
+                                                                        default(IEqualityComparer<NotImplementedStruct>));
+                                                                }
+                                                                """;
+
+    /// <summary>
+    /// Test data for verifying that a collection used as a nested type argument is still flagged when the outer
+    /// object creation happens to receive an equality comparer
+    /// </summary>
+    private const string NestedCollectionTypeArgumentTestData = """
+                                                                using System.Collections.Generic;
+
+                                                                namespace Reihitsu.Analyzer.Test.Performance.Resources;
+
+                                                                internal struct NotImplementedStruct;
+
+                                                                internal class Wrapper<T>
+                                                                {
+                                                                    internal Wrapper(IEqualityComparer<NotImplementedStruct> comparer)
+                                                                    {
+                                                                    }
+                                                                }
+
+                                                                internal class RH1001
+                                                                {
+                                                                    private static readonly IEqualityComparer<NotImplementedStruct> _comparer;
+
+                                                                    private object CreateWrapper() => new Wrapper<Dictionary<{|#0:NotImplementedStruct|}, string>>(_comparer);
+                                                                }
+                                                                """;
+
     #endregion // Constants
 
     #region Methods
@@ -174,6 +252,38 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzerTests : An
     public async Task VerifyStructTypesUsedAsDictionaryValuesAreNotFlagged()
     {
         await Verify(StructValueTestData);
+    }
+
+    /// <summary>
+    /// Verifying that collection constructions receiving an explicit custom <c>IEqualityComparer&lt;T&gt;</c>
+    /// are exempt
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCollectionConstructionsWithExplicitCustomComparerAreNotFlagged()
+    {
+        await Verify(CustomComparerConstructionTestData);
+    }
+
+    /// <summary>
+    /// Verifying that a <see langword="null"/> or default comparer argument does not exempt the diagnostic
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCollectionConstructionsWithNullLikeComparerAreFlagged()
+    {
+        await Verify(NullLikeComparerConstructionTestData, Diagnostics(RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer.DiagnosticId, AnalyzerResources.RH1001MessageFormat, 3));
+    }
+
+    /// <summary>
+    /// Verifying that an equality comparer on an outer object creation does not exempt a nested collection type
+    /// argument
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNestedCollectionTypeArgumentIsStillFlagged()
+    {
+        await Verify(NestedCollectionTypeArgumentTestData, Diagnostics(RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer.DiagnosticId, AnalyzerResources.RH1001MessageFormat, 1));
     }
 
     #endregion // Methods

--- a/Reihitsu.Analyzer.Test/Performance/RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Performance/RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzerTests.cs
@@ -229,11 +229,17 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzerTests : An
 
                                                                   internal struct NotImplementedStruct;
 
+                                                                  internal class NotImplementedStructComparer : IEqualityComparer<NotImplementedStruct>
+                                                                  {
+                                                                      public bool Equals(NotImplementedStruct x, NotImplementedStruct y) => true;
+                                                                      public int GetHashCode(NotImplementedStruct obj) => 0;
+                                                                  }
+
                                                                   internal class RH1001
                                                                   {
                                                                       private object CreateDictionary() => new Dictionary<NotImplementedStruct, int>(
                                                                           typeof(Dictionary<{|#0:NotImplementedStruct|}, int>).Name.Length,
-                                                                          EqualityComparer<NotImplementedStruct>.Default);
+                                                                          new NotImplementedStructComparer());
                                                                   }
                                                                   """;
 
@@ -270,33 +276,195 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzerTests : An
     /// comparer, while a nullable value-type comparer still produces <see langword="null"/>
     /// </summary>
     private const string ValueTypeDefaultComparerConstructionTestData = """
-                                                                         using System.Collections.Generic;
+                                                                        using System.Collections.Generic;
 
-                                                                         namespace Reihitsu.Analyzer.Test.Performance.Resources;
+                                                                          namespace Reihitsu.Analyzer.Test.Performance.Resources;
 
-                                                                         internal struct NotImplementedStruct;
+                                                                          internal struct NotImplementedStruct;
 
-                                                                         internal readonly struct NotImplementedStructComparer : IEqualityComparer<NotImplementedStruct>
-                                                                         {
-                                                                             public bool Equals(NotImplementedStruct x, NotImplementedStruct y) => true;
-                                                                             public int GetHashCode(NotImplementedStruct obj) => 0;
-                                                                         }
+                                                                          internal readonly struct NotImplementedStructComparer : IEqualityComparer<NotImplementedStruct>
+                                                                          {
+                                                                              public bool Equals(NotImplementedStruct x, NotImplementedStruct y) => true;
+                                                                              public int GetHashCode(NotImplementedStruct obj) => 0;
+                                                                          }
 
-                                                                         internal class RH1001
-                                                                         {
-                                                                             private object CreateHashSet() => new HashSet<NotImplementedStruct>(
-                                                                                 comparer: default(NotImplementedStructComparer));
+                                                                          internal class RH1001
+                                                                          {
+                                                                              private object CreateHashSet() => new HashSet<NotImplementedStruct>(
+                                                                                  comparer: default(NotImplementedStructComparer));
 
-                                                                            private object CreateDictionaryWithNullableComparer() => new Dictionary<{|#0:NotImplementedStruct|}, int>(
-                                                                                comparer: default(NotImplementedStructComparer?));
+                                                                             private object CreateDictionaryWithNullableComparer() => new Dictionary<{|#0:NotImplementedStruct|}, int>(
+                                                                                 comparer: default(NotImplementedStructComparer?));
 
-                                                                            private object CreateHashSetWithConvertedComparer() => new HashSet<NotImplementedStruct>(
-                                                                                comparer: (IEqualityComparer<NotImplementedStruct>)default(NotImplementedStructComparer));
+                                                                             private object CreateHashSetWithConvertedComparer() => new HashSet<NotImplementedStruct>(
+                                                                                 comparer: (IEqualityComparer<NotImplementedStruct>)default(NotImplementedStructComparer));
 
-                                                                            private object CreateDictionaryWithConvertedNullableComparer() => new Dictionary<{|#1:NotImplementedStruct|}, int>(
-                                                                                comparer: (IEqualityComparer<NotImplementedStruct>)default(NotImplementedStructComparer?));
+                                                                             private object CreateDictionaryWithConvertedNullableComparer() => new Dictionary<{|#1:NotImplementedStruct|}, int>(
+                                                                                 comparer: (IEqualityComparer<NotImplementedStruct>)default(NotImplementedStructComparer?));
                                                                         }
                                                                         """;
+
+    /// <summary>
+    /// Test data for verifying that target-typed collection constructions use their bound constructor's comparer
+    /// semantics
+    /// </summary>
+    private const string TargetTypedComparerConstructionTestData = """
+                                                                   using System.Collections.Generic;
+
+                                                                   namespace Reihitsu.Analyzer.Test.Performance.Resources;
+
+                                                                   internal struct NotImplementedStruct;
+
+                                                                   internal class NotImplementedStructComparer : IEqualityComparer<NotImplementedStruct>
+                                                                   {
+                                                                       public bool Equals(NotImplementedStruct x, NotImplementedStruct y) => true;
+                                                                       public int GetHashCode(NotImplementedStruct obj) => 0;
+                                                                   }
+
+                                                                   internal class RH1001
+                                                                   {
+                                                                       private object CreateWithCustomComparer()
+                                                                       {
+                                                                           Dictionary<NotImplementedStruct, int> values = new(new NotImplementedStructComparer());
+                                                                           return values;
+                                                                       }
+
+                                                                       private object CreateExplicitWithCustomComparer()
+                                                                       {
+                                                                           Dictionary<NotImplementedStruct, int> values =
+                                                                               new Dictionary<NotImplementedStruct, int>(new NotImplementedStructComparer());
+                                                                           return values;
+                                                                       }
+
+                                                                       private object CreateWithDefaultComparer()
+                                                                       {
+                                                                           Dictionary<{|#0:NotImplementedStruct|}, int> values = new();
+                                                                           return values;
+                                                                       }
+
+                                                                       private object CreateMultipleWithCustomComparers()
+                                                                       {
+                                                                           Dictionary<NotImplementedStruct, int> first = new(new NotImplementedStructComparer()),
+                                                                                                                 second = new(new NotImplementedStructComparer());
+                                                                           return first;
+                                                                       }
+
+                                                                       private object CreateMultipleWithMixedComparers()
+                                                                       {
+                                                                           Dictionary<{|#1:NotImplementedStruct|}, int> first = new(new NotImplementedStructComparer()),
+                                                                                                                        second = new();
+                                                                           return first;
+                                                                       }
+                                                                   }
+                                                                   """;
+
+    /// <summary>
+    /// Test data for verifying that aliased collection constructions are analyzed at their construction sites
+    /// </summary>
+    private const string AliasedComparerConstructionTestData = """
+                                                               using System.Collections.Generic;
+                                                               using NotImplementedStructDictionary = System.Collections.Generic.Dictionary<Reihitsu.Analyzer.Test.Performance.Resources.NotImplementedStruct, int>;
+
+                                                               namespace Reihitsu.Analyzer.Test.Performance.Resources;
+
+                                                               internal struct NotImplementedStruct;
+
+                                                               internal class NotImplementedStructComparer : IEqualityComparer<NotImplementedStruct>
+                                                               {
+                                                                   public bool Equals(NotImplementedStruct x, NotImplementedStruct y) => true;
+                                                                   public int GetHashCode(NotImplementedStruct obj) => 0;
+                                                               }
+
+                                                               internal class RH1001
+                                                               {
+                                                                   private object CreateExplicitWithCustomComparer() => new NotImplementedStructDictionary(new NotImplementedStructComparer());
+                                                                   private object CreateExplicitWithDefaultComparer() => new {|#0:NotImplementedStructDictionary|}();
+
+                                                                   private object CreateTargetTypedWithCustomComparer()
+                                                                   {
+                                                                       NotImplementedStructDictionary values = new(new NotImplementedStructComparer());
+                                                                       return values;
+                                                                   }
+
+                                                                   private object CreateTargetTypedWithDefaultComparer()
+                                                                   {
+                                                                       NotImplementedStructDictionary values = {|#1:new|}();
+                                                                       return values;
+                                                                   }
+                                                               }
+                                                               """;
+
+    /// <summary>
+    /// Test data for verifying that <c>EqualityComparer&lt;T&gt;.Default</c> is not treated as a custom comparer
+    /// </summary>
+    private const string FrameworkDefaultComparerConstructionTestData = """
+                                                                        using System.Collections.Generic;
+
+                                                                        namespace Reihitsu.Analyzer.Test.Performance.Resources;
+
+                                                                        internal struct NotImplementedStruct;
+
+                                                                        internal class RH1001
+                                                                        {
+                                                                            private object CreateDictionary() => new Dictionary<{|#0:NotImplementedStruct|}, int>(
+                                                                                comparer: EqualityComparer<NotImplementedStruct>.Default);
+
+                                                                            private object CreateHashSet() => new HashSet<{|#1:NotImplementedStruct|}>(
+                                                                                comparer: ((IEqualityComparer<NotImplementedStruct>)EqualityComparer<NotImplementedStruct>.Default)!);
+                                                                        }
+                                                                        """;
+
+    /// <summary>
+    /// Test data for verifying that composite comparer expressions which necessarily produce
+    /// <see langword="null"/> do not exempt collection constructions
+    /// </summary>
+    private const string CompositeNullComparerConstructionTestData = """
+                                                                     using System.Collections.Concurrent;
+                                                                     using System.Collections.Generic;
+
+                                                                     namespace Reihitsu.Analyzer.Test.Performance.Resources;
+
+                                                                     internal struct NotImplementedStruct;
+
+                                                                     internal class RH1001
+                                                                     {
+                                                                         private bool _condition;
+                                                                         private int _value;
+
+                                                                         private object CreateWithCoalescingComparer() => new Dictionary<{|#0:NotImplementedStruct|}, int>(
+                                                                             comparer: (IEqualityComparer<NotImplementedStruct>)null
+                                                                                       ?? default(IEqualityComparer<NotImplementedStruct>));
+
+                                                                         private object CreateWithConditionalComparer() => new HashSet<{|#1:NotImplementedStruct|}>(
+                                                                             comparer: _condition
+                                                                                           ? null
+                                                                                           : default(IEqualityComparer<NotImplementedStruct>));
+
+                                                                         private object CreateWithSwitchComparer() => new ConcurrentDictionary<{|#2:NotImplementedStruct|}, int>(
+                                                                             comparer: _value switch
+                                                                                       {
+                                                                                           _ => default(IEqualityComparer<NotImplementedStruct>)
+                                                                                       });
+                                                                     }
+                                                                     """;
+
+    /// <summary>
+    /// Test data for verifying that explicit object creations without parentheses are still analyzed
+    /// </summary>
+    private const string ObjectInitializerConstructionTestData = """
+                                                                 using System.Collections.Generic;
+
+                                                                 namespace Reihitsu.Analyzer.Test.Performance.Resources;
+
+                                                                 internal struct NotImplementedStruct;
+
+                                                                 internal class RH1001
+                                                                 {
+                                                                     private object CreateDictionary() => new Dictionary<{|#0:NotImplementedStruct|}, int>
+                                                                     {
+                                                                     };
+                                                                 }
+                                                                 """;
 
     #endregion // Constants
 
@@ -394,6 +562,57 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzerTests : An
     public async Task VerifyValueTypeDefaultComparerNullabilityIsRespected()
     {
         await Verify(ValueTypeDefaultComparerConstructionTestData, Diagnostics(RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer.DiagnosticId, AnalyzerResources.RH1001MessageFormat, 2));
+    }
+
+    /// <summary>
+    /// Verifying that target-typed collection constructions use their bound constructor's comparer semantics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyTargetTypedCollectionConstructionsUseBoundComparer()
+    {
+        await Verify(TargetTypedComparerConstructionTestData, Diagnostics(RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer.DiagnosticId, AnalyzerResources.RH1001MessageFormat, 2));
+    }
+
+    /// <summary>
+    /// Verifying that aliased collection constructions are analyzed at their construction sites
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyAliasedCollectionConstructionsUseBoundComparer()
+    {
+        await Verify(AliasedComparerConstructionTestData, Diagnostics(RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer.DiagnosticId, AnalyzerResources.RH1001MessageFormat, 2));
+    }
+
+    /// <summary>
+    /// Verifying that <c>EqualityComparer&lt;T&gt;.Default</c> does not exempt collection constructions
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFrameworkDefaultComparerDoesNotExemptCollectionConstructions()
+    {
+        await Verify(FrameworkDefaultComparerConstructionTestData, Diagnostics(RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer.DiagnosticId, AnalyzerResources.RH1001MessageFormat, 2));
+    }
+
+    /// <summary>
+    /// Verifying that composite comparer expressions which necessarily produce <see langword="null"/> do not
+    /// exempt collection constructions
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCompositeNullComparerDoesNotExemptCollectionConstructions()
+    {
+        await Verify(CompositeNullComparerConstructionTestData, Diagnostics(RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer.DiagnosticId, AnalyzerResources.RH1001MessageFormat, 3));
+    }
+
+    /// <summary>
+    /// Verifying that explicit object creations without parentheses are still analyzed
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyObjectInitializerConstructionWithoutParenthesesIsFlagged()
+    {
+        await Verify(ObjectInitializerConstructionTestData, Diagnostics(RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer.DiagnosticId, AnalyzerResources.RH1001MessageFormat, 1));
     }
 
     #endregion // Methods

--- a/Reihitsu.Analyzer.Test/Performance/RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Performance/RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzerTests.cs
@@ -323,6 +323,9 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzerTests : An
 
                                                                    internal class RH1001
                                                                    {
+                                                                       private bool _condition;
+                                                                       private int _value;
+
                                                                        private object CreateWithCustomComparer()
                                                                        {
                                                                            Dictionary<NotImplementedStruct, int> values = new(new NotImplementedStructComparer());
@@ -355,6 +358,38 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzerTests : An
                                                                                                                         second = new();
                                                                            return first;
                                                                        }
+
+                                                                       private object CreateParenthesizedWithCustomComparer()
+                                                                       {
+                                                                           Dictionary<NotImplementedStruct, int> values = (new(new NotImplementedStructComparer()));
+                                                                           return values;
+                                                                       }
+
+                                                                       private object CreateConditionalWithCustomComparers()
+                                                                       {
+                                                                           Dictionary<NotImplementedStruct, int> values = _condition
+                                                                               ? new(new NotImplementedStructComparer())
+                                                                               : new(new NotImplementedStructComparer());
+                                                                           return values;
+                                                                       }
+
+                                                                       private object CreateSwitchWithCustomComparers()
+                                                                       {
+                                                                           Dictionary<NotImplementedStruct, int> values = _value switch
+                                                                           {
+                                                                               0 => new(new NotImplementedStructComparer()),
+                                                                               _ => new(new NotImplementedStructComparer())
+                                                                           };
+                                                                           return values;
+                                                                       }
+
+                                                                       private object CreateConditionalWithMixedComparers()
+                                                                       {
+                                                                           Dictionary<{|#2:NotImplementedStruct|}, int> values = _condition
+                                                                               ? new(new NotImplementedStructComparer())
+                                                                               : new();
+                                                                           return values;
+                                                                       }
                                                                    }
                                                                    """;
 
@@ -364,6 +399,7 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzerTests : An
     private const string AliasedComparerConstructionTestData = """
                                                                using System.Collections.Generic;
                                                                using NotImplementedStructDictionary = System.Collections.Generic.Dictionary<Reihitsu.Analyzer.Test.Performance.Resources.NotImplementedStruct, int>;
+                                                               using NestedNotImplementedStructDictionaries = System.Collections.Generic.List<System.Collections.Generic.Dictionary<Reihitsu.Analyzer.Test.Performance.Resources.NotImplementedStruct, int>>;
 
                                                                namespace Reihitsu.Analyzer.Test.Performance.Resources;
 
@@ -377,6 +413,8 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzerTests : An
 
                                                                internal class RH1001
                                                                {
+                                                                   private {|#2:NotImplementedStructDictionary|} _field;
+
                                                                    private object CreateExplicitWithCustomComparer() => new NotImplementedStructDictionary(new NotImplementedStructComparer());
                                                                    private object CreateExplicitWithDefaultComparer() => new {|#0:NotImplementedStructDictionary|}();
 
@@ -388,9 +426,19 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzerTests : An
 
                                                                    private object CreateTargetTypedWithDefaultComparer()
                                                                    {
-                                                                       NotImplementedStructDictionary values = {|#1:new|}();
+                                                                       {|#1:NotImplementedStructDictionary|} values = new();
                                                                        return values;
                                                                    }
+
+                                                                   private {|#3:NotImplementedStructDictionary|} ReturnWithCustomComparer() =>
+                                                                       new NotImplementedStructDictionary(new NotImplementedStructComparer());
+
+                                                                   private void Accept({|#4:NotImplementedStructDictionary|} values)
+                                                                   {
+                                                                   }
+
+                                                                   private List<{|#5:NotImplementedStructDictionary|}> GetNestedAliases() => [];
+                                                                   private {|#6:NestedNotImplementedStructDictionaries|} GetAliasWithNestedCollection() => [];
                                                                }
                                                                """;
 
@@ -431,6 +479,11 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzerTests : An
                                                                          private bool _condition;
                                                                          private int _value;
 
+                                                                         private sealed class ComparerHolder
+                                                                         {
+                                                                             internal IEqualityComparer<NotImplementedStruct> Comparer { get; set; }
+                                                                         }
+
                                                                          private object CreateWithCoalescingComparer() => new Dictionary<{|#0:NotImplementedStruct|}, int>(
                                                                              comparer: (IEqualityComparer<NotImplementedStruct>)null
                                                                                        ?? default(IEqualityComparer<NotImplementedStruct>));
@@ -445,6 +498,21 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzerTests : An
                                                                                        {
                                                                                            _ => default(IEqualityComparer<NotImplementedStruct>)
                                                                                        });
+
+                                                                         private object CreateWithMixedConditionalComparer() => new Dictionary<{|#3:NotImplementedStruct|}, int>(
+                                                                             comparer: _condition
+                                                                                           ? null
+                                                                                           : EqualityComparer<NotImplementedStruct>.Default);
+
+                                                                         private object CreateWithMixedSwitchComparer() => new HashSet<{|#4:NotImplementedStruct|}>(
+                                                                             comparer: _value switch
+                                                                                       {
+                                                                                           0 => null,
+                                                                                           _ => EqualityComparer<NotImplementedStruct>.Default
+                                                                                       });
+
+                                                                         private object CreateWithNullConditionalAccessComparer() => new ConcurrentDictionary<{|#5:NotImplementedStruct|}, int>(
+                                                                             comparer: ((ComparerHolder)null)?.Comparer);
                                                                      }
                                                                      """;
 
@@ -571,7 +639,7 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzerTests : An
     [TestMethod]
     public async Task VerifyTargetTypedCollectionConstructionsUseBoundComparer()
     {
-        await Verify(TargetTypedComparerConstructionTestData, Diagnostics(RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer.DiagnosticId, AnalyzerResources.RH1001MessageFormat, 2));
+        await Verify(TargetTypedComparerConstructionTestData, Diagnostics(RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer.DiagnosticId, AnalyzerResources.RH1001MessageFormat, 3));
     }
 
     /// <summary>
@@ -581,7 +649,7 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzerTests : An
     [TestMethod]
     public async Task VerifyAliasedCollectionConstructionsUseBoundComparer()
     {
-        await Verify(AliasedComparerConstructionTestData, Diagnostics(RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer.DiagnosticId, AnalyzerResources.RH1001MessageFormat, 2));
+        await Verify(AliasedComparerConstructionTestData, Diagnostics(RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer.DiagnosticId, AnalyzerResources.RH1001MessageFormat, 7));
     }
 
     /// <summary>
@@ -602,7 +670,7 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzerTests : An
     [TestMethod]
     public async Task VerifyCompositeNullComparerDoesNotExemptCollectionConstructions()
     {
-        await Verify(CompositeNullComparerConstructionTestData, Diagnostics(RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer.DiagnosticId, AnalyzerResources.RH1001MessageFormat, 3));
+        await Verify(CompositeNullComparerConstructionTestData, Diagnostics(RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer.DiagnosticId, AnalyzerResources.RH1001MessageFormat, 6));
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer.Test/Performance/RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Performance/RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzerTests.cs
@@ -265,6 +265,39 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzerTests : An
                                                                    }
                                                                    """;
 
+    /// <summary>
+    /// Test data for verifying that <c>default(T)</c> supplies a non-null comparer for a non-nullable value-type
+    /// comparer, while a nullable value-type comparer still produces <see langword="null"/>
+    /// </summary>
+    private const string ValueTypeDefaultComparerConstructionTestData = """
+                                                                         using System.Collections.Generic;
+
+                                                                         namespace Reihitsu.Analyzer.Test.Performance.Resources;
+
+                                                                         internal struct NotImplementedStruct;
+
+                                                                         internal readonly struct NotImplementedStructComparer : IEqualityComparer<NotImplementedStruct>
+                                                                         {
+                                                                             public bool Equals(NotImplementedStruct x, NotImplementedStruct y) => true;
+                                                                             public int GetHashCode(NotImplementedStruct obj) => 0;
+                                                                         }
+
+                                                                         internal class RH1001
+                                                                         {
+                                                                             private object CreateHashSet() => new HashSet<NotImplementedStruct>(
+                                                                                 comparer: default(NotImplementedStructComparer));
+
+                                                                            private object CreateDictionaryWithNullableComparer() => new Dictionary<{|#0:NotImplementedStruct|}, int>(
+                                                                                comparer: default(NotImplementedStructComparer?));
+
+                                                                            private object CreateHashSetWithConvertedComparer() => new HashSet<NotImplementedStruct>(
+                                                                                comparer: (IEqualityComparer<NotImplementedStruct>)default(NotImplementedStructComparer));
+
+                                                                            private object CreateDictionaryWithConvertedNullableComparer() => new Dictionary<{|#1:NotImplementedStruct|}, int>(
+                                                                                comparer: (IEqualityComparer<NotImplementedStruct>)default(NotImplementedStructComparer?));
+                                                                        }
+                                                                        """;
+
     #endregion // Constants
 
     #region Methods
@@ -351,6 +384,16 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzerTests : An
     public async Task VerifyCollectionConstructionsWithWrappedNullComparerAreFlagged()
     {
         await Verify(WrappedNullComparerConstructionTestData, Diagnostics(RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer.DiagnosticId, AnalyzerResources.RH1001MessageFormat, 4));
+    }
+
+    /// <summary>
+    /// Verifying that only a nullable value-type default comparer is null-like
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyValueTypeDefaultComparerNullabilityIsRespected()
+    {
+        await Verify(ValueTypeDefaultComparerConstructionTestData, Diagnostics(RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer.DiagnosticId, AnalyzerResources.RH1001MessageFormat, 2));
     }
 
     #endregion // Methods

--- a/Reihitsu.Analyzer.Test/Performance/RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Performance/RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAnalyzerTests.cs
@@ -373,6 +373,67 @@ public class RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAna
                                                             """;
 
     /// <summary>
+    /// Test data for verifying that <c>EqualityComparer&lt;T&gt;.Default</c> is not treated as a custom comparer
+    /// </summary>
+    private const string FrameworkDefaultComparerTestData = """
+                                                            using System.Collections.Generic;
+                                                            using System.Linq;
+
+                                                            namespace Reihitsu.Analyzer.Test.Performance.Resources;
+
+                                                            internal struct NotImplementedStruct;
+
+                                                            internal class RH1002
+                                                            {
+                                                                private IEnumerable<NotImplementedStruct> _enumerable;
+
+                                                                public void Test()
+                                                                {
+                                                                    _enumerable.{|#0:Distinct|}(EqualityComparer<NotImplementedStruct>.Default);
+                                                                    _enumerable.{|#1:Distinct|}(((IEqualityComparer<NotImplementedStruct>)EqualityComparer<NotImplementedStruct>.Default)!);
+                                                                }
+                                                            }
+                                                            """;
+
+    /// <summary>
+    /// Test data for verifying that composite comparer expressions which necessarily produce
+    /// <see langword="null"/> do not exempt diagnostics
+    /// </summary>
+    private const string CompositeNullComparerTestData = """
+                                                         using System.Collections.Generic;
+                                                         using System.Linq;
+
+                                                         namespace Reihitsu.Analyzer.Test.Performance.Resources;
+
+                                                         internal struct NotImplementedStruct;
+
+                                                         internal class RH1002
+                                                         {
+                                                             private IEnumerable<NotImplementedStruct> _enumerable;
+                                                             private bool _condition;
+                                                             private int _value;
+
+                                                             public void Test()
+                                                             {
+                                                                 _enumerable.{|#0:Distinct|}(
+                                                                     (IEqualityComparer<NotImplementedStruct>)null
+                                                                     ?? default(IEqualityComparer<NotImplementedStruct>));
+
+                                                                 _enumerable.{|#1:Distinct|}(
+                                                                     _condition
+                                                                         ? null
+                                                                         : default(IEqualityComparer<NotImplementedStruct>));
+
+                                                                 _enumerable.{|#2:Distinct|}(
+                                                                     _value switch
+                                                                     {
+                                                                         _ => default(IEqualityComparer<NotImplementedStruct>)
+                                                                     });
+                                                             }
+                                                         }
+                                                         """;
+
+    /// <summary>
     /// Test data for verifying that a named <c>keySelector</c> argument in its natural position does not desync
     /// positional matching for a subsequent, unnamed comparer argument
     /// </summary>
@@ -393,7 +454,7 @@ public class RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAna
 
                                                                     public void Test()
                                                                     {
-                                                                        _enumerable.ToFrozenDictionary(keySelector: x => x, EqualityComparer<NotImplementedStruct>.Default);
+                                                                        _enumerable.{|#0:ToFrozenDictionary|}(keySelector: x => x, EqualityComparer<NotImplementedStruct>.Default);
                                                                     }
                                                                 }
                                                             }
@@ -569,6 +630,27 @@ public class RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAna
     }
 
     /// <summary>
+    /// Verifying that <c>EqualityComparer&lt;T&gt;.Default</c> does not exempt diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFrameworkDefaultComparerDoesNotExempt()
+    {
+        await Verify(FrameworkDefaultComparerTestData, Diagnostics(RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAnalyzer.DiagnosticId, AnalyzerResources.RH1002MessageFormat, 2));
+    }
+
+    /// <summary>
+    /// Verifying that composite comparer expressions which necessarily produce <see langword="null"/> do not
+    /// exempt diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCompositeNullComparerDoesNotExempt()
+    {
+        await Verify(CompositeNullComparerTestData, Diagnostics(RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAnalyzer.DiagnosticId, AnalyzerResources.RH1002MessageFormat, 3));
+    }
+
+    /// <summary>
     /// Verifying that a named <c>keySelector</c> argument in its natural position does not desync positional
     /// matching for a subsequent, unnamed comparer argument
     /// </summary>
@@ -576,7 +658,7 @@ public class RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAna
     [TestMethod]
     public async Task VerifyNamedKeySelectorArgumentDoesNotDesyncComparerDetection()
     {
-        await Verify(NamedKeySelectorArgumentTestData);
+        await Verify(NamedKeySelectorArgumentTestData, Diagnostics(RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAnalyzer.DiagnosticId, AnalyzerResources.RH1002MessageFormat, 1));
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer.Test/Performance/RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Performance/RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAnalyzerTests.cs
@@ -413,6 +413,11 @@ public class RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAna
                                                              private bool _condition;
                                                              private int _value;
 
+                                                             private sealed class ComparerHolder
+                                                             {
+                                                                 internal IEqualityComparer<NotImplementedStruct> Comparer { get; set; }
+                                                             }
+
                                                              public void Test()
                                                              {
                                                                  _enumerable.{|#0:Distinct|}(
@@ -429,6 +434,21 @@ public class RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAna
                                                                      {
                                                                          _ => default(IEqualityComparer<NotImplementedStruct>)
                                                                      });
+
+                                                                 _enumerable.{|#3:Distinct|}(
+                                                                     _condition
+                                                                         ? null
+                                                                         : EqualityComparer<NotImplementedStruct>.Default);
+
+                                                                 _enumerable.{|#4:Distinct|}(
+                                                                     _value switch
+                                                                     {
+                                                                         0 => null,
+                                                                         _ => EqualityComparer<NotImplementedStruct>.Default
+                                                                     });
+
+                                                                 _enumerable.{|#5:Distinct|}(
+                                                                     ((ComparerHolder)null)?.Comparer);
                                                              }
                                                          }
                                                          """;
@@ -647,7 +667,7 @@ public class RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAna
     [TestMethod]
     public async Task VerifyCompositeNullComparerDoesNotExempt()
     {
-        await Verify(CompositeNullComparerTestData, Diagnostics(RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAnalyzer.DiagnosticId, AnalyzerResources.RH1002MessageFormat, 3));
+        await Verify(CompositeNullComparerTestData, Diagnostics(RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAnalyzer.DiagnosticId, AnalyzerResources.RH1002MessageFormat, 6));
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer.Test/Performance/RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Performance/RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAnalyzerTests.cs
@@ -316,6 +316,31 @@ public class RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAna
                                                         """;
 
     /// <summary>
+    /// Test data for verifying that wrapped <see langword="null"/> comparer arguments are treated like omitted
+    /// comparers and do not exempt diagnostics
+    /// </summary>
+    private const string WrappedNullComparerTestData = """
+                                                       using System.Collections.Generic;
+                                                       using System.Linq;
+
+                                                       namespace Reihitsu.Analyzer.Test.Performance.Resources;
+
+                                                       internal struct NotImplementedStruct;
+
+                                                       internal class RH1002
+                                                       {
+                                                           private IEnumerable<NotImplementedStruct> _enumerable;
+
+                                                           public void Test()
+                                                           {
+                                                               _enumerable.{|#0:Distinct|}((IEqualityComparer<NotImplementedStruct>)null);
+                                                               _enumerable.{|#1:Distinct|}(((IEqualityComparer<NotImplementedStruct>)null)!);
+                                                               _enumerable.{|#2:Distinct|}((IEqualityComparer<NotImplementedStruct>)(object)null);
+                                                           }
+                                                       }
+                                                       """;
+
+    /// <summary>
     /// Test data for verifying that a named <c>keySelector</c> argument in its natural position does not desync
     /// positional matching for a subsequent, unnamed comparer argument
     /// </summary>
@@ -489,6 +514,16 @@ public class RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAna
     public async Task VerifyExplicitNullComparerArgumentDoesNotExempt()
     {
         await Verify(ExplicitNullComparerTestData, Diagnostics(RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAnalyzer.DiagnosticId, AnalyzerResources.RH1002MessageFormat, 1));
+    }
+
+    /// <summary>
+    /// Verifying that wrapped <see langword="null"/> comparer arguments do not exempt diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyWrappedNullComparerArgumentsDoNotExempt()
+    {
+        await Verify(WrappedNullComparerTestData, Diagnostics(RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAnalyzer.DiagnosticId, AnalyzerResources.RH1002MessageFormat, 3));
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer.Test/Performance/RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Performance/RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAnalyzerTests.cs
@@ -341,6 +341,38 @@ public class RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAna
                                                        """;
 
     /// <summary>
+    /// Test data for verifying that <c>default(T)</c> supplies a non-null comparer for a non-nullable value-type
+    /// comparer, while a nullable value-type comparer still produces <see langword="null"/>
+    /// </summary>
+    private const string ValueTypeDefaultComparerTestData = """
+                                                            using System.Collections.Generic;
+                                                            using System.Linq;
+
+                                                            namespace Reihitsu.Analyzer.Test.Performance.Resources;
+
+                                                            internal struct NotImplementedStruct;
+
+                                                            internal readonly struct NotImplementedStructComparer : IEqualityComparer<NotImplementedStruct>
+                                                            {
+                                                                public bool Equals(NotImplementedStruct x, NotImplementedStruct y) => true;
+                                                                public int GetHashCode(NotImplementedStruct obj) => 0;
+                                                            }
+
+                                                            internal class RH1002
+                                                            {
+                                                                private IEnumerable<NotImplementedStruct> _enumerable;
+
+                                                                public void Test()
+                                                                {
+                                                                    _enumerable.Distinct(default(NotImplementedStructComparer));
+                                                                    _enumerable.{|#0:Distinct|}(default(NotImplementedStructComparer?));
+                                                                    _enumerable.Distinct((IEqualityComparer<NotImplementedStruct>)default(NotImplementedStructComparer));
+                                                                    _enumerable.{|#1:Distinct|}((IEqualityComparer<NotImplementedStruct>)default(NotImplementedStructComparer?));
+                                                                }
+                                                            }
+                                                            """;
+
+    /// <summary>
     /// Test data for verifying that a named <c>keySelector</c> argument in its natural position does not desync
     /// positional matching for a subsequent, unnamed comparer argument
     /// </summary>
@@ -524,6 +556,16 @@ public class RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAna
     public async Task VerifyWrappedNullComparerArgumentsDoNotExempt()
     {
         await Verify(WrappedNullComparerTestData, Diagnostics(RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAnalyzer.DiagnosticId, AnalyzerResources.RH1002MessageFormat, 3));
+    }
+
+    /// <summary>
+    /// Verifying that only a nullable value-type default comparer is null-like
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyValueTypeDefaultComparerNullabilityIsRespected()
+    {
+        await Verify(ValueTypeDefaultComparerTestData, Diagnostics(RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAnalyzer.DiagnosticId, AnalyzerResources.RH1002MessageFormat, 2));
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer/Base/EqualityComparerArgumentUtilities.cs
+++ b/Reihitsu.Analyzer/Base/EqualityComparerArgumentUtilities.cs
@@ -3,6 +3,7 @@ using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace Reihitsu.Analyzer.Base;
 
@@ -17,13 +18,13 @@ internal static class EqualityComparerArgumentUtilities
     /// Determines whether an argument list passes an explicit, non-<see langword="null"/>
     /// <see cref="System.Collections.Generic.IEqualityComparer{T}"/> argument
     /// </summary>
-    /// <param name="compilation">Compilation</param>
+    /// <param name="semanticModel">Semantic model</param>
     /// <param name="argumentList">Argument list</param>
     /// <param name="parameters">Parameters of the bound method or constructor</param>
     /// <returns><see langword="true"/> if a custom equality comparer is explicitly supplied</returns>
-    internal static bool HasExplicitEqualityComparerArgument(Compilation compilation, ArgumentListSyntax argumentList, ImmutableArray<IParameterSymbol> parameters)
+    internal static bool HasExplicitEqualityComparerArgument(SemanticModel semanticModel, ArgumentListSyntax argumentList, ImmutableArray<IParameterSymbol> parameters)
     {
-        var comparerType = compilation.GetTypeByMetadataName("System.Collections.Generic.IEqualityComparer`1")?.ConstructUnboundGenericType();
+        var comparerType = semanticModel.Compilation.GetTypeByMetadataName("System.Collections.Generic.IEqualityComparer`1")?.ConstructUnboundGenericType();
 
         if (comparerType == null)
         {
@@ -53,7 +54,7 @@ internal static class EqualityComparerArgumentUtilities
 
             if (parameter is { Type: INamedTypeSymbol { IsGenericType: true } parameterType }
                 && SymbolEqualityComparer.Default.Equals(parameterType.ConstructUnboundGenericType(), comparerType)
-                && IsNullLikeExpression(argument.Expression) == false)
+                && IsNullLikeExpression(semanticModel, argument.Expression) == false)
             {
                 return true;
             }
@@ -63,17 +64,64 @@ internal static class EqualityComparerArgumentUtilities
     }
 
     /// <summary>
-    /// Determines whether an expression is <see langword="null"/> or functionally equivalent to it for a
-    /// reference-typed parameter: the <see langword="null"/> literal, target-typed <see langword="default"/>, or
-    /// an explicit <c>default(T)</c>
+    /// Determines whether an expression evaluates to <see langword="null"/>, including through parentheses,
+    /// built-in conversions, null-forgiving syntax, or a default expression
     /// </summary>
+    /// <param name="semanticModel">Semantic model</param>
     /// <param name="expression">Expression</param>
     /// <returns><see langword="true"/> if the expression is null-like</returns>
-    private static bool IsNullLikeExpression(ExpressionSyntax expression)
+    private static bool IsNullLikeExpression(SemanticModel semanticModel, ExpressionSyntax expression)
     {
-        return expression.IsKind(SyntaxKind.NullLiteralExpression)
+        var constantValue = semanticModel.GetConstantValue(expression);
+
+        if (constantValue.HasValue)
+        {
+            return constantValue.Value == null;
+        }
+
+        return IsNullLikeOperation(semanticModel.GetOperation(expression))
+               || expression.IsKind(SyntaxKind.NullLiteralExpression)
                || expression.IsKind(SyntaxKind.DefaultLiteralExpression)
                || expression.IsKind(SyntaxKind.DefaultExpression);
+    }
+
+    /// <summary>
+    /// Determines whether an operation evaluates to <see langword="null"/> after unwrapping semantics-preserving
+    /// parentheses and built-in conversions
+    /// </summary>
+    /// <param name="operation">Operation</param>
+    /// <returns><see langword="true"/> if the operation is null-like</returns>
+    private static bool IsNullLikeOperation(IOperation operation)
+    {
+        while (operation != null)
+        {
+            if (operation.ConstantValue.HasValue)
+            {
+                return operation.ConstantValue.Value == null;
+            }
+
+            switch (operation)
+            {
+                case IConversionOperation conversion when conversion.Conversion.IsUserDefined == false:
+                    {
+                        operation = conversion.Operand;
+                    }
+                    break;
+
+                case IParenthesizedOperation parenthesized:
+                    {
+                        operation = parenthesized.Operand;
+                    }
+                    break;
+
+                default:
+                    {
+                        return false;
+                    }
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer/Base/EqualityComparerArgumentUtilities.cs
+++ b/Reihitsu.Analyzer/Base/EqualityComparerArgumentUtilities.cs
@@ -54,10 +54,111 @@ internal static class EqualityComparerArgumentUtilities
 
             if (parameter is { Type: INamedTypeSymbol { IsGenericType: true } parameterType }
                 && SymbolEqualityComparer.Default.Equals(parameterType.ConstructUnboundGenericType(), comparerType)
-                && IsNullLikeExpression(semanticModel, argument.Expression) == false
-                && IsFrameworkDefaultEqualityComparerExpression(semanticModel, argument.Expression) == false)
+                && IsDefinitelyNonCustomEqualityComparerExpression(semanticModel, argument.Expression) == false)
             {
                 return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether an expression can only produce <see langword="null"/> or the framework's
+    /// <c>EqualityComparer&lt;T&gt;.Default</c>, neither of which bypasses the compared type's equality behavior
+    /// </summary>
+    /// <param name="semanticModel">Semantic model</param>
+    /// <param name="expression">Expression</param>
+    /// <returns><see langword="true"/> if every represented comparer value is non-custom</returns>
+    private static bool IsDefinitelyNonCustomEqualityComparerExpression(SemanticModel semanticModel, ExpressionSyntax expression)
+    {
+        var equalityComparerType = semanticModel.Compilation.GetTypeByMetadataName("System.Collections.Generic.EqualityComparer`1")?.ConstructUnboundGenericType();
+
+        return IsNullLikeExpression(semanticModel, expression)
+               || (equalityComparerType != null
+                   && (IsFrameworkDefaultEqualityComparerExpression(semanticModel, expression)
+                       || IsDefinitelyNonCustomEqualityComparerOperation(semanticModel.GetOperation(expression), equalityComparerType)));
+    }
+
+    /// <summary>
+    /// Determines whether an operation can only produce <see langword="null"/> or the framework's default equality
+    /// comparer, including when different branches produce different non-custom values
+    /// </summary>
+    /// <param name="operation">Operation</param>
+    /// <param name="equalityComparerType">Unbound <c>EqualityComparer&lt;T&gt;</c> type</param>
+    /// <returns><see langword="true"/> if every represented comparer value is non-custom</returns>
+    private static bool IsDefinitelyNonCustomEqualityComparerOperation(IOperation operation, INamedTypeSymbol equalityComparerType)
+    {
+        if (IsNullLikeOperation(operation)
+            || IsFrameworkDefaultEqualityComparerOperation(operation, equalityComparerType))
+        {
+            return true;
+        }
+
+        while (operation != null)
+        {
+            switch (operation)
+            {
+                case IConversionOperation conversion when conversion.Conversion.IsUserDefined == false:
+                    {
+                        operation = conversion.Operand;
+                    }
+                    break;
+
+                case IParenthesizedOperation parenthesized:
+                    {
+                        operation = parenthesized.Operand;
+                    }
+                    break;
+
+                case ICoalesceOperation coalesce:
+                    {
+                        return IsDefinitelyNonCustomEqualityComparerOperation(coalesce.Value, equalityComparerType)
+                               && IsDefinitelyNonCustomEqualityComparerOperation(coalesce.WhenNull, equalityComparerType);
+                    }
+
+                case IConditionalOperation conditional:
+                    {
+                        if (conditional.Condition.ConstantValue is { HasValue: true, Value: bool conditionValue })
+                        {
+                            return IsDefinitelyNonCustomEqualityComparerOperation(conditionValue
+                                                                                      ? conditional.WhenTrue
+                                                                                      : conditional.WhenFalse,
+                                                                                  equalityComparerType);
+                        }
+
+                        return IsDefinitelyNonCustomEqualityComparerOperation(conditional.WhenTrue, equalityComparerType)
+                               && IsDefinitelyNonCustomEqualityComparerOperation(conditional.WhenFalse, equalityComparerType);
+                    }
+
+                case ISwitchExpressionOperation switchExpression:
+                    {
+                        if (switchExpression.Arms.Length == 0)
+                        {
+                            return false;
+                        }
+
+                        foreach (var arm in switchExpression.Arms)
+                        {
+                            if (IsDefinitelyNonCustomEqualityComparerOperation(arm.Value, equalityComparerType) == false)
+                            {
+                                return false;
+                            }
+                        }
+
+                        return true;
+                    }
+
+                case IConditionalAccessOperation conditionalAccess:
+                    {
+                        return IsNullLikeOperation(conditionalAccess.Operation)
+                               || IsDefinitelyNonCustomEqualityComparerOperation(conditionalAccess.WhenNotNull, equalityComparerType);
+                    }
+
+                default:
+                    {
+                        return false;
+                    }
             }
         }
 
@@ -158,7 +259,8 @@ internal static class EqualityComparerArgumentUtilities
 
                 case IConditionalAccessOperation conditionalAccess:
                     {
-                        return IsNullLikeOperation(conditionalAccess.WhenNotNull);
+                        return IsNullLikeOperation(conditionalAccess.Operation)
+                               || IsNullLikeOperation(conditionalAccess.WhenNotNull);
                     }
 
                 default:

--- a/Reihitsu.Analyzer/Base/EqualityComparerArgumentUtilities.cs
+++ b/Reihitsu.Analyzer/Base/EqualityComparerArgumentUtilities.cs
@@ -1,0 +1,99 @@
+using System.Collections.Immutable;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Reihitsu.Analyzer.Base;
+
+/// <summary>
+/// Utilities for detecting explicitly supplied equality comparers
+/// </summary>
+internal static class EqualityComparerArgumentUtilities
+{
+    #region Methods
+
+    /// <summary>
+    /// Determines whether an argument list passes an explicit, non-<see langword="null"/>
+    /// <see cref="System.Collections.Generic.IEqualityComparer{T}"/> argument
+    /// </summary>
+    /// <param name="compilation">Compilation</param>
+    /// <param name="argumentList">Argument list</param>
+    /// <param name="parameters">Parameters of the bound method or constructor</param>
+    /// <returns><see langword="true"/> if a custom equality comparer is explicitly supplied</returns>
+    internal static bool HasExplicitEqualityComparerArgument(Compilation compilation, ArgumentListSyntax argumentList, ImmutableArray<IParameterSymbol> parameters)
+    {
+        var comparerType = compilation.GetTypeByMetadataName("System.Collections.Generic.IEqualityComparer`1")?.ConstructUnboundGenericType();
+
+        if (comparerType == null)
+        {
+            return false;
+        }
+
+        var positionalIndex = 0;
+
+        foreach (var argument in argumentList.Arguments)
+        {
+            IParameterSymbol parameter;
+
+            if (argument.NameColon != null)
+            {
+                parameter = FindParameterByName(parameters, argument.NameColon.Name.Identifier.ValueText);
+            }
+            else
+            {
+                parameter = positionalIndex < parameters.Length
+                                ? parameters[positionalIndex]
+                                : null;
+            }
+
+            // A named argument in its natural position still occupies that ordinal slot (C# 7.2+ non-trailing
+            // named arguments), so every argument advances the positional count, named or not
+            positionalIndex++;
+
+            if (parameter is { Type: INamedTypeSymbol { IsGenericType: true } parameterType }
+                && SymbolEqualityComparer.Default.Equals(parameterType.ConstructUnboundGenericType(), comparerType)
+                && IsNullLikeExpression(argument.Expression) == false)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether an expression is <see langword="null"/> or functionally equivalent to it for a
+    /// reference-typed parameter: the <see langword="null"/> literal, target-typed <see langword="default"/>, or
+    /// an explicit <c>default(T)</c>
+    /// </summary>
+    /// <param name="expression">Expression</param>
+    /// <returns><see langword="true"/> if the expression is null-like</returns>
+    private static bool IsNullLikeExpression(ExpressionSyntax expression)
+    {
+        return expression.IsKind(SyntaxKind.NullLiteralExpression)
+               || expression.IsKind(SyntaxKind.DefaultLiteralExpression)
+               || expression.IsKind(SyntaxKind.DefaultExpression);
+    }
+
+    /// <summary>
+    /// Finds a parameter by name
+    /// </summary>
+    /// <param name="parameters">Parameters</param>
+    /// <param name="name">Parameter name</param>
+    /// <returns>The matching parameter, or <see langword="null"/> if none is found</returns>
+    private static IParameterSymbol FindParameterByName(ImmutableArray<IParameterSymbol> parameters, string name)
+    {
+        foreach (var parameter in parameters)
+        {
+            if (parameter.Name == name)
+            {
+                return parameter;
+            }
+        }
+
+        return null;
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Analyzer/Base/EqualityComparerArgumentUtilities.cs
+++ b/Reihitsu.Analyzer/Base/EqualityComparerArgumentUtilities.cs
@@ -54,7 +54,8 @@ internal static class EqualityComparerArgumentUtilities
 
             if (parameter is { Type: INamedTypeSymbol { IsGenericType: true } parameterType }
                 && SymbolEqualityComparer.Default.Equals(parameterType.ConstructUnboundGenericType(), comparerType)
-                && IsNullLikeExpression(semanticModel, argument.Expression) == false)
+                && IsNullLikeExpression(semanticModel, argument.Expression) == false
+                && IsFrameworkDefaultEqualityComparerExpression(semanticModel, argument.Expression) == false)
             {
                 return true;
             }
@@ -116,6 +117,199 @@ internal static class EqualityComparerArgumentUtilities
                 case IDefaultValueOperation defaultValue:
                     {
                         return IsNullLikeDefaultType(defaultValue.Type);
+                    }
+
+                case ICoalesceOperation coalesce:
+                    {
+                        return IsNullLikeOperation(coalesce.Value)
+                               && IsNullLikeOperation(coalesce.WhenNull);
+                    }
+
+                case IConditionalOperation conditional:
+                    {
+                        if (conditional.Condition.ConstantValue is { HasValue: true, Value: bool conditionValue })
+                        {
+                            return IsNullLikeOperation(conditionValue
+                                                           ? conditional.WhenTrue
+                                                           : conditional.WhenFalse);
+                        }
+
+                        return IsNullLikeOperation(conditional.WhenTrue)
+                               && IsNullLikeOperation(conditional.WhenFalse);
+                    }
+
+                case ISwitchExpressionOperation switchExpression:
+                    {
+                        if (switchExpression.Arms.Length == 0)
+                        {
+                            return false;
+                        }
+
+                        foreach (var arm in switchExpression.Arms)
+                        {
+                            if (IsNullLikeOperation(arm.Value) == false)
+                            {
+                                return false;
+                            }
+                        }
+
+                        return true;
+                    }
+
+                case IConditionalAccessOperation conditionalAccess:
+                    {
+                        return IsNullLikeOperation(conditionalAccess.WhenNotNull);
+                    }
+
+                default:
+                    {
+                        return false;
+                    }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether an expression resolves to the framework's <c>EqualityComparer&lt;T&gt;.Default</c>,
+    /// which uses the compared type's own equality behavior and therefore is not a custom comparer
+    /// </summary>
+    /// <param name="semanticModel">Semantic model</param>
+    /// <param name="expression">Expression</param>
+    /// <returns><see langword="true"/> if the expression resolves to the framework default comparer</returns>
+    private static bool IsFrameworkDefaultEqualityComparerExpression(SemanticModel semanticModel, ExpressionSyntax expression)
+    {
+        var equalityComparerType = semanticModel.Compilation.GetTypeByMetadataName("System.Collections.Generic.EqualityComparer`1")?.ConstructUnboundGenericType();
+
+        if (equalityComparerType == null)
+        {
+            return false;
+        }
+
+        while (true)
+        {
+            switch (expression)
+            {
+                case ParenthesizedExpressionSyntax parenthesized:
+                    {
+                        expression = parenthesized.Expression;
+                    }
+                    break;
+
+                case PostfixUnaryExpressionSyntax postfixUnary when postfixUnary.IsKind(SyntaxKind.SuppressNullableWarningExpression):
+                    {
+                        expression = postfixUnary.Operand;
+                    }
+                    break;
+
+                case CastExpressionSyntax castExpression when semanticModel.GetOperation(castExpression) is IConversionOperation { Conversion.IsUserDefined: false }:
+                    {
+                        expression = castExpression.Expression;
+                    }
+                    break;
+
+                default:
+                    {
+                        return IsFrameworkDefaultEqualityComparerProperty(semanticModel, expression, equalityComparerType)
+                               || IsFrameworkDefaultEqualityComparerOperation(semanticModel.GetOperation(expression), equalityComparerType);
+                    }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Determines whether an expression directly references <c>EqualityComparer&lt;T&gt;.Default</c>
+    /// </summary>
+    /// <param name="semanticModel">Semantic model</param>
+    /// <param name="expression">Expression</param>
+    /// <param name="equalityComparerType">Unbound <c>EqualityComparer&lt;T&gt;</c> type</param>
+    /// <returns><see langword="true"/> if the expression is the framework default comparer property</returns>
+    private static bool IsFrameworkDefaultEqualityComparerProperty(SemanticModel semanticModel, ExpressionSyntax expression, INamedTypeSymbol equalityComparerType)
+    {
+        return semanticModel.GetSymbolInfo(expression).Symbol is IPropertySymbol
+                                                              {
+                                                                  IsStatic: true,
+                                                                  Name: "Default",
+                                                                  ContainingType: { IsGenericType: true } containingType
+                                                              }
+               && SymbolEqualityComparer.Default.Equals(containingType.ConstructUnboundGenericType(), equalityComparerType);
+    }
+
+    /// <summary>
+    /// Determines whether an operation necessarily produces the framework's default equality comparer
+    /// </summary>
+    /// <param name="operation">Operation</param>
+    /// <param name="equalityComparerType">Unbound <c>EqualityComparer&lt;T&gt;</c> type</param>
+    /// <returns><see langword="true"/> if the operation produces the framework default comparer</returns>
+    private static bool IsFrameworkDefaultEqualityComparerOperation(IOperation operation, INamedTypeSymbol equalityComparerType)
+    {
+        while (operation != null)
+        {
+            switch (operation)
+            {
+                case IConversionOperation conversion when conversion.Conversion.IsUserDefined == false:
+                    {
+                        operation = conversion.Operand;
+                    }
+                    break;
+
+                case IParenthesizedOperation parenthesized:
+                    {
+                        operation = parenthesized.Operand;
+                    }
+                    break;
+
+                case IPropertyReferenceOperation
+                     {
+                         Property:
+                         {
+                             IsStatic: true,
+                             Name: "Default",
+                             ContainingType: { IsGenericType: true } containingType
+                         }
+                     }:
+                    {
+                        return SymbolEqualityComparer.Default.Equals(containingType.ConstructUnboundGenericType(), equalityComparerType);
+                    }
+
+                case ICoalesceOperation coalesce:
+                    {
+                        return IsFrameworkDefaultEqualityComparerOperation(coalesce.Value, equalityComparerType)
+                               || (IsNullLikeOperation(coalesce.Value)
+                                   && IsFrameworkDefaultEqualityComparerOperation(coalesce.WhenNull, equalityComparerType));
+                    }
+
+                case IConditionalOperation conditional:
+                    {
+                        if (conditional.Condition.ConstantValue is { HasValue: true, Value: bool conditionValue })
+                        {
+                            return IsFrameworkDefaultEqualityComparerOperation(conditionValue
+                                                                                   ? conditional.WhenTrue
+                                                                                   : conditional.WhenFalse,
+                                                                               equalityComparerType);
+                        }
+
+                        return IsFrameworkDefaultEqualityComparerOperation(conditional.WhenTrue, equalityComparerType)
+                               && IsFrameworkDefaultEqualityComparerOperation(conditional.WhenFalse, equalityComparerType);
+                    }
+
+                case ISwitchExpressionOperation switchExpression:
+                    {
+                        if (switchExpression.Arms.Length == 0)
+                        {
+                            return false;
+                        }
+
+                        foreach (var arm in switchExpression.Arms)
+                        {
+                            if (IsFrameworkDefaultEqualityComparerOperation(arm.Value, equalityComparerType) == false)
+                            {
+                                return false;
+                            }
+                        }
+
+                        return true;
                     }
 
                 default:

--- a/Reihitsu.Analyzer/Base/EqualityComparerArgumentUtilities.cs
+++ b/Reihitsu.Analyzer/Base/EqualityComparerArgumentUtilities.cs
@@ -81,8 +81,7 @@ internal static class EqualityComparerArgumentUtilities
 
         return IsNullLikeOperation(semanticModel.GetOperation(expression))
                || expression.IsKind(SyntaxKind.NullLiteralExpression)
-               || expression.IsKind(SyntaxKind.DefaultLiteralExpression)
-               || expression.IsKind(SyntaxKind.DefaultExpression);
+               || IsNullLikeDefaultExpression(semanticModel, expression);
     }
 
     /// <summary>
@@ -114,6 +113,11 @@ internal static class EqualityComparerArgumentUtilities
                     }
                     break;
 
+                case IDefaultValueOperation defaultValue:
+                    {
+                        return IsNullLikeDefaultType(defaultValue.Type);
+                    }
+
                 default:
                     {
                         return false;
@@ -122,6 +126,40 @@ internal static class EqualityComparerArgumentUtilities
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Determines whether a default expression produces <see langword="null"/> when converted to the comparer
+    /// parameter. A non-nullable value-type comparer is boxed as a real comparer, while reference types,
+    /// nullable value types, and types that cannot be resolved conservatively remain null-like
+    /// </summary>
+    /// <param name="semanticModel">Semantic model</param>
+    /// <param name="expression">Expression</param>
+    /// <returns><see langword="true"/> if the default expression is null-like</returns>
+    private static bool IsNullLikeDefaultExpression(SemanticModel semanticModel, ExpressionSyntax expression)
+    {
+        if (expression.IsKind(SyntaxKind.DefaultLiteralExpression) == false
+            && expression.IsKind(SyntaxKind.DefaultExpression) == false)
+        {
+            return false;
+        }
+
+        var expressionType = semanticModel.GetTypeInfo(expression).Type;
+
+        return IsNullLikeDefaultType(expressionType);
+    }
+
+    /// <summary>
+    /// Determines whether the default value of a type produces <see langword="null"/> when converted to the
+    /// comparer parameter
+    /// </summary>
+    /// <param name="type">Type of the default value</param>
+    /// <returns><see langword="true"/> if the default value is null-like</returns>
+    private static bool IsNullLikeDefaultType(ITypeSymbol type)
+    {
+        return type == null
+               || type.IsValueType == false
+               || type is INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T };
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer/Rules/Performance/RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Performance/RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer.cs
@@ -92,6 +92,7 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer : StructE
         var objectCreation = genericName.FirstAncestorOrSelf<ObjectCreationExpressionSyntax>();
 
         if (objectCreation?.ArgumentList == null
+            || objectCreation.Type.Span.Contains(genericName.Span) == false
             || context.SemanticModel.GetTypeInfo(objectCreation).Type is not INamedTypeSymbol createdType
             || SymbolEqualityComparer.Default.Equals(createdType, collectionType) == false
             || context.SemanticModel.GetSymbolInfo(objectCreation).Symbol is not IMethodSymbol constructor)
@@ -99,7 +100,7 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer : StructE
             return false;
         }
 
-        return EqualityComparerArgumentUtilities.HasExplicitEqualityComparerArgument(context.Compilation, objectCreation.ArgumentList, constructor.Parameters);
+        return EqualityComparerArgumentUtilities.HasExplicitEqualityComparerArgument(context.SemanticModel, objectCreation.ArgumentList, constructor.Parameters);
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer/Rules/Performance/RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Performance/RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer.cs
@@ -80,27 +80,184 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer : StructE
     }
 
     /// <summary>
-    /// Determines whether the generic name represents the collection type in an object creation that passes an
-    /// explicit custom equality comparer
+    /// Determines whether a collection type should produce the diagnostic
     /// </summary>
-    /// <param name="context">Context</param>
+    /// <param name="compilation">Compilation</param>
+    /// <param name="collectionType">Collection type</param>
+    /// <returns><see langword="true"/> if the key is a struct without equality members</returns>
+    private static bool ShouldReportDiagnostic(Compilation compilation, INamedTypeSymbol collectionType)
+    {
+        // Only the key position is hashed. For every recognized collection type the key is the first
+        // type argument (dictionaries: key, value; sets: element), so restrict the check to index 0.
+        var keyType = collectionType.TypeArguments[0];
+
+        return keyType.TypeKind == TypeKind.Structure
+               && AreEqualityMembersImplemented(compilation, keyType) == false;
+    }
+
+    /// <summary>
+    /// Determines whether a generic name is the collection type being explicitly constructed
+    /// </summary>
+    /// <param name="semanticModel">Semantic model</param>
     /// <param name="genericName">Generic collection name</param>
     /// <param name="collectionType">Bound collection type</param>
-    /// <returns><see langword="true"/> if the collection construction explicitly supplies a custom comparer</returns>
-    private static bool IsConstructionWithExplicitEqualityComparer(SyntaxNodeAnalysisContext context, GenericNameSyntax genericName, INamedTypeSymbol collectionType)
+    /// <returns><see langword="true"/> if the generic name is the explicitly constructed type</returns>
+    private static bool IsExplicitlyConstructedType(SemanticModel semanticModel, GenericNameSyntax genericName, INamedTypeSymbol collectionType)
     {
         var objectCreation = genericName.FirstAncestorOrSelf<ObjectCreationExpressionSyntax>();
 
-        if (objectCreation?.ArgumentList == null
-            || objectCreation.Type.Span.Contains(genericName.Span) == false
-            || context.SemanticModel.GetTypeInfo(objectCreation).Type is not INamedTypeSymbol createdType
-            || SymbolEqualityComparer.Default.Equals(createdType, collectionType) == false
-            || context.SemanticModel.GetSymbolInfo(objectCreation).Symbol is not IMethodSymbol constructor)
+        return objectCreation != null
+               && objectCreation.Type.Span.Contains(genericName.Span)
+               && semanticModel.GetTypeInfo(objectCreation).Type is INamedTypeSymbol createdType
+               && SymbolEqualityComparer.Default.Equals(createdType, collectionType);
+    }
+
+    /// <summary>
+    /// Determines whether every object creation directly initialized through a generic type reference supplies
+    /// an explicit custom equality comparer
+    /// </summary>
+    /// <param name="semanticModel">Semantic model</param>
+    /// <param name="genericName">Generic collection name</param>
+    /// <param name="collectionType">Bound collection type</param>
+    /// <returns><see langword="true"/> if all associated creations supply custom comparers</returns>
+    private static bool AreInitializerCreationsUsingExplicitEqualityComparers(SemanticModel semanticModel, GenericNameSyntax genericName, INamedTypeSymbol collectionType)
+    {
+        if (genericName.FirstAncestorOrSelf<VariableDeclarationSyntax>() is { } variableDeclaration
+            && variableDeclaration.Type.Span.Contains(genericName.Span)
+            && variableDeclaration.Variables.Count > 0)
+        {
+            foreach (var variable in variableDeclaration.Variables)
+            {
+                if (HasExplicitEqualityComparerInitializer(semanticModel, variable.Initializer?.Value, collectionType) == false)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        if (genericName.FirstAncestorOrSelf<PropertyDeclarationSyntax>() is { } propertyDeclaration
+            && propertyDeclaration.Type.Span.Contains(genericName.Span))
+        {
+            return HasExplicitEqualityComparerInitializer(semanticModel, propertyDeclaration.Initializer?.Value, collectionType);
+        }
+
+        if (genericName.FirstAncestorOrSelf<CastExpressionSyntax>() is { } castExpression
+            && castExpression.Type.Span.Contains(genericName.Span))
+        {
+            return HasExplicitEqualityComparerInitializer(semanticModel, castExpression.Expression, collectionType);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether an initializer is an explicit or implicit object creation supplying a custom comparer
+    /// </summary>
+    /// <param name="semanticModel">Semantic model</param>
+    /// <param name="initializer">Initializer expression</param>
+    /// <param name="expectedType">Expected collection type</param>
+    /// <returns><see langword="true"/> if the initializer construction receives a custom comparer</returns>
+    private static bool HasExplicitEqualityComparerInitializer(SemanticModel semanticModel, ExpressionSyntax initializer, INamedTypeSymbol expectedType)
+    {
+        return initializer switch
+               {
+                   ObjectCreationExpressionSyntax { ArgumentList: not null } objectCreation => HasExplicitEqualityComparer(semanticModel,
+                                                                                                                           objectCreation,
+                                                                                                                           objectCreation.ArgumentList,
+                                                                                                                           expectedType),
+                   ImplicitObjectCreationExpressionSyntax implicitCreation => HasExplicitEqualityComparer(semanticModel,
+                                                                                                          implicitCreation,
+                                                                                                          implicitCreation.ArgumentList,
+                                                                                                          expectedType),
+                   _ => false
+               };
+    }
+
+    /// <summary>
+    /// Determines whether an object creation supplies an explicit custom equality comparer
+    /// </summary>
+    /// <param name="semanticModel">Semantic model</param>
+    /// <param name="objectCreation">Object creation</param>
+    /// <param name="argumentList">Argument list</param>
+    /// <param name="expectedType">Expected collection type</param>
+    /// <returns><see langword="true"/> if the bound constructor receives a custom comparer</returns>
+    private static bool HasExplicitEqualityComparer(SemanticModel semanticModel, ExpressionSyntax objectCreation, ArgumentListSyntax argumentList, INamedTypeSymbol expectedType)
+    {
+        return semanticModel.GetTypeInfo(objectCreation).Type is INamedTypeSymbol createdType
+               && SymbolEqualityComparer.Default.Equals(createdType, expectedType)
+               && semanticModel.GetSymbolInfo(objectCreation).Symbol is IMethodSymbol constructor
+               && EqualityComparerArgumentUtilities.HasExplicitEqualityComparerArgument(semanticModel, argumentList, constructor.Parameters);
+    }
+
+    /// <summary>
+    /// Determines whether an implicit creation's immediate target type contains the matching generic collection
+    /// name, which is analyzed separately to preserve the key-type diagnostic location
+    /// </summary>
+    /// <param name="semanticModel">Semantic model</param>
+    /// <param name="objectCreation">Implicit object creation</param>
+    /// <param name="collectionType">Created collection type</param>
+    /// <returns><see langword="true"/> if the target generic name owns analysis of the creation</returns>
+    private static bool IsAnalyzedByTargetGenericName(SemanticModel semanticModel, ImplicitObjectCreationExpressionSyntax objectCreation, INamedTypeSymbol collectionType)
+    {
+        TypeSyntax targetType = null;
+
+        if (objectCreation.Parent is EqualsValueClauseSyntax equalsValue)
+        {
+            targetType = equalsValue.Parent switch
+                         {
+                             VariableDeclaratorSyntax { Parent: VariableDeclarationSyntax variableDeclaration } => variableDeclaration.Type,
+                             PropertyDeclarationSyntax propertyDeclaration => propertyDeclaration.Type,
+                             _ => null
+                         };
+        }
+        else if (objectCreation.Parent is CastExpressionSyntax castExpression
+                 && castExpression.Expression == objectCreation)
+        {
+            targetType = castExpression.Type;
+        }
+
+        if (targetType == null)
         {
             return false;
         }
 
-        return EqualityComparerArgumentUtilities.HasExplicitEqualityComparerArgument(context.SemanticModel, objectCreation.ArgumentList, constructor.Parameters);
+        foreach (var node in targetType.DescendantNodesAndSelf())
+        {
+            if (node is GenericNameSyntax genericName
+                && semanticModel.GetSymbolInfo(genericName).Symbol is INamedTypeSymbol targetTypeSymbol
+                && SymbolEqualityComparer.Default.Equals(targetTypeSymbol, collectionType))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Gets the diagnostic location for an explicit object creation
+    /// </summary>
+    /// <param name="semanticModel">Semantic model</param>
+    /// <param name="objectCreation">Object creation</param>
+    /// <param name="collectionType">Created collection type</param>
+    /// <returns>Diagnostic location</returns>
+    private static Location GetObjectCreationDiagnosticLocation(SemanticModel semanticModel, ObjectCreationExpressionSyntax objectCreation, INamedTypeSymbol collectionType)
+    {
+        foreach (var node in objectCreation.Type.DescendantNodesAndSelf())
+        {
+            if (node is GenericNameSyntax genericName
+                && semanticModel.GetSymbolInfo(genericName).Symbol is INamedTypeSymbol typeSymbol
+                && SymbolEqualityComparer.Default.Equals(typeSymbol, collectionType))
+            {
+                return genericName.TypeArgumentList.Arguments.Count > 0
+                           ? genericName.TypeArgumentList.Arguments[0].GetLocation()
+                           : genericName.GetLocation();
+            }
+        }
+
+        return objectCreation.Type.GetLocation();
     }
 
     /// <summary>
@@ -124,21 +281,22 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer : StructE
             return;
         }
 
-        if (IsConstructionWithExplicitEqualityComparer(context, genericName, namedTypeSymbol))
+        if (genericName.FirstAncestorOrSelf<UsingDirectiveSyntax>() is { Alias: not null })
         {
             return;
         }
 
-        // Only the key position is hashed. For every recognized collection type the key is the first
-        // type argument (dictionaries: key, value; sets: element), so restrict the check to index 0.
-        var keyType = namedTypeSymbol.TypeArguments[0];
-
-        if (keyType.TypeKind != TypeKind.Structure)
+        if (IsExplicitlyConstructedType(context.SemanticModel, genericName, namedTypeSymbol))
         {
             return;
         }
 
-        if (AreEqualityMembersImplemented(context.Compilation, keyType) == false)
+        if (AreInitializerCreationsUsingExplicitEqualityComparers(context.SemanticModel, genericName, namedTypeSymbol))
+        {
+            return;
+        }
+
+        if (ShouldReportDiagnostic(context.Compilation, namedTypeSymbol))
         {
             var location = genericName.TypeArgumentList.Arguments.Count > 0
                                ? genericName.TypeArgumentList.Arguments[0].GetLocation()
@@ -146,6 +304,48 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer : StructE
 
             context.ReportDiagnostic(CreateDiagnostic(location));
         }
+    }
+
+    /// <summary>
+    /// Analyzing explicit object creations, including types referenced through aliases
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnObjectCreation(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not ObjectCreationExpressionSyntax objectCreation
+            || context.SemanticModel.GetTypeInfo(objectCreation).Type is not INamedTypeSymbol collectionType
+            || IsRelevantCollectionType(context.Compilation, collectionType) == false
+            || ShouldReportDiagnostic(context.Compilation, collectionType) == false)
+        {
+            return;
+        }
+
+        if (objectCreation.ArgumentList != null
+            && HasExplicitEqualityComparer(context.SemanticModel, objectCreation, objectCreation.ArgumentList, collectionType))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(CreateDiagnostic(GetObjectCreationDiagnosticLocation(context.SemanticModel, objectCreation, collectionType)));
+    }
+
+    /// <summary>
+    /// Analyzing implicit object creations whose target collection type is referenced through an alias
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnImplicitObjectCreation(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not ImplicitObjectCreationExpressionSyntax objectCreation
+            || context.SemanticModel.GetTypeInfo(objectCreation).Type is not INamedTypeSymbol collectionType
+            || IsRelevantCollectionType(context.Compilation, collectionType) == false
+            || ShouldReportDiagnostic(context.Compilation, collectionType) == false
+            || IsAnalyzedByTargetGenericName(context.SemanticModel, objectCreation, collectionType)
+            || HasExplicitEqualityComparer(context.SemanticModel, objectCreation, objectCreation.ArgumentList, collectionType))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(CreateDiagnostic(objectCreation.NewKeyword.GetLocation()));
     }
 
     #endregion // Methods
@@ -158,6 +358,8 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer : StructE
         base.Initialize(context);
 
         context.RegisterSyntaxNodeAction(OnGenericName, SyntaxKind.GenericName);
+        context.RegisterSyntaxNodeAction(OnObjectCreation, SyntaxKind.ObjectCreationExpression);
+        context.RegisterSyntaxNodeAction(OnImplicitObjectCreation, SyntaxKind.ImplicitObjectCreationExpression);
     }
 
     #endregion // DiagnosticAnalyzer

--- a/Reihitsu.Analyzer/Rules/Performance/RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Performance/RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer.cs
@@ -2,6 +2,7 @@
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
 
 using Reihitsu.Analyzer.Base;
 using Reihitsu.Analyzer.Enumerations;
@@ -96,18 +97,18 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer : StructE
     }
 
     /// <summary>
-    /// Determines whether a generic name is the collection type being explicitly constructed
+    /// Determines whether a type reference is the collection type being explicitly constructed
     /// </summary>
     /// <param name="semanticModel">Semantic model</param>
-    /// <param name="genericName">Generic collection name</param>
+    /// <param name="typeReference">Collection type reference</param>
     /// <param name="collectionType">Bound collection type</param>
-    /// <returns><see langword="true"/> if the generic name is the explicitly constructed type</returns>
-    private static bool IsExplicitlyConstructedType(SemanticModel semanticModel, GenericNameSyntax genericName, INamedTypeSymbol collectionType)
+    /// <returns><see langword="true"/> if the type reference is the explicitly constructed type</returns>
+    private static bool IsExplicitlyConstructedType(SemanticModel semanticModel, TypeSyntax typeReference, INamedTypeSymbol collectionType)
     {
-        var objectCreation = genericName.FirstAncestorOrSelf<ObjectCreationExpressionSyntax>();
+        var objectCreation = typeReference.FirstAncestorOrSelf<ObjectCreationExpressionSyntax>();
 
         return objectCreation != null
-               && objectCreation.Type.Span.Contains(genericName.Span)
+               && objectCreation.Type.Span.Contains(typeReference.Span)
                && semanticModel.GetTypeInfo(objectCreation).Type is INamedTypeSymbol createdType
                && SymbolEqualityComparer.Default.Equals(createdType, collectionType);
     }
@@ -117,13 +118,13 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer : StructE
     /// an explicit custom equality comparer
     /// </summary>
     /// <param name="semanticModel">Semantic model</param>
-    /// <param name="genericName">Generic collection name</param>
+    /// <param name="typeReference">Collection type reference</param>
     /// <param name="collectionType">Bound collection type</param>
     /// <returns><see langword="true"/> if all associated creations supply custom comparers</returns>
-    private static bool AreInitializerCreationsUsingExplicitEqualityComparers(SemanticModel semanticModel, GenericNameSyntax genericName, INamedTypeSymbol collectionType)
+    private static bool AreInitializerCreationsUsingExplicitEqualityComparers(SemanticModel semanticModel, TypeSyntax typeReference, INamedTypeSymbol collectionType)
     {
-        if (genericName.FirstAncestorOrSelf<VariableDeclarationSyntax>() is { } variableDeclaration
-            && variableDeclaration.Type.Span.Contains(genericName.Span)
+        if (typeReference.FirstAncestorOrSelf<VariableDeclarationSyntax>() is { } variableDeclaration
+            && variableDeclaration.Type.Span.Contains(typeReference.Span)
             && variableDeclaration.Variables.Count > 0)
         {
             foreach (var variable in variableDeclaration.Variables)
@@ -137,14 +138,14 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer : StructE
             return true;
         }
 
-        if (genericName.FirstAncestorOrSelf<PropertyDeclarationSyntax>() is { } propertyDeclaration
-            && propertyDeclaration.Type.Span.Contains(genericName.Span))
+        if (typeReference.FirstAncestorOrSelf<PropertyDeclarationSyntax>() is { } propertyDeclaration
+            && propertyDeclaration.Type.Span.Contains(typeReference.Span))
         {
             return HasExplicitEqualityComparerInitializer(semanticModel, propertyDeclaration.Initializer?.Value, collectionType);
         }
 
-        if (genericName.FirstAncestorOrSelf<CastExpressionSyntax>() is { } castExpression
-            && castExpression.Type.Span.Contains(genericName.Span))
+        if (typeReference.FirstAncestorOrSelf<CastExpressionSyntax>() is { } castExpression
+            && castExpression.Type.Span.Contains(typeReference.Span))
         {
             return HasExplicitEqualityComparerInitializer(semanticModel, castExpression.Expression, collectionType);
         }
@@ -161,18 +162,81 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer : StructE
     /// <returns><see langword="true"/> if the initializer construction receives a custom comparer</returns>
     private static bool HasExplicitEqualityComparerInitializer(SemanticModel semanticModel, ExpressionSyntax initializer, INamedTypeSymbol expectedType)
     {
-        return initializer switch
-               {
-                   ObjectCreationExpressionSyntax { ArgumentList: not null } objectCreation => HasExplicitEqualityComparer(semanticModel,
-                                                                                                                           objectCreation,
-                                                                                                                           objectCreation.ArgumentList,
-                                                                                                                           expectedType),
-                   ImplicitObjectCreationExpressionSyntax implicitCreation => HasExplicitEqualityComparer(semanticModel,
-                                                                                                          implicitCreation,
-                                                                                                          implicitCreation.ArgumentList,
-                                                                                                          expectedType),
-                   _ => false
-               };
+        switch (initializer)
+        {
+            case ParenthesizedExpressionSyntax parenthesized:
+                {
+                    return HasExplicitEqualityComparerInitializer(semanticModel, parenthesized.Expression, expectedType);
+                }
+
+            case PostfixUnaryExpressionSyntax postfixUnary when postfixUnary.IsKind(SyntaxKind.SuppressNullableWarningExpression):
+                {
+                    return HasExplicitEqualityComparerInitializer(semanticModel, postfixUnary.Operand, expectedType);
+                }
+
+            case CastExpressionSyntax castExpression when semanticModel.GetOperation(castExpression) is IConversionOperation
+                                                                                                     {
+                                                                                                         Conversion.IsUserDefined: false
+                                                                                                     }:
+                {
+                    return HasExplicitEqualityComparerInitializer(semanticModel, castExpression.Expression, expectedType);
+                }
+
+            case ConditionalExpressionSyntax conditional:
+                {
+                    if (semanticModel.GetConstantValue(conditional.Condition) is { HasValue: true, Value: bool conditionValue })
+                    {
+                        return HasExplicitEqualityComparerInitializer(semanticModel,
+                                                                      conditionValue
+                                                                          ? conditional.WhenTrue
+                                                                          : conditional.WhenFalse,
+                                                                      expectedType);
+                    }
+
+                    return HasExplicitEqualityComparerInitializer(semanticModel, conditional.WhenTrue, expectedType)
+                           && HasExplicitEqualityComparerInitializer(semanticModel, conditional.WhenFalse, expectedType);
+                }
+
+            case SwitchExpressionSyntax { Arms.Count: > 0 } switchExpression:
+                {
+                    return AreSwitchExpressionArmsUsingExplicitEqualityComparers(semanticModel, switchExpression, expectedType);
+                }
+
+            case ObjectCreationExpressionSyntax { ArgumentList: not null } objectCreation:
+                {
+                    return HasExplicitEqualityComparer(semanticModel, objectCreation, objectCreation.ArgumentList, expectedType);
+                }
+
+            case ImplicitObjectCreationExpressionSyntax implicitCreation:
+                {
+                    return HasExplicitEqualityComparer(semanticModel, implicitCreation, implicitCreation.ArgumentList, expectedType);
+                }
+
+            default:
+                {
+                    return false;
+                }
+        }
+    }
+
+    /// <summary>
+    /// Determines whether every switch-expression arm constructs the expected collection with a custom comparer
+    /// </summary>
+    /// <param name="semanticModel">Semantic model</param>
+    /// <param name="switchExpression">Switch expression</param>
+    /// <param name="expectedType">Expected collection type</param>
+    /// <returns><see langword="true"/> if every arm constructs the collection with a custom comparer</returns>
+    private static bool AreSwitchExpressionArmsUsingExplicitEqualityComparers(SemanticModel semanticModel, SwitchExpressionSyntax switchExpression, INamedTypeSymbol expectedType)
+    {
+        foreach (var arm in switchExpression.Arms)
+        {
+            if (HasExplicitEqualityComparerInitializer(semanticModel, arm.Expression, expectedType) == false)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /// <summary>
@@ -192,44 +256,80 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer : StructE
     }
 
     /// <summary>
-    /// Determines whether an implicit creation's immediate target type contains the matching generic collection
-    /// name, which is analyzed separately to preserve the key-type diagnostic location
+    /// Determines whether a creation is inside a collection-typed variable, property, or cast initializer whose
+    /// type reference owns analysis of all initializer branches
     /// </summary>
     /// <param name="semanticModel">Semantic model</param>
-    /// <param name="objectCreation">Implicit object creation</param>
+    /// <param name="objectCreation">Object creation</param>
     /// <param name="collectionType">Created collection type</param>
-    /// <returns><see langword="true"/> if the target generic name owns analysis of the creation</returns>
-    private static bool IsAnalyzedByTargetGenericName(SemanticModel semanticModel, ImplicitObjectCreationExpressionSyntax objectCreation, INamedTypeSymbol collectionType)
+    /// <returns><see langword="true"/> if a target type reference owns analysis of the creation</returns>
+    private static bool IsAnalyzedByTargetTypeReference(SemanticModel semanticModel, ExpressionSyntax objectCreation, INamedTypeSymbol collectionType)
     {
-        TypeSyntax targetType = null;
+        SyntaxNode current = objectCreation;
 
-        if (objectCreation.Parent is EqualsValueClauseSyntax equalsValue)
+        while (current.Parent != null)
         {
-            targetType = equalsValue.Parent switch
-                         {
-                             VariableDeclaratorSyntax { Parent: VariableDeclarationSyntax variableDeclaration } => variableDeclaration.Type,
-                             PropertyDeclarationSyntax propertyDeclaration => propertyDeclaration.Type,
-                             _ => null
-                         };
-        }
-        else if (objectCreation.Parent is CastExpressionSyntax castExpression
-                 && castExpression.Expression == objectCreation)
-        {
-            targetType = castExpression.Type;
-        }
-
-        if (targetType == null)
-        {
-            return false;
-        }
-
-        foreach (var node in targetType.DescendantNodesAndSelf())
-        {
-            if (node is GenericNameSyntax genericName
-                && semanticModel.GetSymbolInfo(genericName).Symbol is INamedTypeSymbol targetTypeSymbol
-                && SymbolEqualityComparer.Default.Equals(targetTypeSymbol, collectionType))
+            switch (current.Parent)
             {
-                return true;
+                case ParenthesizedExpressionSyntax parenthesized when parenthesized.Expression == current:
+                    {
+                        current = parenthesized;
+                    }
+                    break;
+
+                case PostfixUnaryExpressionSyntax postfixUnary when postfixUnary.Operand == current
+                                                                    && postfixUnary.IsKind(SyntaxKind.SuppressNullableWarningExpression):
+                    {
+                        current = postfixUnary;
+                    }
+                    break;
+
+                case ConditionalExpressionSyntax conditional when conditional.WhenTrue == current
+                                                                  || conditional.WhenFalse == current:
+                    {
+                        current = conditional;
+                    }
+                    break;
+
+                case SwitchExpressionArmSyntax switchArm when switchArm.Expression == current:
+                    {
+                        current = switchArm;
+                    }
+                    break;
+
+                case SwitchExpressionSyntax switchExpression when current is SwitchExpressionArmSyntax:
+                    {
+                        current = switchExpression;
+                    }
+                    break;
+
+                case CastExpressionSyntax castExpression when castExpression.Expression == current:
+                    {
+                        return semanticModel.GetTypeInfo(castExpression.Type).Type is INamedTypeSymbol castType
+                               && SymbolEqualityComparer.Default.Equals(castType, collectionType);
+                    }
+
+                case EqualsValueClauseSyntax equalsValue when equalsValue.Value == current:
+                    {
+                        var targetType = equalsValue.Parent switch
+                                         {
+                                             VariableDeclaratorSyntax
+                                             {
+                                                 Parent: VariableDeclarationSyntax variableDeclaration
+                                             } => variableDeclaration.Type,
+                                             PropertyDeclarationSyntax propertyDeclaration => propertyDeclaration.Type,
+                                             _ => null
+                                         };
+
+                        return targetType != null
+                               && semanticModel.GetTypeInfo(targetType).Type is INamedTypeSymbol targetTypeSymbol
+                               && SymbolEqualityComparer.Default.Equals(targetTypeSymbol, collectionType);
+                    }
+
+                default:
+                    {
+                        return false;
+                    }
             }
         }
 
@@ -307,6 +407,64 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer : StructE
     }
 
     /// <summary>
+    /// Analyzing collection type references made through aliases
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnIdentifierName(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not IdentifierNameSyntax identifierName
+            || identifierName.FirstAncestorOrSelf<UsingDirectiveSyntax>() != null
+            || context.SemanticModel.GetAliasInfo(identifierName)?.Target is not ITypeSymbol aliasedType)
+        {
+            return;
+        }
+
+        AnalyzeAliasedTypeReference(context, identifierName, aliasedType);
+    }
+
+    /// <summary>
+    /// Analyzes every collection type represented by an alias use, including collections nested inside another
+    /// generic type or array
+    /// </summary>
+    /// <param name="context">Context</param>
+    /// <param name="identifierName">Alias use</param>
+    /// <param name="aliasedType">Type represented by the alias</param>
+    private void AnalyzeAliasedTypeReference(SyntaxNodeAnalysisContext context, IdentifierNameSyntax identifierName, ITypeSymbol aliasedType)
+    {
+        if (aliasedType is IArrayTypeSymbol arrayType)
+        {
+            AnalyzeAliasedTypeReference(context, identifierName, arrayType.ElementType);
+
+            return;
+        }
+
+        if (aliasedType is IPointerTypeSymbol pointerType)
+        {
+            AnalyzeAliasedTypeReference(context, identifierName, pointerType.PointedAtType);
+
+            return;
+        }
+
+        if (aliasedType is not INamedTypeSymbol namedType)
+        {
+            return;
+        }
+
+        if (IsRelevantCollectionType(context.Compilation, namedType)
+            && IsExplicitlyConstructedType(context.SemanticModel, identifierName, namedType) == false
+            && AreInitializerCreationsUsingExplicitEqualityComparers(context.SemanticModel, identifierName, namedType) == false
+            && ShouldReportDiagnostic(context.Compilation, namedType))
+        {
+            context.ReportDiagnostic(CreateDiagnostic(identifierName.GetLocation()));
+        }
+
+        foreach (var typeArgument in namedType.TypeArguments)
+        {
+            AnalyzeAliasedTypeReference(context, identifierName, typeArgument);
+        }
+    }
+
+    /// <summary>
     /// Analyzing explicit object creations, including types referenced through aliases
     /// </summary>
     /// <param name="context">Context</param>
@@ -339,7 +497,7 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer : StructE
             || context.SemanticModel.GetTypeInfo(objectCreation).Type is not INamedTypeSymbol collectionType
             || IsRelevantCollectionType(context.Compilation, collectionType) == false
             || ShouldReportDiagnostic(context.Compilation, collectionType) == false
-            || IsAnalyzedByTargetGenericName(context.SemanticModel, objectCreation, collectionType)
+            || IsAnalyzedByTargetTypeReference(context.SemanticModel, objectCreation, collectionType)
             || HasExplicitEqualityComparer(context.SemanticModel, objectCreation, objectCreation.ArgumentList, collectionType))
         {
             return;
@@ -358,6 +516,7 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer : StructE
         base.Initialize(context);
 
         context.RegisterSyntaxNodeAction(OnGenericName, SyntaxKind.GenericName);
+        context.RegisterSyntaxNodeAction(OnIdentifierName, SyntaxKind.IdentifierName);
         context.RegisterSyntaxNodeAction(OnObjectCreation, SyntaxKind.ObjectCreationExpression);
         context.RegisterSyntaxNodeAction(OnImplicitObjectCreation, SyntaxKind.ImplicitObjectCreationExpression);
     }

--- a/Reihitsu.Analyzer/Rules/Performance/RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Performance/RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer.cs
@@ -80,6 +80,29 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer : StructE
     }
 
     /// <summary>
+    /// Determines whether the generic name represents the collection type in an object creation that passes an
+    /// explicit custom equality comparer
+    /// </summary>
+    /// <param name="context">Context</param>
+    /// <param name="genericName">Generic collection name</param>
+    /// <param name="collectionType">Bound collection type</param>
+    /// <returns><see langword="true"/> if the collection construction explicitly supplies a custom comparer</returns>
+    private static bool IsConstructionWithExplicitEqualityComparer(SyntaxNodeAnalysisContext context, GenericNameSyntax genericName, INamedTypeSymbol collectionType)
+    {
+        var objectCreation = genericName.FirstAncestorOrSelf<ObjectCreationExpressionSyntax>();
+
+        if (objectCreation?.ArgumentList == null
+            || context.SemanticModel.GetTypeInfo(objectCreation).Type is not INamedTypeSymbol createdType
+            || SymbolEqualityComparer.Default.Equals(createdType, collectionType) == false
+            || context.SemanticModel.GetSymbolInfo(objectCreation).Symbol is not IMethodSymbol constructor)
+        {
+            return false;
+        }
+
+        return EqualityComparerArgumentUtilities.HasExplicitEqualityComparerArgument(context.Compilation, objectCreation.ArgumentList, constructor.Parameters);
+    }
+
+    /// <summary>
     /// Analyzing all <see cref="SyntaxKind.GenericName"/> occurrences
     /// </summary>
     /// <param name="context">Context</param>
@@ -96,6 +119,11 @@ public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer : StructE
         }
 
         if (IsRelevantCollectionType(context.Compilation, namedTypeSymbol) == false)
+        {
+            return;
+        }
+
+        if (IsConstructionWithExplicitEqualityComparer(context, genericName, namedTypeSymbol))
         {
             return;
         }

--- a/Reihitsu.Analyzer/Rules/Performance/RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Performance/RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAnalyzer.cs
@@ -103,24 +103,24 @@ public class RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAna
     /// <summary>
     /// Check if the diagnostic should be reported
     /// </summary>
-    /// <param name="compilation">Compilation</param>
+    /// <param name="semanticModel">Semantic model</param>
     /// <param name="invocationExpression">Invocation expression</param>
     /// <param name="methodSymbol">Method symbol</param>
     /// <returns>Should the diagnostic by reported?</returns>
-    private static bool CheckIfDiagnosticShouldBeReported(Compilation compilation, InvocationExpressionSyntax invocationExpression, IMethodSymbol methodSymbol)
+    private static bool CheckIfDiagnosticShouldBeReported(SemanticModel semanticModel, InvocationExpressionSyntax invocationExpression, IMethodSymbol methodSymbol)
     {
-        if (IsRelevantContainingType(compilation, methodSymbol.ContainingType) == false)
+        if (IsRelevantContainingType(semanticModel.Compilation, methodSymbol.ContainingType) == false)
         {
             return false;
         }
 
-        if (HasExplicitEqualityComparerArgument(compilation, invocationExpression, methodSymbol))
+        if (HasExplicitEqualityComparerArgument(semanticModel, invocationExpression, methodSymbol))
         {
             return false;
         }
 
         return GetEqualityComparisonType(methodSymbol) is { TypeKind: TypeKind.Struct } comparisonType
-               && AreEqualityMembersImplemented(compilation, comparisonType) == false;
+               && AreEqualityMembersImplemented(semanticModel.Compilation, comparisonType) == false;
     }
 
     /// <summary>
@@ -186,13 +186,13 @@ public class RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAna
     /// Determines whether the invocation passes an explicit, non-<see langword="null"/> <see cref="IEqualityComparer{T}"/>
     /// argument. Such an argument bypasses the compared type's own equality members, so the overload is exempt
     /// </summary>
-    /// <param name="compilation">Compilation</param>
+    /// <param name="semanticModel">Semantic model</param>
     /// <param name="invocationExpression">Invocation expression</param>
     /// <param name="methodSymbol">Method symbol</param>
     /// <returns><see langword="true"/> if a custom equality comparer is explicitly supplied</returns>
-    private static bool HasExplicitEqualityComparerArgument(Compilation compilation, InvocationExpressionSyntax invocationExpression, IMethodSymbol methodSymbol)
+    private static bool HasExplicitEqualityComparerArgument(SemanticModel semanticModel, InvocationExpressionSyntax invocationExpression, IMethodSymbol methodSymbol)
     {
-        return EqualityComparerArgumentUtilities.HasExplicitEqualityComparerArgument(compilation, invocationExpression.ArgumentList, methodSymbol.Parameters);
+        return EqualityComparerArgumentUtilities.HasExplicitEqualityComparerArgument(semanticModel, invocationExpression.ArgumentList, methodSymbol.Parameters);
     }
 
     /// <summary>
@@ -217,7 +217,7 @@ public class RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAna
             return;
         }
 
-        if (CheckIfDiagnosticShouldBeReported(context.Compilation, invocationExpression, methodSymbol))
+        if (CheckIfDiagnosticShouldBeReported(context.SemanticModel, invocationExpression, methodSymbol))
         {
             var location = invocationExpression.Expression switch
                            {

--- a/Reihitsu.Analyzer/Rules/Performance/RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Performance/RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAnalyzer.cs
@@ -192,77 +192,7 @@ public class RH1002TypesUsedForEqualityComparisonMustImplementEqualityMembersAna
     /// <returns><see langword="true"/> if a custom equality comparer is explicitly supplied</returns>
     private static bool HasExplicitEqualityComparerArgument(Compilation compilation, InvocationExpressionSyntax invocationExpression, IMethodSymbol methodSymbol)
     {
-        var comparerType = compilation.GetTypeByMetadataName("System.Collections.Generic.IEqualityComparer`1")?.ConstructUnboundGenericType();
-
-        if (comparerType == null)
-        {
-            return false;
-        }
-
-        var parameters = methodSymbol.Parameters;
-        var positionalIndex = 0;
-
-        foreach (var argument in invocationExpression.ArgumentList.Arguments)
-        {
-            IParameterSymbol parameter;
-
-            if (argument.NameColon != null)
-            {
-                parameter = FindParameterByName(parameters, argument.NameColon.Name.Identifier.ValueText);
-            }
-            else
-            {
-                parameter = positionalIndex < parameters.Length
-                                ? parameters[positionalIndex]
-                                : null;
-            }
-
-            // A named argument in its natural position still occupies that ordinal slot (C# 7.2+ non-trailing
-            // named arguments), so every argument advances the positional count, named or not
-            positionalIndex++;
-
-            if (parameter is { Type: INamedTypeSymbol { IsGenericType: true } parameterType }
-                && SymbolEqualityComparer.Default.Equals(parameterType.ConstructUnboundGenericType(), comparerType)
-                && IsNullLikeExpression(argument.Expression) == false)
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /// <summary>
-    /// Determines whether an expression is <see langword="null"/> or functionally equivalent to it for a
-    /// reference-typed parameter: the <see langword="null"/> literal, target-typed <see langword="default"/>, or
-    /// an explicit <c>default(T)</c>
-    /// </summary>
-    /// <param name="expression">Expression</param>
-    /// <returns><see langword="true"/> if the expression is null-like</returns>
-    private static bool IsNullLikeExpression(ExpressionSyntax expression)
-    {
-        return expression.IsKind(SyntaxKind.NullLiteralExpression)
-               || expression.IsKind(SyntaxKind.DefaultLiteralExpression)
-               || expression.IsKind(SyntaxKind.DefaultExpression);
-    }
-
-    /// <summary>
-    /// Finds a parameter by name
-    /// </summary>
-    /// <param name="parameters">Parameters</param>
-    /// <param name="name">Parameter name</param>
-    /// <returns>The matching parameter, or <see langword="null"/> if none is found</returns>
-    private static IParameterSymbol FindParameterByName(ImmutableArray<IParameterSymbol> parameters, string name)
-    {
-        foreach (var parameter in parameters)
-        {
-            if (parameter.Name == name)
-            {
-                return parameter;
-            }
-        }
-
-        return null;
+        return EqualityComparerArgumentUtilities.HasExplicitEqualityComparerArgument(compilation, invocationExpression.ArgumentList, methodSymbol.Parameters);
     }
 
     /// <summary>

--- a/documentation/rules/RH1001.md
+++ b/documentation/rules/RH1001.md
@@ -20,7 +20,9 @@ The rule covers:
 
 For dictionary types, only the key type is checked. A struct used only as a dictionary value does not trigger the rule.
 
-An object creation that explicitly supplies a non-null custom `IEqualityComparer<T>` is exempt because the collection uses that comparer instead of the key type's own equality members. This includes target-typed and aliased constructions. Passing `null`, a composite expression that necessarily produces `null`, or `EqualityComparer<T>.Default` does not exempt the construction. A default non-nullable comparer struct is boxed as a real custom comparer and does qualify for the exemption.
+An object creation that explicitly supplies a non-null custom `IEqualityComparer<T>` is exempt because the collection uses that comparer instead of the key type's own equality members. This includes explicit, target-typed, and aliased constructions, as well as parenthesized, conditional, and switch-expression initializers when every reachable construction supplies a custom comparer. An alias use that is not owned by such a construction is still checked.
+
+Passing `null`, `EqualityComparer<T>.Default`, or a composite expression whose every result is one of those non-custom values does not exempt the construction. A default non-nullable comparer struct is boxed as a real custom comparer and does qualify for the exemption.
 
 ## Why is this a problem?
 

--- a/documentation/rules/RH1001.md
+++ b/documentation/rules/RH1001.md
@@ -20,7 +20,7 @@ The rule covers:
 
 For dictionary types, only the key type is checked. A struct used only as a dictionary value does not trigger the rule.
 
-An object creation that explicitly supplies a non-null `IEqualityComparer<T>` is exempt because the collection uses that comparer instead of the key type's own equality members. Passing `null` or a default expression that produces `null` does not exempt the construction. A default non-nullable comparer struct is boxed as a real comparer and does qualify for the exemption.
+An object creation that explicitly supplies a non-null custom `IEqualityComparer<T>` is exempt because the collection uses that comparer instead of the key type's own equality members. This includes target-typed and aliased constructions. Passing `null`, a composite expression that necessarily produces `null`, or `EqualityComparer<T>.Default` does not exempt the construction. A default non-nullable comparer struct is boxed as a real custom comparer and does qualify for the exemption.
 
 ## Why is this a problem?
 

--- a/documentation/rules/RH1001.md
+++ b/documentation/rules/RH1001.md
@@ -20,13 +20,15 @@ The rule covers:
 
 For dictionary types, only the key type is checked. A struct used only as a dictionary value does not trigger the rule.
 
+An object creation that explicitly supplies a non-null `IEqualityComparer<T>` is exempt because the collection uses that comparer instead of the key type's own equality members. Passing `null` or `default` does not exempt the construction.
+
 ## Why is this a problem?
 
 A struct without its own equality implementation falls back to the default `ValueType` behavior. Hash-based collections can invoke equality and hash-code calculations many times, so boxing or runtime field inspection can add significant overhead.
 
 ## How to fix it
 
-Implement `IEquatable<T>`, or override both `Equals(object)` and `GetHashCode()` on the struct used as a dictionary key or set element.
+Implement `IEquatable<T>`, or override both `Equals(object)` and `GetHashCode()` on the struct used as a dictionary key or set element. Alternatively, pass a custom `IEqualityComparer<T>` when constructing the collection.
 
 ## Examples
 

--- a/documentation/rules/RH1001.md
+++ b/documentation/rules/RH1001.md
@@ -20,7 +20,7 @@ The rule covers:
 
 For dictionary types, only the key type is checked. A struct used only as a dictionary value does not trigger the rule.
 
-An object creation that explicitly supplies a non-null `IEqualityComparer<T>` is exempt because the collection uses that comparer instead of the key type's own equality members. Passing `null` or `default` does not exempt the construction.
+An object creation that explicitly supplies a non-null `IEqualityComparer<T>` is exempt because the collection uses that comparer instead of the key type's own equality members. Passing `null` or a default expression that produces `null` does not exempt the construction. A default non-nullable comparer struct is boxed as a real comparer and does qualify for the exemption.
 
 ## Why is this a problem?
 

--- a/documentation/rules/RH1002.md
+++ b/documentation/rules/RH1002.md
@@ -23,7 +23,7 @@ A struct without its own equality implementation falls back to the default `Valu
 
 ## How to fix it
 
-Implement `IEquatable<T>`, or override both `Equals(object)` and `GetHashCode()` on the struct used for equality comparison. Alternatively, pass an explicit, non-null custom `IEqualityComparer<T>` to the operation. Passing `null`, a composite expression that necessarily produces `null`, or `EqualityComparer<T>.Default` still uses the struct's own equality behavior and does not suppress the diagnostic. A default non-nullable comparer struct is boxed as a real custom comparer and does qualify for the exemption.
+Implement `IEquatable<T>`, or override both `Equals(object)` and `GetHashCode()` on the struct used for equality comparison. Alternatively, pass an explicit, non-null custom `IEqualityComparer<T>` to the operation. Passing `null`, `EqualityComparer<T>.Default`, or a composite expression whose every result is one of those non-custom values still uses the struct's own equality behavior and does not suppress the diagnostic. A default non-nullable comparer struct is boxed as a real custom comparer and does qualify for the exemption.
 
 ## Examples
 

--- a/documentation/rules/RH1002.md
+++ b/documentation/rules/RH1002.md
@@ -23,7 +23,7 @@ A struct without its own equality implementation falls back to the default `Valu
 
 ## How to fix it
 
-Implement `IEquatable<T>`, or override both `Equals(object)` and `GetHashCode()` on the struct used for equality comparison. Alternatively, pass an explicit, non-null `IEqualityComparer<T>` to the operation. Passing `null` or `default` still uses the struct's own equality behavior and does not suppress the diagnostic.
+Implement `IEquatable<T>`, or override both `Equals(object)` and `GetHashCode()` on the struct used for equality comparison. Alternatively, pass an explicit, non-null `IEqualityComparer<T>` to the operation. Passing `null` or a default expression that produces `null` still uses the struct's own equality behavior and does not suppress the diagnostic. A default non-nullable comparer struct is boxed as a real comparer and does qualify for the exemption.
 
 ## Examples
 

--- a/documentation/rules/RH1002.md
+++ b/documentation/rules/RH1002.md
@@ -23,7 +23,7 @@ A struct without its own equality implementation falls back to the default `Valu
 
 ## How to fix it
 
-Implement `IEquatable<T>`, or override both `Equals(object)` and `GetHashCode()` on the struct used for equality comparison. Alternatively, pass an explicit, non-null `IEqualityComparer<T>` to the operation. Passing `null` or a default expression that produces `null` still uses the struct's own equality behavior and does not suppress the diagnostic. A default non-nullable comparer struct is boxed as a real comparer and does qualify for the exemption.
+Implement `IEquatable<T>`, or override both `Equals(object)` and `GetHashCode()` on the struct used for equality comparison. Alternatively, pass an explicit, non-null custom `IEqualityComparer<T>` to the operation. Passing `null`, a composite expression that necessarily produces `null`, or `EqualityComparer<T>.Default` still uses the struct's own equality behavior and does not suppress the diagnostic. A default non-nullable comparer struct is boxed as a real custom comparer and does qualify for the exemption.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

RH1001 now resolves the bound constructor behind explicit, target-typed, and aliased collection constructions and skips the diagnostic when a genuine custom `IEqualityComparer<T>` is passed. The comparer-argument policy moved into the shared `EqualityComparerArgumentUtilities`, which RH1002 now consumes instead of its own private copy, so both rules classify null-like and framework-default comparers identically.

## Why

A collection constructed with a custom comparer never calls the key struct's own equality members, so flagging those construction sites was a false positive. The same expression shapes must keep reporting when the argument can only ever be `null` or `EqualityComparer<T>.Default`, because those still route back to the key type's equality.

## Linked issues

Closes #541

## Review notes

- Diagnostics are preserved for nested and repeated collection type references, alias uses that no construction owns, mixed multi-declarator initializers, and object-initializer syntax without parentheses.
- Null classification covers casts, parentheses, null-forgiving syntax, built-in conversions, coalescing, conditionals, switch expressions, conditional access, reference defaults, and nullable value-type defaults. A non-nullable comparer struct `default` is boxed into a real comparer and therefore does exempt.
- Behavior change worth a look: an aliased collection is no longer reported at the `using` alias declaration but at each alias use, which is what makes `new AliasName(comparer)` exemptable. RH1001 additionally analyzes object-creation and implicit-object-creation nodes directly, so target-typed `new(...)` in assignment position is now a reported construction site.
- RH1002 keeps its previous diagnostics except that `default(SomeComparerStruct)` is now treated as a real comparer and `EqualityComparer<T>.Default` no longer exempts; both are covered by new tests and reflected in the rule docs.

## Follow-up work

- `ImmutableDictionary`, `ImmutableHashSet`, `FrozenDictionary`, and `FrozenSet` have no public constructors, so the construction-site exemption cannot reach them; `ImmutableDictionary.Create<K, V>(comparer)` assigned to an explicitly typed variable still reports RH1001. Out of scope for #541, which is limited to object-creation sites.
- RH1001 registers on `SyntaxKind.IdentifierName` to resolve alias uses and calls `GetAliasInfo` per identifier. A cheap syntactic prefilter could cut that binding cost if analyzer throughput becomes a concern.