### PR TITLE
Verify RH4120 record reference renaming

### DIFF
--- a/Reihitsu.Analyzer.Test/Naming/RH4120RecordPrimaryConstructorParameterCasingAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Naming/RH4120RecordPrimaryConstructorParameterCasingAnalyzerTests.cs
@@ -39,6 +39,42 @@ public class RH4120RecordPrimaryConstructorParameterCasingAnalyzerTests : Analyz
     }
 
     /// <summary>
+    /// Verifying the code fix renames record primary constructor parameter references
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCodeFixRenamesRecordPrimaryConstructorParameterReferences()
+    {
+        const string testCode = """
+                                public record R(string {|#0:badName|});
+
+                                public class C
+                                {
+                                    void M()
+                                    {
+                                        var r = new R(badName: "x");
+                                        var v = r.badName;
+                                    }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 public record R(string BadName);
+
+                                 public class C
+                                 {
+                                     void M()
+                                     {
+                                         var r = new R(BadName: "x");
+                                         var v = r.BadName;
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH4120RecordPrimaryConstructorParameterCasingAnalyzer.DiagnosticId, AnalyzerResources.RH4120MessageFormat));
+    }
+
+    /// <summary>
     /// Verifying diagnostics for camelCase record struct primary constructor parameters
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>


### PR DESCRIPTION
## Summary

Adds a focused RH4120 regression that applies the record primary-constructor casing fix with both a named constructor argument and a synthesized-property access. The expected output checks that the declaration and both references are renamed consistently and remain compilable.

## Why

This establishes executable evidence that the pinned Roslyn related-symbol cascade performs a comprehensive rename for record primary-constructor parameters.

## Linked issues

Closes #471

## Review notes

The change is test-only because the existing provider passes the comprehensive rename scenario; no production adjustment or code-fix withdrawal is required.

## Follow-up work

None.