### PR TITLE
Document RH5010 switch exemptions with a valid loop example

### DIFF
--- a/documentation/rules/RH5010.md
+++ b/documentation/rules/RH5010.md
@@ -11,7 +11,7 @@
 
 This rule checks that `break` statements are preceded by a blank line. This commonly applies in loop bodies when another statement comes before the `break`.
 
-The rule does not apply when the `break` statement belongs directly to a switch section, is the first statement in a block, or is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause). Top-level statements are also excluded.
+The rule does not apply when the `break` statement belongs directly to a switch section, is inside a block that belongs directly to a switch section, is the first statement in a block, or is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause). Top-level statements are also excluded.
 
 ## Why is this a problem?
 
@@ -19,7 +19,7 @@ Separating statements with blank lines improves code readability by visually gro
 
 ## How to fix it
 
-Add a blank line before the `break` statement. No change is required when the statement belongs directly to a switch section, is the first statement in a block, is an unbraced embedded statement, or is top-level.
+Add a blank line before the `break` statement. No change is required when the statement belongs directly to a switch section, is inside a block that belongs directly to a switch section, is the first statement in a block, is an unbraced embedded statement, or is top-level.
 
 ## Examples
 

--- a/documentation/rules/RH5010.md
+++ b/documentation/rules/RH5010.md
@@ -9,9 +9,9 @@
 
 ## Description
 
-This rule checks that `break` statements are preceded by a blank line. This commonly applies inside switch cases and loops. The rule does not apply when the `break` statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
+This rule checks that `break` statements are preceded by a blank line. This commonly applies in loop bodies when another statement comes before the `break`.
 
-The rule applies only to direct members of blocks and switch sections; top-level statements are excluded.
+The rule does not apply when the `break` statement belongs directly to a switch section, is the first statement in a block, or is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause). Top-level statements are also excluded.
 
 ## Why is this a problem?
 
@@ -19,25 +19,27 @@ Separating statements with blank lines improves code readability by visually gro
 
 ## How to fix it
 
-Add a blank line before the `break` statement. The rule does not apply when the statement is the first statement in a block, or when it is the unbraced embedded body of another statement (for example the body of a `while`, `for`, `foreach`, `using`, `lock`, or `fixed` statement, a `do` loop, or an `else` clause).
-
-No change is required for a top-level statement.
+Add a blank line before the `break` statement. No change is required when the statement belongs directly to a switch section, is the first statement in a block, is an unbraced embedded statement, or is top-level.
 
 ## Examples
 
 ### Violation
 
 ```cs
-case 1:
+while (condition)
+{
     DoSomething();
     break;
+}
 ```
 
 ### Correction
 
 ```cs
-case 1:
+while (condition)
+{
     DoSomething();
 
     break;
+}
 ```


### PR DESCRIPTION
## Summary

Replace the exempt RH5010 switch-case violation with a loop-body example and its blank-line correction. Document both switch-section container shapes exempted by the current analyzer and formatter policy.

## Why

The rule page now demonstrates a diagnostic users can reproduce and accurately describes the behavior shipped by the analyzer and code fix.

## Linked issues

Closes #582

## Review notes

This is documentation-only; analyzer, formatter, code-fix, and Fix All behavior remain unchanged.

## Follow-up work

#583 tracks changing the braced switch-section policy and must update this documentation with that behavior.