### PR TITLE
Keep auto-properties inline before trailing comments

### DIFF
--- a/Reihitsu.Analyzer.CodeFixes/Rules/Layout/RH5408SimpleAutoPropertiesShouldBeSingleLinedCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Layout/RH5408SimpleAutoPropertiesShouldBeSingleLinedCodeFixProvider.cs
@@ -104,6 +104,13 @@ public class RH5408SimpleAutoPropertiesShouldBeSingleLinedCodeFixProvider : Code
                 return false;
             }
 
+            // A comment or directive between the accessor list and the initializer makes the formatter refuse to
+            // join the initializer, so registering the fix here would produce a no-op action. Guard the same gap.
+            if (SyntaxTriviaUtilities.WouldJoinAcrossUnjoinableTrivia(propertyDeclaration.AccessorList.CloseBraceToken, propertyDeclaration.Initializer.EqualsToken))
+            {
+                return false;
+            }
+
             if (SyntaxNodeUtilities.IsSingleLineSpan(propertyDeclaration.SyntaxTree, propertyDeclaration.Initializer.Value.Span) == false)
             {
                 return false;

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Layout/RH5408SimpleAutoPropertiesShouldBeSingleLinedCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Layout/RH5408SimpleAutoPropertiesShouldBeSingleLinedCodeFixProvider.cs
@@ -104,9 +104,13 @@ public class RH5408SimpleAutoPropertiesShouldBeSingleLinedCodeFixProvider : Code
                 return false;
             }
 
-            // A comment or directive between the accessor list and the initializer makes the formatter refuse to
-            // join the initializer, so registering the fix here would produce a no-op action. Guard the same gap.
-            if (SyntaxTriviaUtilities.WouldJoinAcrossUnjoinableTrivia(propertyDeclaration.AccessorList.CloseBraceToken, propertyDeclaration.Initializer.EqualsToken))
+            // A comment or directive between the accessor list and an initializer that starts on a later line makes
+            // the formatter refuse to join the initializer, so registering the fix here would produce a no-op
+            // action. Guard the same gap, and only when the gap actually spans lines.
+            var initializerGapSpan = TextSpan.FromBounds(propertyDeclaration.AccessorList.CloseBraceToken.Span.End, propertyDeclaration.Initializer.EqualsToken.SpanStart);
+
+            if (SyntaxNodeUtilities.IsSingleLineSpan(propertyDeclaration.SyntaxTree, initializerGapSpan) == false
+                && SyntaxTriviaUtilities.WouldJoinAcrossUnjoinableTrivia(propertyDeclaration.AccessorList.CloseBraceToken, propertyDeclaration.Initializer.EqualsToken))
             {
                 return false;
             }

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Layout/RH5408SimpleAutoPropertiesShouldBeSingleLinedCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Layout/RH5408SimpleAutoPropertiesShouldBeSingleLinedCodeFixProvider.cs
@@ -59,7 +59,9 @@ public class RH5408SimpleAutoPropertiesShouldBeSingleLinedCodeFixProvider : Code
     /// <returns><see langword="true"/> if the code fix can be applied safely; otherwise, <see langword="false"/></returns>
     private static bool CanApplyCodeFix(PropertyDeclarationSyntax propertyDeclaration)
     {
-        if (propertyDeclaration.AccessorList == null || SyntaxNodeUtilities.ContainsCommentOrDirective(propertyDeclaration.AccessorList))
+        // The guard is interior-scoped to match the formatter's collapse: a comment trailing the accessor
+        // list's closing brace is never crossed, so it must not block the fix (see issue #604).
+        if (propertyDeclaration.AccessorList == null || SyntaxNodeUtilities.InteriorContainsCommentOrDirective(propertyDeclaration.AccessorList))
         {
             return false;
         }

--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5408SimpleAutoPropertiesShouldBeSingleLinedFormatterTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5408SimpleAutoPropertiesShouldBeSingleLinedFormatterTests.cs
@@ -142,5 +142,53 @@ public class RH5408SimpleAutoPropertiesShouldBeSingleLinedFormatterTests : Forma
                                  Diagnostics(RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer.DiagnosticId, AnalyzerResources.RH5408MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies that the formatter collapses a multi-line auto-property whose accessor list is followed by a
+    /// trailing comment, so analyzer and formatter agree on that shape (issue #604)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFormatterFixesAutoPropertyWithTrailingComment()
+    {
+        const string input = """
+                             internal class Example
+                             {
+                                 {|#0:internal int Value
+                                 {
+                                     get;
+                                     set;
+                                 }|} // explanation
+                             }
+                             """;
+        const string fixedData = """
+                                 internal class Example
+                                 {
+                                     internal int Value { get; set; } // explanation
+                                 }
+                                 """;
+
+        await VerifyFormatterFixAndIdempotency(input,
+                                               fixedData,
+                                               Diagnostics(RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer.DiagnosticId, AnalyzerResources.RH5408MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that the formatter leaves a single-line auto-property with a trailing comment untouched, so
+    /// analyzer-clean code stays stable (issue #604)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFormatterKeepsSingleLineAutoPropertyWithTrailingComment()
+    {
+        const string input = """
+                             internal class Example
+                             {
+                                 internal int Value { get; set; } // explanation
+                             }
+                             """;
+
+        await VerifyFormatterStability(input);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatting/RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzerTests.cs
@@ -625,5 +625,117 @@ public class RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzerTests : Analyz
                      Diagnostics(RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer.DiagnosticId, AnalyzerResources.RH5408MessageFormat, 2));
     }
 
+    /// <summary>
+    /// Verifying that an auto-property carrying a comment between its accessor list and its initializer is not
+    /// flagged, because the formatter refuses to join the initializer across that comment (issue #604)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCommentInInitializerGapAutoPropertyIsNotFlagged()
+    {
+        const string testData = """
+                                internal class RH5408
+                                {
+                                    public int Value { get; set; } // note
+                                    = 1;
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifying that an auto-property carrying a multi-line block comment between its accessor list and its
+    /// initializer is not flagged (issue #604)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyBlockCommentInInitializerGapAutoPropertyIsNotFlagged()
+    {
+        const string testData = """
+                                internal class RH5408
+                                {
+                                    public int Value { get; set; } /* note
+                                       more */ = 2;
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifying that an auto-property carrying a directive between its accessor list and its initializer is not
+    /// flagged (issue #604)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDirectiveInInitializerGapAutoPropertyIsNotFlagged()
+    {
+        const string testData = """
+                                internal class RH5408
+                                {
+                                    public int Value { get; set; }
+                                #if FEATURE
+                                #endif
+                                    = 1;
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifying that an auto-property whose initializer sits on its own line without intervening trivia is still
+    /// flagged, because the formatter joins the initializer in that case (issue #604)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyOwnLineInitializerAutoPropertyIsDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class RH5408
+                                {
+                                    {|#0:public int Value { get; set; }
+                                    = 1;|}
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class RH5408
+                                 {
+                                     public int Value { get; set; } = 1;
+                                 }
+                                 """;
+
+        await Verify(testData,
+                     fixedData,
+                     Diagnostics(RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer.DiagnosticId, AnalyzerResources.RH5408MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying that no code fix action is registered for an auto-property carrying a comment between its accessor
+    /// list and its initializer, so the code fix does not offer a no-op action (issue #604)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCommentInInitializerGapAutoPropertyIsNotOfferedACodeFix()
+    {
+        const string codeFixData = """
+                                   internal class RH5408
+                                   {
+                                       public int Value { get; set; } // note
+                                       = 1;
+                                   }
+                                   """;
+
+        var actions = await GetCodeFixActionsAsync(codeFixData,
+                                                   RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<PropertyDeclarationSyntax>()
+                                                               .First()
+                                                               .GetLocation());
+
+        Assert.IsEmpty(actions);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatting/RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzerTests.cs
@@ -737,5 +737,65 @@ public class RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzerTests : Analyz
         Assert.IsEmpty(actions);
     }
 
+    /// <summary>
+    /// Verifying that an auto-property whose initializer gap sits on one line is still detected and fixed, because
+    /// the formatter never has to join that gap (issue #604)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifySameLineInitializerGapAutoPropertyIsDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class RH5408
+                                {
+                                    {|#0:public int Value
+                                    {
+                                        get;
+                                        set;
+                                    } /* note */ = 1;|}
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class RH5408
+                                 {
+                                     public int Value { get; set; } /* note */ = 1;
+                                 }
+                                 """;
+
+        await Verify(testData,
+                     fixedData,
+                     Diagnostics(RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer.DiagnosticId, AnalyzerResources.RH5408MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying that a multi-line auto-property with an accessor modifier and a trailing comment is detected and
+    /// fixed, and that the fix collapses the modifier together with its keyword (issue #604)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyAccessorModifierAutoPropertyWithTrailingCommentIsDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class RH5408
+                                {
+                                    {|#0:public int Value
+                                    {
+                                        get;
+                                        private set;
+                                    }|} // explanation
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class RH5408
+                                 {
+                                     public int Value { get; private set; } // explanation
+                                 }
+                                 """;
+
+        await Verify(testData,
+                     fixedData,
+                     Diagnostics(RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer.DiagnosticId, AnalyzerResources.RH5408MessageFormat));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatting/RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzerTests.cs
@@ -499,5 +499,131 @@ public class RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzerTests : Analyz
         Assert.IsEmpty(actions);
     }
 
+    /// <summary>
+    /// Verifying that a multi-line get/set auto-property followed by a trailing comment is detected and fixed,
+    /// because the comment sits outside the accessor list and is never crossed by the collapse (issue #604)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyAutoPropertyWithTrailingCommentIsDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class RH5408
+                                {
+                                    {|#0:public int Value
+                                    {
+                                        get;
+                                        set;
+                                    }|} // explanation
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class RH5408
+                                 {
+                                     public int Value { get; set; } // explanation
+                                 }
+                                 """;
+
+        await Verify(testData,
+                     fixedData,
+                     Diagnostics(RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer.DiagnosticId, AnalyzerResources.RH5408MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying that a multi-line get-only auto-property followed by a trailing comment is detected and fixed
+    /// (issue #604)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyGetOnlyAutoPropertyWithTrailingCommentIsDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class RH5408
+                                {
+                                    {|#0:public int Value
+                                    {
+                                        get;
+                                    }|} // explanation
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class RH5408
+                                 {
+                                     public int Value { get; } // explanation
+                                 }
+                                 """;
+
+        await Verify(testData,
+                     fixedData,
+                     Diagnostics(RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer.DiagnosticId, AnalyzerResources.RH5408MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying that a multi-line auto-property followed by a trailing block comment is detected and fixed
+    /// (issue #604)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyAutoPropertyWithTrailingBlockCommentIsDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class RH5408
+                                {
+                                    {|#0:public int Value
+                                    {
+                                        get;
+                                        set;
+                                    }|} /* explanation */
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class RH5408
+                                 {
+                                     public int Value { get; set; } /* explanation */
+                                 }
+                                 """;
+
+        await Verify(testData,
+                     fixedData,
+                     Diagnostics(RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer.DiagnosticId, AnalyzerResources.RH5408MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying that two multi-line auto-properties with trailing comments in one document are both detected and
+    /// fixed together, so a Fix All pass converges (issue #604)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyMultipleAutoPropertiesWithTrailingCommentsAreDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class RH5408
+                                {
+                                    {|#0:public int First
+                                    {
+                                        get;
+                                        set;
+                                    }|} // first
+
+                                    {|#1:public int Second
+                                    {
+                                        get;
+                                    }|} /* second */
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class RH5408
+                                 {
+                                     public int First { get; set; } // first
+
+                                     public int Second { get; } /* second */
+                                 }
+                                 """;
+
+        await Verify(testData,
+                     fixedData,
+                     Diagnostics(RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer.DiagnosticId, AnalyzerResources.RH5408MessageFormat, 2));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer/Rules/Layout/RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Layout/RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer.cs
@@ -97,10 +97,12 @@ public class RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer : DiagnosticA
             return false;
         }
 
-        // The formatter's CanCollapseAutoPropertyToSingleLine bails out on any comment or directive in the
+        // The formatter's CanCollapseAutoPropertyToSingleLine bails out on a comment or directive inside the
         // accessor list (for example a comment between accessors), so the analyzer must guard the same shape,
-        // otherwise it flags a property the formatter never collapses, leaving a permanent diagnostic.
-        if (SyntaxNodeUtilities.ContainsCommentOrDirective(propertyDeclaration.AccessorList))
+        // otherwise it flags a property the formatter never collapses, leaving a permanent diagnostic. The
+        // guard is interior-scoped to match the formatter exactly: a comment trailing the closing brace sits
+        // outside the accessor list, is never crossed by the collapse, and must not suppress the diagnostic.
+        if (SyntaxNodeUtilities.InteriorContainsCommentOrDirective(propertyDeclaration.AccessorList))
         {
             return false;
         }

--- a/Reihitsu.Analyzer/Rules/Layout/RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Layout/RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer.cs
@@ -139,6 +139,15 @@ public class RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer : DiagnosticA
                 return false;
             }
 
+            // The reported span runs to the end of the declaration, so it covers the initializer as well. A comment
+            // or directive in the gap between the accessor list and the initializer lives in the closing brace's
+            // trailing trivia, which neither check above inspects. The formatter refuses to join the initializer
+            // across that trivia, so the analyzer must guard the same gap to avoid a permanent diagnostic.
+            if (SyntaxTriviaUtilities.WouldJoinAcrossUnjoinableTrivia(propertyDeclaration.AccessorList.CloseBraceToken, propertyDeclaration.Initializer.EqualsToken))
+            {
+                return false;
+            }
+
             if (SyntaxNodeUtilities.IsSingleLineSpan(propertyDeclaration.SyntaxTree, propertyDeclaration.Initializer.Value.Span) == false)
             {
                 return false;

--- a/Reihitsu.Analyzer/Rules/Layout/RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Layout/RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer.cs
@@ -140,11 +140,12 @@ public class RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer : DiagnosticA
             }
 
             // The reported span runs to the end of the declaration, so it covers the initializer as well. A comment
-            // or directive in the gap between the accessor list and the initializer lives in the closing brace's
-            // trailing trivia, which neither check above inspects. The formatter only has to join that gap when the
-            // initializer starts on a later line, and it refuses to join across such trivia, so the analyzer must
-            // guard the same gap to avoid a permanent diagnostic. Trivia in a gap that already sits on one line is
-            // never crossed and must not suppress the diagnostic.
+            // in the gap between the accessor list and the initializer lives in the closing brace's trailing trivia,
+            // which the check above does not inspect; a directive cannot occupy trailing trivia, so it always lands
+            // in the initializer's leading trivia and is already covered. The formatter only has to join that gap
+            // when the initializer starts on a later line, and it refuses to join across such trivia, so the
+            // analyzer must guard the same gap to avoid a permanent diagnostic. Trivia in a gap that already sits
+            // on one line is never crossed and must not suppress the diagnostic.
             var initializerGapSpan = TextSpan.FromBounds(propertyDeclaration.AccessorList.CloseBraceToken.Span.End, propertyDeclaration.Initializer.EqualsToken.SpanStart);
 
             if (SyntaxNodeUtilities.IsSingleLineSpan(propertyDeclaration.SyntaxTree, initializerGapSpan) == false

--- a/Reihitsu.Analyzer/Rules/Layout/RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Layout/RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer.cs
@@ -141,9 +141,14 @@ public class RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer : DiagnosticA
 
             // The reported span runs to the end of the declaration, so it covers the initializer as well. A comment
             // or directive in the gap between the accessor list and the initializer lives in the closing brace's
-            // trailing trivia, which neither check above inspects. The formatter refuses to join the initializer
-            // across that trivia, so the analyzer must guard the same gap to avoid a permanent diagnostic.
-            if (SyntaxTriviaUtilities.WouldJoinAcrossUnjoinableTrivia(propertyDeclaration.AccessorList.CloseBraceToken, propertyDeclaration.Initializer.EqualsToken))
+            // trailing trivia, which neither check above inspects. The formatter only has to join that gap when the
+            // initializer starts on a later line, and it refuses to join across such trivia, so the analyzer must
+            // guard the same gap to avoid a permanent diagnostic. Trivia in a gap that already sits on one line is
+            // never crossed and must not suppress the diagnostic.
+            var initializerGapSpan = TextSpan.FromBounds(propertyDeclaration.AccessorList.CloseBraceToken.Span.End, propertyDeclaration.Initializer.EqualsToken.SpanStart);
+
+            if (SyntaxNodeUtilities.IsSingleLineSpan(propertyDeclaration.SyntaxTree, initializerGapSpan) == false
+                && SyntaxTriviaUtilities.WouldJoinAcrossUnjoinableTrivia(propertyDeclaration.AccessorList.CloseBraceToken, propertyDeclaration.Initializer.EqualsToken))
             {
                 return false;
             }

--- a/Reihitsu.Formatter.Test/Regression/FullPipeline/TrailingDocumentationCommentPreservationTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/FullPipeline/TrailingDocumentationCommentPreservationTests.cs
@@ -345,19 +345,8 @@ public class TrailingDocumentationCommentPreservationTests : FormatterTestsBase
                                  public int Other { get; set; }
                              }
                              """;
-        const string expected = """
-                                internal class TestClass
-                                {
-                                    public int Value
-                                    {
-                                        get; set;
-                                    } // trailing note
 
-                                    public int Other { get; set; }
-                                }
-                                """;
-
-        AssertRuleResult(input, expected);
+        AssertRuleResult(input);
     }
 
     /// <summary>
@@ -374,19 +363,8 @@ public class TrailingDocumentationCommentPreservationTests : FormatterTestsBase
                                  public int Other { get; set; }
                              }
                              """;
-        const string expected = """
-                                internal class TestClass
-                                {
-                                    public int Value
-                                    {
-                                        get; set;
-                                    } /* trailing note */
 
-                                    public int Other { get; set; }
-                                }
-                                """;
-
-        AssertRuleResult(input, expected);
+        AssertRuleResult(input);
     }
 
     /// <summary>
@@ -406,10 +384,7 @@ public class TrailingDocumentationCommentPreservationTests : FormatterTestsBase
         const string expected = """
                                 internal class TestClass
                                 {
-                                    public int Value
-                                    {
-                                        get; set;
-                                    } /* value note */
+                                    public int Value { get; set; } /* value note */
 
                                     /// trailing documentation
                                     public int Other { get; set; }

--- a/Reihitsu.Formatter.Test/Regression/LineBreaks/AutoPropertyTrailingCommentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/LineBreaks/AutoPropertyTrailingCommentTests.cs
@@ -405,6 +405,92 @@ public class AutoPropertyTrailingCommentTests : FormatterTestsBase
     }
 
     /// <summary>
+    /// Verifies that a comment sitting on one line between the accessor list and the initializer is
+    /// carried along when the accessor list collapses, because that gap is never crossed
+    /// </summary>
+    [TestMethod]
+    public void SameLineCommentBeforeInitializerCollapsesWithTheProperty()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 public int Value
+                                 {
+                                     get; set;
+                                 } /* note */ = 1;
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    public int Value { get; set; } /* note */ = 1;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that an accessor modifier is collapsed together with its keyword, so a single pass
+    /// produces the final spacing instead of leaving the modifier's original indentation behind
+    /// </summary>
+    [TestMethod]
+    public void AccessorModifierWithTrailingCommentCollapsesInOnePass()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 public int Value
+                                 {
+                                     get;
+                                     private set;
+                                 } // explanation
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    public int Value { get; private set; } // explanation
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that an accessor modifier is collapsed in one pass even without a trailing comment,
+    /// which is the shape that reaches the collapse independently of this issue
+    /// </summary>
+    [TestMethod]
+    public void AccessorModifierCollapsesInOnePass()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 public int Value
+                                 {
+                                     get;
+                                     private set;
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    public int Value { get; private set; }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
     /// Verifies that an indexer with a multi-line auto-accessor list and a trailing comment keeps its
     /// existing layout, so the property fix does not leak into the indexer path
     /// </summary>

--- a/Reihitsu.Formatter.Test/Regression/LineBreaks/AutoPropertyTrailingCommentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/LineBreaks/AutoPropertyTrailingCommentTests.cs
@@ -339,6 +339,72 @@ public class AutoPropertyTrailingCommentTests : FormatterTestsBase
     }
 
     /// <summary>
+    /// Verifies that a comment between the accessor list and an initializer on the following line is
+    /// not crossed, so the declaration keeps its existing layout
+    /// </summary>
+    [TestMethod]
+    public void CommentBeforeOwnLineInitializerIsNotCrossed()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 public int Value { get; set; } // note
+                                 = 1;
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a multi-line block comment between the accessor list and the initializer is not
+    /// crossed, so the declaration keeps its existing layout
+    /// </summary>
+    [TestMethod]
+    public void BlockCommentBeforeInitializerIsNotCrossed()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 public int Value { get; set; } /* note
+                                    more */ = 2;
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that an initializer on its own line is joined onto the property line when no trivia
+    /// sits in between, which is the boundary that keeps the initializer-gap guard from over-reaching
+    /// </summary>
+    [TestMethod]
+    public void OwnLineInitializerWithoutTriviaIsJoined()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 public int Value { get; set; }
+                                 = 1;
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    public int Value { get; set; } = 1;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
     /// Verifies that an indexer with a multi-line auto-accessor list and a trailing comment keeps its
     /// existing layout, so the property fix does not leak into the indexer path
     /// </summary>

--- a/Reihitsu.Formatter.Test/Regression/LineBreaks/AutoPropertyTrailingCommentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/LineBreaks/AutoPropertyTrailingCommentTests.cs
@@ -1,0 +1,364 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Formatter.Test.Helpers;
+
+namespace Reihitsu.Formatter.Test.Regression.LineBreaks;
+
+/// <summary>
+/// Regression tests for issue #604: a comment that trails the accessor list of an auto-property sits
+/// outside that list and is never rewritten by the single-line collapse, so it must not force the
+/// accessor list apart. Trivia the collapse would cross - inside the accessor list, or in the gap
+/// between the property signature and the opening brace - remains a join barrier
+/// </summary>
+[TestClass]
+public class AutoPropertyTrailingCommentTests : FormatterTestsBase
+{
+    #region Methods
+
+    /// <summary>
+    /// Verifies that a single-line comment trailing the accessor list does not split a single-line
+    /// get/set auto-property
+    /// </summary>
+    [TestMethod]
+    public void CommentAfterAutoAccessorListDoesNotSplitTheProperty()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 public int Value { get; set; } // explanation
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a block comment trailing the accessor list does not split a single-line
+    /// get/set auto-property
+    /// </summary>
+    [TestMethod]
+    public void BlockCommentAfterAutoAccessorListDoesNotSplitTheProperty()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 public int Value { get; set; } /* explanation */
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a comment trailing the accessor list does not split a single-line get-only
+    /// auto-property
+    /// </summary>
+    [TestMethod]
+    public void CommentAfterGetOnlyAutoAccessorListDoesNotSplitTheProperty()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 public int Value { get; } // explanation
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a comment trailing the accessor list does not split a single-line auto-property
+    /// whose accessors carry attributes
+    /// </summary>
+    [TestMethod]
+    public void CommentAfterAttributedAutoAccessorListDoesNotSplitTheProperty()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 public required int Value { [Test] get; [Test] init; } // explanation
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a comment between the accessor list and the property initializer does not split
+    /// a single-line auto-property
+    /// </summary>
+    [TestMethod]
+    public void CommentBetweenAccessorListAndInitializerDoesNotSplitTheProperty()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 public int Value { get; set; } /* note */ = 1;
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a multi-line get/set auto-property collapses even when a comment trails its
+    /// accessor list
+    /// </summary>
+    [TestMethod]
+    public void MultiLineAutoPropertyWithTrailingCommentCollapses()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 public int Value
+                                 {
+                                     get; set;
+                                 } // explanation
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    public int Value { get; set; } // explanation
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a multi-line get-only auto-property collapses even when a comment trails its
+    /// accessor list
+    /// </summary>
+    [TestMethod]
+    public void MultiLineGetOnlyAutoPropertyWithTrailingCommentCollapses()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 public int Value
+                                 {
+                                     get;
+                                 } // explanation
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    public int Value { get; } // explanation
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a multi-line get/set auto-property collapses even when a block comment trails
+    /// its accessor list
+    /// </summary>
+    [TestMethod]
+    public void MultiLineAutoPropertyWithTrailingBlockCommentCollapses()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 public int Value
+                                 {
+                                     get; set;
+                                 } /* explanation */
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    public int Value { get; set; } /* explanation */
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a comment inside the accessor list still prevents the single-line collapse
+    /// </summary>
+    [TestMethod]
+    public void CommentInsideAccessorListStillSplitsTheProperty()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 public int Value { get; /* inner */ set; }
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    public int Value
+                                    {
+                                        get; /* inner */ set;
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a directive inside the accessor list still prevents the single-line collapse.
+    /// The test deliberately uses <c>#if</c> rather than <c>#region</c>, because the region phase
+    /// removes region directives from an accessor list before the line-break phase runs
+    /// </summary>
+    [TestMethod]
+    public void DirectiveInsideAccessorListStillSplitsTheProperty()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 public int Value
+                                 {
+                             #if FEATURE
+                                     get;
+                             #endif
+                                     set;
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a comment in the gap between the property signature and the accessor-list
+    /// opening brace still prevents the collapse and is not crossed
+    /// </summary>
+    [TestMethod]
+    public void CommentInSignatureGapIsNotCrossed()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 public int Value // note
+                                 { get; set; }
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    public int Value // note
+                                    {
+                                        get; set;
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a comment on its own line before the accessor-list opening brace still prevents
+    /// the collapse and is not crossed
+    /// </summary>
+    [TestMethod]
+    public void CommentOnOwnLineBeforeAccessorListIsNotCrossed()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 public int Value
+                                 // note
+                                 { get; set; }
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    public int Value
+                                    // note
+                                    {
+                                        get; set;
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a property whose signature spans several lines keeps its existing layout even
+    /// when a comment trails the accessor list, because the collapse is refused for the signature
+    /// rather than for the trivia
+    /// </summary>
+    [TestMethod]
+    public void MultiLineSignatureWithTrailingCommentRemainsUnchanged()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 public System.Collections.Generic.Dictionary<string,
+                                 int> Value { get; set; } // explanation
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    public System.Collections.Generic.Dictionary<string,
+                                    int> Value
+                                    {
+                                        get; set;
+                                    } // explanation
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that an indexer with a multi-line auto-accessor list and a trailing comment keeps its
+    /// existing layout, so the property fix does not leak into the indexer path
+    /// </summary>
+    [TestMethod]
+    public void MultiLineAutoAccessorIndexerWithTrailingCommentRemainsUnchanged()
+    {
+        // Arrange
+        const string input = """
+                             interface I
+                             {
+                                 int this[int index]
+                                 {
+                                     get; set;
+                                 } // trailing
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/LineBreakDetection.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/LineBreakDetection.cs
@@ -24,9 +24,9 @@ internal static class LineBreakDetection
     /// existing layout, unless the list itself carries a comment or a directive. The interior-scoped
     /// check is deliberate: a comment trailing the closing brace sits outside the list and must not
     /// force the braces apart.
-    /// The property collapse path in <c>PropertyLayoutLineBreakRewriter</c> applies a second, wider
-    /// guard of its own, so a property and an indexer still diverge for a comment that follows the
-    /// accessor list. That divergence is pre-existing and is not owned by this predicate.
+    /// The property collapse path in <c>PropertyLayoutLineBreakRewriter</c> applies a second guard of
+    /// its own, which is interior-scoped for the same reason, so a property and an indexer agree that a
+    /// comment following the accessor list is not a join barrier (see issue #604).
     /// </remarks>
     public static bool ShouldNormalizeAccessorListBraces(AccessorListSyntax accessorList)
     {

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/PropertyLayoutLineBreakRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/PropertyLayoutLineBreakRewriter.cs
@@ -198,7 +198,7 @@ internal sealed class PropertyLayoutLineBreakRewriter : CSharpSyntaxRewriter
     }
 
     /// <summary>
-    /// Collapses each accessor's attribute-list brackets, keyword, and semicolon onto the accessor line
+    /// Collapses each accessor's attribute-list brackets, modifiers, keyword, and semicolon onto the accessor line
     /// </summary>
     /// <param name="updatedNode">The property declaration whose accessors are collapsed</param>
     /// <returns>The property declaration with each accessor collapsed onto a single line</returns>

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/PropertyLayoutLineBreakRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/PropertyLayoutLineBreakRewriter.cs
@@ -214,6 +214,15 @@ internal sealed class PropertyLayoutLineBreakRewriter : CSharpSyntaxRewriter
                 accessor = updatedNode.AccessorList.Accessors[accessorIndex];
             }
 
+            // Modifiers precede the keyword, so an accessor such as "private set;" carries the line break and the
+            // indentation on its modifier rather than on its keyword. Collapsing only the keyword would leave that
+            // indentation behind as stray spacing that a second pass has to clean up.
+            for (var modifierIndex = 0; modifierIndex < accessor.Modifiers.Count; modifierIndex++)
+            {
+                updatedNode = LineBreakTriviaUtilities.CollapseTokenToSameLine(updatedNode, accessor.Modifiers[modifierIndex]);
+                accessor = updatedNode.AccessorList.Accessors[accessorIndex];
+            }
+
             updatedNode = LineBreakTriviaUtilities.CollapseTokenToSameLine(updatedNode, accessor.Keyword);
             accessor = updatedNode.AccessorList.Accessors[accessorIndex];
 

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/PropertyLayoutLineBreakRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/PropertyLayoutLineBreakRewriter.cs
@@ -136,11 +136,17 @@ internal sealed class PropertyLayoutLineBreakRewriter : CSharpSyntaxRewriter
     /// <remarks>
     /// The initializer is a sibling that follows the accessor list and is laid out by other subphases.
     /// Collapsing the accessor list does not touch it, so a multi-line initializer must not prevent the
-    /// simple auto-property accessor list from staying single-line (see issue #311)
+    /// simple auto-property accessor list from staying single-line (see issue #311).
+    /// The comment and directive guard is interior-scoped for the same reason: the collapse rewrites only
+    /// the closing brace's leading trivia, so a comment trailing that brace sits outside the accessor list
+    /// and is never crossed. Guarding the accessor list's full span instead would count that trailing
+    /// comment and force an already-correct single-line property apart (see issue #604).
+    /// Trivia the collapse would cross is still guarded: inside the accessor list by the check below, and
+    /// in the gap between the signature and the opening brace by <see cref="LineBreakTriviaUtilities.WouldJoinAcrossUnjoinableTrivia"/>
     /// </remarks>
     private static bool CanCollapseAutoPropertyToSingleLine(PropertyDeclarationSyntax node)
     {
-        if (node?.AccessorList == null || SyntaxNodeUtilities.ContainsCommentOrDirective(node.AccessorList))
+        if (node?.AccessorList == null || SyntaxNodeUtilities.InteriorContainsCommentOrDirective(node.AccessorList))
         {
             return false;
         }

--- a/documentation/rules/RH5408.md
+++ b/documentation/rules/RH5408.md
@@ -38,6 +38,8 @@ Collapse the declaration so the property signature and accessor list are on one 
 
 Auto-properties are not reported when a comment or directive would be crossed by the collapse — whether it sits inside the accessor list or in the gap between the signature and the accessor brace (for example `public int Value // note` on its own line). The formatter refuses to join across that trivia, so the code fix only applies when collapsing can be done safely.
 
+A comment that follows the accessor list is not crossed by the collapse, so it does not exempt the property. `public int Value { get; set; } // explanation` stays on one line, and the multi-line form of the same declaration is reported and collapsed with the comment kept in place.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH5408.md
+++ b/documentation/rules/RH5408.md
@@ -40,6 +40,8 @@ Auto-properties are not reported when a comment or directive would be crossed by
 
 A comment that follows the accessor list is not crossed by the collapse, so it does not exempt the property. `public int Value { get; set; } // explanation` stays on one line, and the multi-line form of the same declaration is reported and collapsed with the comment kept in place.
 
+A property initializer is part of the reported declaration, so a comment or directive between the accessor list and the initializer does exempt the property. The formatter cannot join the initializer across that trivia, and the rule stays silent rather than reporting a declaration that cannot be collapsed.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH5408.md
+++ b/documentation/rules/RH5408.md
@@ -40,7 +40,7 @@ Auto-properties are not reported when a comment or directive would be crossed by
 
 A comment that follows the accessor list is not crossed by the collapse, so it does not exempt the property. `public int Value { get; set; } // explanation` stays on one line, and the multi-line form of the same declaration is reported and collapsed with the comment kept in place.
 
-A property initializer is part of the reported declaration, so a comment or directive between the accessor list and the initializer does exempt the property. The formatter cannot join the initializer across that trivia, and the rule stays silent rather than reporting a declaration that cannot be collapsed.
+A property initializer is part of the reported declaration, so a comment or directive between the accessor list and an initializer that starts on a later line does exempt the property. The formatter cannot pull the initializer up across that trivia, and the rule stays silent rather than reporting a declaration that cannot be collapsed. Trivia in a gap that already sits on one line — for example `public int Value { get; set; } /* note */ = 1;` — is never crossed and does not exempt the property.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

Scope the accessor-list comment and directive guard to the list *interior* in the formatter's auto-property collapse, and apply the same narrowing to the RH5408 analyzer and its code fix. Two supporting corrections keep that narrowing sound: the RH5408 initializer gap is guarded only when it actually spans lines, and accessor modifiers are now collapsed together with their keyword.

## Why

A comment trailing the accessor list's closing brace lives outside that list, and the collapse rewrites only the closing brace's *leading* trivia — so the comment is provably never crossed. Guarding the accessor list's full span counted that trailing comment and forced an already-correct declaration apart:

```csharp
public int Value { get; set; } // explanation   →   public int Value
                                                    {
                                                        get; set;
                                                    } // explanation
```

Trivia the collapse *would* cross is still a barrier: inside the accessor list, and in the gap between the property signature and the opening brace.

## Linked issues

Closes #604

## Review notes

- **RH5408 moves with the formatter.** The identical full-span guard existed in the analyzer and the code fix; leaving them behind would have made `reihitsu-format` reflow a shape the analyzer stayed silent on. The rule now reports the multi-line form of a trailing-comment property, so a diagnostic newly fires on code that was warning-free before. `documentation/rules/RH5408.md` already documented this boundary ("trivia that would be crossed by the collapse") and is extended with the initializer caveat.
- **Initializer gap.** Because RH5408's reported span runs to the end of the declaration, the narrowing needed a matching guard on the `}` → `=` gap — but only when that gap spans lines. Trivia already on one line is never crossed, so `public int Value { get; set; } /* note */ = 1;` is still reported and still collapses.
- **Accessor modifiers.** `CollapseAccessorTokensToSingleLine` never collapsed `accessor.Modifiers`, so an accessor such as `private set;` kept its original indentation. On `main` the full-span guard prevented these shapes from reaching the collapse at all; the narrowing makes them reachable, which exposed the defect as `{ get;         private set; }` on the first pass, converging only on the second. It now collapses in one pass. This is the one change that reaches beyond the issue's literal wording, and it is why `accessor.Modifiers` appears in the diff.
- **Not changed:** indexer and event accessor lists (already interior-scoped, no collapse path), `Reihitsu.Core` predicates (`InteriorContainsCommentOrDirective` already existed), and the expression-bodied property path.
- Three expectations in `TrailingDocumentationCommentPreservationTests` encoded the old split output and were corrected to the inline form.

## Follow-up work

Confirmed and reproduced during review, tracked separately and intentionally not fixed here:

- #610 — `LineBreakListRewriter.CanSafelyCollapseBracketedArguments`, mirrored in RH5307's analyzer and code fix, carries the same over-broad exterior guard this PR removes for accessor lists. Harmless today because all three surfaces share the guard, so no permanent diagnostic arises.
- #611 — a `#region`/`#endregion` pair inside an accessor list is silently deleted by the region phase rather than treated as a join barrier. Verified independent of this change.
- #612 — pre-existing permanent RH5408: a property whose declaration semicolon sits on its own line is reported, but no formatter subphase joins the value-to-semicolon gap.
- #613 — `Reihitsu.Core/AttributeTargetUtilities.cs` is not formatter-clean at this head, from the switch-case brace phase. Unrelated to this diff.
