### PR TITLE
Permit Boolean questions in RH8306 property docs

### DIFF
--- a/Reihitsu.Analyzer.Test/Documentation/RH8306PropertySummaryMustUseNounPhraseInsteadOfSentenceAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH8306PropertySummaryMustUseNounPhraseInsteadOfSentenceAnalyzerTests.cs
@@ -116,17 +116,137 @@ public class RH8306PropertySummaryMustUseNounPhraseInsteadOfSentenceAnalyzerTest
     }
 
     /// <summary>
-    /// Verifies that a property summary ending with a question mark is detected
+    /// Verifies that a Boolean property summary ending with a question mark does not produce a diagnostic
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
     [TestMethod]
-    public async Task VerifyDiagnosticForPropertySummaryEndingWithQuestionMark()
+    public async Task VerifyNoDiagnosticForBooleanPropertySummaryEndingWithQuestionMark()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    /// <summary>
+                                    /// Is the value valid?
+                                    /// </summary>
+                                    public bool IsValid { get; set; }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that a nullable Boolean property summary ending with a question mark does not produce a diagnostic
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticForNullableBooleanPropertySummaryEndingWithQuestionMark()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    /// <summary>
+                                    /// Is the value valid?
+                                    /// </summary>
+                                    public bool? IsValid { get; set; }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that a Nullable Boolean property summary ending with a question mark does not produce a diagnostic
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticForNullableBooleanTypePropertySummaryEndingWithQuestionMark()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    /// <summary>
+                                    /// Is the value valid?
+                                    /// </summary>
+                                    public System.Nullable<bool> IsValid { get; set; }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that a non-Boolean property summary ending with a question mark is detected
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticForNonBooleanPropertySummaryEndingWithQuestionMark()
     {
         const string testData = """
                                 internal class TestClass
                                 {
                                     /// {|#0:<summary>
-                                    /// Is the value valid?
+                                    /// Current value?
+                                    /// </summary>|}
+                                    public int Value { get; set; }
+                                }
+                                """;
+
+        await Verify(testData, Diagnostics(RH8306PropertySummaryMustUseNounPhraseInsteadOfSentenceAnalyzer.DiagnosticId, AnalyzerResources.RH8306MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that a Boolean property summary ending with a period is detected
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticForBooleanPropertySummaryEndingWithPeriod()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    /// {|#0:<summary>
+                                    /// Is the value valid.
+                                    /// </summary>|}
+                                    public bool IsValid { get; set; }
+                                }
+                                """;
+
+        await Verify(testData, Diagnostics(RH8306PropertySummaryMustUseNounPhraseInsteadOfSentenceAnalyzer.DiagnosticId, AnalyzerResources.RH8306MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that a Boolean property summary ending with an exclamation mark is detected
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticForBooleanPropertySummaryEndingWithExclamationMark()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    /// {|#0:<summary>
+                                    /// Is the value valid!
+                                    /// </summary>|}
+                                    public bool IsValid { get; set; }
+                                }
+                                """;
+
+        await Verify(testData, Diagnostics(RH8306PropertySummaryMustUseNounPhraseInsteadOfSentenceAnalyzer.DiagnosticId, AnalyzerResources.RH8306MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that a Boolean property summary starting with a sentence-leading verb is detected when it ends with a question mark
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticForBooleanPropertySummaryStartingWithSentenceLeadingVerbAndEndingWithQuestionMark()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    /// {|#0:<summary>
+                                    /// Indicates whether the value is valid?
                                     /// </summary>|}
                                     public bool IsValid { get; set; }
                                 }

--- a/Reihitsu.Analyzer/Rules/Documentation/RH8306PropertySummaryMustUseNounPhraseInsteadOfSentenceAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH8306PropertySummaryMustUseNounPhraseInsteadOfSentenceAnalyzer.cs
@@ -99,6 +99,23 @@ public class RH8306PropertySummaryMustUseNounPhraseInsteadOfSentenceAnalyzer : D
     }
 
     /// <summary>
+    /// Determines whether the specified type is Boolean or nullable Boolean
+    /// </summary>
+    /// <param name="type">Type</param>
+    /// <returns><see langword="true"/> if the type is Boolean or nullable Boolean</returns>
+    private static bool IsBooleanType(ITypeSymbol type)
+    {
+        if (type?.SpecialType == SpecialType.System_Boolean)
+        {
+            return true;
+        }
+
+        return type is INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T } namedType
+               && namedType.TypeArguments.Length == 1
+               && namedType.TypeArguments[0].SpecialType == SpecialType.System_Boolean;
+    }
+
+    /// <summary>
     /// Gets the first whitespace separated word of the specified text
     /// </summary>
     /// <param name="text">Text</param>
@@ -128,8 +145,9 @@ public class RH8306PropertySummaryMustUseNounPhraseInsteadOfSentenceAnalyzer : D
     /// Determines whether the summary text reads as a sentence rather than a noun phrase
     /// </summary>
     /// <param name="text">Summary text</param>
+    /// <param name="isBooleanProperty"><see langword="true"/> when the summary belongs to a Boolean or nullable Boolean property</param>
     /// <returns><see langword="true"/> if the text is written as a sentence</returns>
-    private static bool IsSentence(string text)
+    private static bool IsSentence(string text, bool isBooleanProperty)
     {
         var trimmed = text.Trim();
 
@@ -138,7 +156,11 @@ public class RH8306PropertySummaryMustUseNounPhraseInsteadOfSentenceAnalyzer : D
             return false;
         }
 
-        if (IsSentenceTerminator(trimmed[trimmed.Length - 1]))
+        var finalCharacter = trimmed[trimmed.Length - 1];
+
+        if (IsSentenceTerminator(finalCharacter)
+            && (finalCharacter != '?'
+                || isBooleanProperty == false))
         {
             return true;
         }
@@ -160,8 +182,14 @@ public class RH8306PropertySummaryMustUseNounPhraseInsteadOfSentenceAnalyzer : D
         var documentationComment = DirectDocumentationSyntaxChecker.GetDocumentationComment(propertyDeclaration);
 
         if (documentationComment == null
-            || DirectDocumentationSyntaxChecker.GetFirstTagIncludingNested(documentationComment, "summary") is not XmlElementSyntax summaryElement
-            || IsSentence(GetTextContent(summaryElement)) == false)
+            || DirectDocumentationSyntaxChecker.GetFirstTagIncludingNested(documentationComment, "summary") is not XmlElementSyntax summaryElement)
+        {
+            return;
+        }
+
+        var propertyType = context.SemanticModel.GetDeclaredSymbol(propertyDeclaration, context.CancellationToken)?.Type;
+
+        if (IsSentence(GetTextContent(summaryElement), IsBooleanType(propertyType)) == false)
         {
             return;
         }

--- a/documentation/rules/RH8306.md
+++ b/documentation/rules/RH8306.md
@@ -23,14 +23,18 @@ Property summaries read best as concise labels. A behavior-narrating sentence su
 
 A property `<summary>` is treated as a sentence, and therefore reported, when either of the following holds:
 
-- the text ends with a sentence terminator (`.`, `!`, or `?`), or
+- the text ends with a sentence terminator (`.`, `!`, or `?`), except that `?` is allowed for `bool` and nullable `bool` properties, or
 - the text begins with a verb that introduces a behavior-narrating sentence: `Gets`, `Sets`, `Returns`, `Represents`, `Indicates`, `Specifies`, `Determines`, `Holds`, or `Stores` (the leading verb `Gets` also covers the common `Gets or sets` phrasing).
+
+The leading-verb check still applies to Boolean properties. For example, `Indicates whether the connection is open?` is reported even though its question-mark terminator is allowed.
 
 An empty summary and a property that inherits its documentation with `<inheritdoc/>` are not reported by this rule.
 
 ## How to fix it
 
 Rewrite the property summary as a noun phrase: drop any leading verb such as "Gets or sets" and remove the trailing terminator. Because this rewrite cannot be produced automatically without changing the wording, the rule does not offer a code fix.
+
+Boolean and nullable Boolean properties may instead use a question-form summary ending in `?`, such as `Is the connection open?`, provided the summary does not begin with one of the sentence-leading verbs listed above.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

RH8306 now uses semantic type information to accept question-mark summaries for Boolean and nullable Boolean properties. Focused tests and rule documentation preserve and describe the surrounding diagnostic boundaries.

## Why

A question-form summary maps naturally to a Boolean property's yes-or-no value without weakening the noun-phrase rule for other property types.

## Linked issues

Closes #473

## Review notes

The behavior change is limited to a trailing `?`. Periods, exclamation marks, non-Boolean questions, and configured sentence-leading verbs remain diagnostic; aliases and nullable forms are classified through Roslyn symbols, and no code fix is introduced.

## Follow-up work

None.