### PR TITLE
Anchor the field split indentation on the field's own line and preserve documentation comments

### DIFF
--- a/Reihitsu.Analyzer.Test/Formatting/RH7101DoNotCombineFieldsAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH7101DoNotCombineFieldsAnalyzerTests.cs
@@ -124,6 +124,161 @@ public class RH7101DoNotCombineFieldsAnalyzerTests : AnalyzerTestsBase<RH7101DoN
     }
 
     /// <summary>
+    /// Verifies that the fix indents every generated field at the member level when the declaration is documented.
+    /// The fix applies the split transform without running the formatting pipeline, so no later indentation phase
+    /// repairs the anchor and this output is what the user sees (issue #592)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDocumentedCombinedFieldsAreFixedAtMemberIndentation()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    /// <summary>
+                                    /// Two fields.
+                                    /// </summary>
+                                    private int firstField, {|#0:secondField|};
+                                }
+                                """;
+
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     /// <summary>
+                                     /// Two fields.
+                                     /// </summary>
+                                     private int firstField;
+                                     private int secondField;
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH7101DoNotCombineFieldsAnalyzer.DiagnosticId, AnalyzerResources.RH7101MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that the fix anchors the generated fields on the line the field declaration starts on rather than on
+    /// the documentation comment, which may be indented differently (issue #592)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyMisalignedDocumentationCommentFixUsesFieldLineIndentation()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                  /// <summary>
+                                  /// Two fields.
+                                  /// </summary>
+                                    private int firstField, {|#0:secondField|};
+                                }
+                                """;
+
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                   /// <summary>
+                                   /// Two fields.
+                                   /// </summary>
+                                     private int firstField;
+                                     private int secondField;
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH7101DoNotCombineFieldsAnalyzer.DiagnosticId, AnalyzerResources.RH7101MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that the fix still finds the field's own indentation when the documentation comment starts on the
+    /// opening brace line, so the generated field does not fall back to column zero (issue #592)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDocumentationCommentOnOpeningBraceLineFixUsesFieldLineIndentation()
+    {
+        const string testData = """
+                                internal class TestClass
+                                { /// <summary>
+                                  /// Two fields.
+                                  /// </summary>
+                                    private int firstField, {|#0:secondField|};
+                                }
+                                """;
+
+        const string fixedData = """
+                                 internal class TestClass
+                                 { /// <summary>
+                                   /// Two fields.
+                                   /// </summary>
+                                     private int firstField;
+                                     private int secondField;
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH7101DoNotCombineFieldsAnalyzer.DiagnosticId, AnalyzerResources.RH7101MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that a single-line documentation comment re-attached to a generated field is not followed by a blank
+    /// line. This form carries its own line break, so the split must not append a second one. The formatting
+    /// pipeline's blank-line phase absorbs the stray break, which is why only the code fix can observe it (issue #592)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifySingleLineDocumentationCommentBeforeDeclaratorGetsNoBlankLine()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    private int firstField,
+                                                /// <summary>Second field.</summary>
+                                                {|#0:secondField|};
+                                }
+                                """;
+
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     private int firstField;
+                                     /// <summary>Second field.</summary>
+                                     private int secondField;
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH7101DoNotCombineFieldsAnalyzer.DiagnosticId, AnalyzerResources.RH7101MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that a delimited documentation comment re-attached to a generated field keeps a line break after it.
+    /// Unlike a single-line documentation comment it carries none of its own, so this is the side of the boundary
+    /// that a guard written against the trivia kind instead of the trivia text would break (issue #592)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyMultiLineDocumentationCommentBeforeDeclaratorKeepsItsLineBreak()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    private int firstField,
+                                                /** Second field. */
+                                                {|#0:secondField|};
+                                }
+                                """;
+
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     private int firstField;
+                                     /** Second field. */
+                                     private int secondField;
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH7101DoNotCombineFieldsAnalyzer.DiagnosticId, AnalyzerResources.RH7101MessageFormat));
+    }
+
+    /// <summary>
     /// Verifies that the fix is not offered when the combined field carries a preprocessor directive, because the
     /// split transform leaves directive-bearing fields intact and the fix would otherwise be a no-op (issue #456)
     /// </summary>

--- a/Reihitsu.Formatter.Test/Regression/Structural/FieldDeclarationSplitTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Structural/FieldDeclarationSplitTests.cs
@@ -93,6 +93,647 @@ public class FieldDeclarationSplitTests : FormatterTestsBase
     }
 
     /// <summary>
+    /// Verifies that a documented combined field declaration is split at the member indentation on the first pass.
+    /// A documentation comment carries its line break inside its own structure, so the indentation anchor must not
+    /// look for a top-level end-of-line trivia after it (issue #592)
+    /// </summary>
+    [TestMethod]
+    public void DocumentedCombinedFieldsAreSplitAtMemberIndentation()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 /// <summary>Two fields.</summary>
+                                 private int _first, _second;
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    /// <summary>
+                                    /// Two fields.
+                                    /// </summary>
+                                    private int _first;
+                                    private int _second;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a documented combined field declaration in a nested type is split at the nested member
+    /// indentation rather than at a multiple of it (issue #592)
+    /// </summary>
+    [TestMethod]
+    public void DocumentedCombinedFieldsInNestedTypeAreSplitAtMemberIndentation()
+    {
+        // Arrange
+        const string input = """
+                             internal class Outer
+                             {
+                                 internal class Inner
+                                 {
+                                     /// <summary>
+                                     /// Two fields.
+                                     /// </summary>
+                                     private int _first, _second;
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                internal class Outer
+                                {
+                                    internal class Inner
+                                    {
+                                        /// <summary>
+                                        /// Two fields.
+                                        /// </summary>
+                                        private int _first;
+                                        private int _second;
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that every field generated from a documented declaration with more than two declarators is placed
+    /// at the member indentation (issue #592)
+    /// </summary>
+    [TestMethod]
+    public void DocumentedCombinedFieldsWithThreeDeclaratorsAreSplitAtMemberIndentation()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 /// <summary>
+                                 /// Three fields.
+                                 /// </summary>
+                                 private int _first, _second, _third;
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    /// <summary>
+                                    /// Three fields.
+                                    /// </summary>
+                                    private int _first;
+                                    private int _second;
+                                    private int _third;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a documented combined field declaration carrying an attribute list is split at the member
+    /// indentation, so the generated attribute lists line up with the generated fields (issue #592)
+    /// </summary>
+    [TestMethod]
+    public void DocumentedCombinedFieldsWithAttributeAreSplitAtMemberIndentation()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 /// <summary>
+                                 /// Two fields.
+                                 /// </summary>
+                                 [System.Obsolete]
+                                 private int _first, _second;
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    /// <summary>
+                                    /// Two fields.
+                                    /// </summary>
+                                    [System.Obsolete]
+                                    private int _first;
+                                    [System.Obsolete]
+                                    private int _second;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a combined field declaration preceded by an inline block comment is split at the indentation of
+    /// the line the field starts on, instead of accumulating the whitespace on both sides of the comment (issue #592)
+    /// </summary>
+    [TestMethod]
+    public void InlineBlockCommentCombinedFieldsAreSplitAtMemberIndentation()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 /* note */ private int _first, _second;
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    /* note */ private int _first;
+                                    private int _second;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a combined field declaration preceded by a block comment on its own line keeps its current,
+    /// already correct indentation. This is the "field starts its own line" side of the boundary that
+    /// <see cref="InlineBlockCommentCombinedFieldsAreSplitAtMemberIndentation"/> exercises from the other side
+    /// </summary>
+    [TestMethod]
+    public void OwnLineBlockCommentCombinedFieldsAreSplitAtMemberIndentation()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 /* note */
+                                 private int _first, _second;
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    /* note */
+                                    private int _first;
+                                    private int _second;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a combined field declaration documented with a delimited documentation comment keeps its
+    /// current, already correct indentation. Unlike a single-line documentation comment this form does not carry its
+    /// line break internally, so it is the side of the boundary that a fix widened to "documentation comments" would
+    /// break (issue #592)
+    /// </summary>
+    [TestMethod]
+    public void MultiLineDocumentationCommentCombinedFieldsAreSplitAtMemberIndentation()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 /** Two fields. */
+                                 private int _first, _second;
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    /** Two fields. */
+                                    private int _first;
+                                    private int _second;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a documented combined field declaration in a struct is split at the member indentation (issue #592)
+    /// </summary>
+    [TestMethod]
+    public void DocumentedCombinedStructFieldsAreSplitAtMemberIndentation()
+    {
+        // Arrange
+        const string input = """
+                             internal struct TestStruct
+                             {
+                                 /// <summary>
+                                 /// Two fields.
+                                 /// </summary>
+                                 private int _first, _second;
+                             }
+                             """;
+        const string expected = """
+                                internal struct TestStruct
+                                {
+                                    /// <summary>
+                                    /// Two fields.
+                                    /// </summary>
+                                    private int _first;
+                                    private int _second;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a documented combined field declaration in a record is split at the member indentation (issue #592)
+    /// </summary>
+    [TestMethod]
+    public void DocumentedCombinedRecordFieldsAreSplitAtMemberIndentation()
+    {
+        // Arrange
+        const string input = """
+                             internal record TestRecord
+                             {
+                                 /// <summary>
+                                 /// Two fields.
+                                 /// </summary>
+                                 private int _first, _second;
+                             }
+                             """;
+        const string expected = """
+                                internal record TestRecord
+                                {
+                                    /// <summary>
+                                    /// Two fields.
+                                    /// </summary>
+                                    private int _first;
+                                    private int _second;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a documented combined field declaration in a record struct is split at the member indentation (issue #592)
+    /// </summary>
+    [TestMethod]
+    public void DocumentedCombinedRecordStructFieldsAreSplitAtMemberIndentation()
+    {
+        // Arrange
+        const string input = """
+                             internal record struct TestRecordStruct
+                             {
+                                 /// <summary>
+                                 /// Two fields.
+                                 /// </summary>
+                                 private int _first, _second;
+                             }
+                             """;
+        const string expected = """
+                                internal record struct TestRecordStruct
+                                {
+                                    /// <summary>
+                                    /// Two fields.
+                                    /// </summary>
+                                    private int _first;
+                                    private int _second;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a documented combined field declaration in an interface is split at the member indentation (issue #592)
+    /// </summary>
+    [TestMethod]
+    public void DocumentedCombinedInterfaceFieldsAreSplitAtMemberIndentation()
+    {
+        // Arrange
+        const string input = """
+                             internal interface ITest
+                             {
+                                 /// <summary>
+                                 /// Two fields.
+                                 /// </summary>
+                                 static int _first, _second;
+                             }
+                             """;
+        const string expected = """
+                                internal interface ITest
+                                {
+                                    /// <summary>
+                                    /// Two fields.
+                                    /// </summary>
+                                    static int _first;
+                                    static int _second;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a documentation comment preceding a later declarator is preserved and documents the field it
+    /// precedes. Before the fix the split rebuilt the generated field's trivia from a comment set that excluded
+    /// documentation comments, which deleted it outright (issue #592)
+    /// </summary>
+    [TestMethod]
+    public void DocumentationCommentBeforeDeclaratorIsPreserved()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 private int _first,
+                                             /// <summary>Second.</summary>
+                                             _second;
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    private int _first;
+
+                                    /// <summary>
+                                    /// Second.
+                                    /// </summary>
+                                    private int _second;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a delimited documentation comment preceding a later declarator is preserved. This form carries
+    /// no line break of its own, so the split has to supply one (issue #592)
+    /// </summary>
+    [TestMethod]
+    public void MultiLineDocumentationCommentBeforeDeclaratorIsPreserved()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 private int _first,
+                                             /** Second. */
+                                             _second;
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    private int _first;
+
+                                    /** Second. */
+                                    private int _second;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a documentation comment written after the separator documents the following field. Roslyn files
+    /// it as leading trivia of the next declarator, unlike the line comment in
+    /// <see cref="TrailingCommentAfterSeparatorIsPreserved"/>, which stays trailing on the first field (issue #592)
+    /// </summary>
+    [TestMethod]
+    public void DocumentationCommentAfterSeparatorDocumentsFollowingField()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 private int _first, /// <summary>Second.</summary>
+                                             _second;
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    private int _first;
+
+                                    /// <summary>
+                                    /// Second.
+                                    /// </summary>
+                                    private int _second;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a line comment written before the separator stays a trailing comment on the first generated
+    /// field. It lands in the declarator's trailing trivia, which the widened comment predicate must leave alone
+    /// </summary>
+    [TestMethod]
+    public void LineCommentBeforeSeparatorStaysTrailingOnFirstField()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 private int _first /* first */,
+                                             _second;
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    private int _first; /* first */
+                                    private int _second;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a documentation comment on the declaration and a documentation comment on a later declarator are
+    /// both preserved, each documenting its own generated field (issue #592)
+    /// </summary>
+    [TestMethod]
+    public void FieldAndDeclaratorDocumentationCommentsAreBothPreserved()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 /// <summary>First.</summary>
+                                 private int _first,
+                                             /// <summary>Second.</summary>
+                                             _second;
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    /// <summary>
+                                    /// First.
+                                    /// </summary>
+                                    private int _first;
+
+                                    /// <summary>
+                                    /// Second.
+                                    /// </summary>
+                                    private int _second;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a documentation comment preceding the second of three declarators is preserved on that field
+    /// only, leaving the third field undocumented (issue #592)
+    /// </summary>
+    [TestMethod]
+    public void DocumentationCommentBeforeSecondOfThreeDeclaratorsIsPreserved()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 private int _first,
+                                             /// <summary>Second.</summary>
+                                             _second,
+                                             _third;
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    private int _first;
+
+                                    /// <summary>
+                                    /// Second.
+                                    /// </summary>
+                                    private int _second;
+                                    private int _third;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a line comment and a documentation comment preceding the same declarator are both preserved in
+    /// source order (issue #592)
+    /// </summary>
+    [TestMethod]
+    public void LineAndDocumentationCommentBeforeDeclaratorArePreserved()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 private int _first,
+                                             // note
+                                             /// <summary>Second.</summary>
+                                             _second;
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    private int _first;
+
+                                    // note
+                                    /// <summary>
+                                    /// Second.
+                                    /// </summary>
+                                    private int _second;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a documentation comment preceding a later declarator is preserved at the nested member
+    /// indentation (issue #592)
+    /// </summary>
+    [TestMethod]
+    public void DocumentationCommentBeforeDeclaratorInNestedTypeIsPreserved()
+    {
+        // Arrange
+        const string input = """
+                             internal class Outer
+                             {
+                                 internal class Inner
+                                 {
+                                     private int _first,
+                                                 /// <summary>Second.</summary>
+                                                 _second;
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                internal class Outer
+                                {
+                                    internal class Inner
+                                    {
+                                        private int _first;
+
+                                        /// <summary>
+                                        /// Second.
+                                        /// </summary>
+                                        private int _second;
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a documentation comment preceding a later declarator is preserved in an interface (issue #592)
+    /// </summary>
+    [TestMethod]
+    public void DocumentationCommentBeforeDeclaratorInInterfaceIsPreserved()
+    {
+        // Arrange
+        const string input = """
+                             internal interface ITest
+                             {
+                                 static int _first,
+                                            /// <summary>Second.</summary>
+                                            _second;
+                             }
+                             """;
+        const string expected = """
+                                internal interface ITest
+                                {
+                                    static int _first;
+
+                                    /// <summary>
+                                    /// Second.
+                                    /// </summary>
+                                    static int _second;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
     /// Verifies that static fields declared in an interface are split
     /// </summary>
     [TestMethod]

--- a/Reihitsu.Formatter/Pipeline/StructuralTransforms/Rewriter/FieldDeclarationSplitTransform.cs
+++ b/Reihitsu.Formatter/Pipeline/StructuralTransforms/Rewriter/FieldDeclarationSplitTransform.cs
@@ -77,47 +77,72 @@ internal sealed class FieldDeclarationSplitTransform : CSharpSyntaxRewriter
     }
 
     /// <summary>
-    /// Gets the comment trivia contained in the provided trivia list
+    /// Gets the comment trivia contained in the provided trivia list, including documentation comments
     /// </summary>
     /// <param name="trivia">The trivia list</param>
     /// <returns>The comment trivia</returns>
     private static IEnumerable<SyntaxTrivia> GetComments(SyntaxTriviaList trivia)
     {
-        return trivia.Where(item => item.IsKind(SyntaxKind.SingleLineCommentTrivia)
-                                    || item.IsKind(SyntaxKind.MultiLineCommentTrivia));
+        return trivia.Where(ReihitsuFormatterHelpers.IsCommentTrivia);
     }
 
     /// <summary>
-    /// Gets the indentation trivia for additional generated fields
+    /// Gets the contiguous whitespace trivia run that starts at the provided index
+    /// </summary>
+    /// <param name="trivia">The trivia list</param>
+    /// <param name="startIndex">The index the run starts at</param>
+    /// <returns>The whitespace trivia run, which is empty when no whitespace starts at the index</returns>
+    private static SyntaxTriviaList GetWhitespaceRun(SyntaxTriviaList trivia, int startIndex)
+    {
+        var run = new List<SyntaxTrivia>();
+        var triviaIndex = startIndex;
+
+        while (triviaIndex < trivia.Count
+               && trivia[triviaIndex].IsKind(SyntaxKind.WhitespaceTrivia))
+        {
+            run.Add(trivia[triviaIndex]);
+
+            triviaIndex++;
+        }
+
+        return SyntaxFactory.TriviaList(run);
+    }
+
+    /// <summary>
+    /// Gets the indentation trivia for additional generated fields, which is the whitespace that begins the
+    /// physical line the field declaration starts on
     /// </summary>
     /// <param name="leadingTrivia">The original leading trivia</param>
     /// <returns>The indentation trivia</returns>
     private static SyntaxTriviaList GetMemberIndentationTrivia(SyntaxTriviaList leadingTrivia)
     {
-        var lastEndOfLineIndex = -1;
+        // The whitespace that opens the field's line is the trailing whitespace run of the leading trivia, but only
+        // when the trivia in front of that run ends the previous line. Locating it by scanning for the last
+        // top-level end-of-line trivia is wrong twice over: a single-line documentation comment terminates its line
+        // inside its own structure, so no top-level end-of-line follows it and the scan restarts at the beginning,
+        // summing the whitespace of every preceding line; and an inline comment leaves a second whitespace run on
+        // the same line, which the scan appends to the first (issue #592).
+        var runStart = leadingTrivia.Count;
 
-        for (var triviaIndex = 0; triviaIndex < leadingTrivia.Count; triviaIndex++)
+        while (runStart > 0
+               && leadingTrivia[runStart - 1].IsKind(SyntaxKind.WhitespaceTrivia))
         {
-            if (leadingTrivia[triviaIndex].IsKind(SyntaxKind.EndOfLineTrivia))
-            {
-                lastEndOfLineIndex = triviaIndex;
-            }
+            runStart--;
         }
 
-        // Collect the whitespace that follows the last end-of-line — the member's indentation. When the field is
-        // the first member of its type its leading trivia carries no end-of-line (the newline sits on the opening
-        // brace), so fall back to the leading whitespace of the trivia list instead of returning no indentation.
-        var trivia = new List<SyntaxTrivia>(leadingTrivia.Count - lastEndOfLineIndex - 1);
-
-        for (var triviaIndex = lastEndOfLineIndex + 1; triviaIndex < leadingTrivia.Count; triviaIndex++)
+        // Testing the trivia text rather than its kind is deliberate: it recognizes the line break embedded in a
+        // single-line documentation comment as readily as a plain end-of-line trivia.
+        if (runStart > 0
+            && leadingTrivia[runStart - 1].ToFullString().EndsWith("\n", StringComparison.Ordinal) == false)
         {
-            if (leadingTrivia[triviaIndex].IsKind(SyntaxKind.WhitespaceTrivia))
-            {
-                trivia.Add(leadingTrivia[triviaIndex]);
-            }
+            // The declaration shares its line with preceding trivia, so the run found above is an inner gap rather
+            // than the line's indentation. The whitespace that opens the trivia list opens the line instead.
+            return GetWhitespaceRun(leadingTrivia, 0);
         }
 
-        return SyntaxFactory.TriviaList(trivia);
+        // When the field is the first member of its type its leading trivia carries no line break at all (the
+        // newline sits on the opening brace), which leaves the run starting at index 0 — still the right answer.
+        return GetWhitespaceRun(leadingTrivia, runStart);
     }
 
     /// <summary>
@@ -160,7 +185,16 @@ internal sealed class FieldDeclarationSplitTransform : CSharpSyntaxRewriter
         {
             trivia.AddRange(indentationTrivia);
             trivia.Add(comment);
-            trivia.Add(SyntaxFactory.EndOfLine(_context.EndOfLine));
+
+            // A single-line documentation comment already terminates its line inside its own structure, so appending
+            // another end-of-line would put a blank line between the comment and the field it documents. The
+            // pipeline's blank-line phase absorbs that break, but the RH7101 code fix runs this transform on its own
+            // and would emit the detached comment verbatim. Test the trivia text rather than its kind: a delimited
+            // documentation comment (/** … */) carries no line break and still needs one appended (issue #592).
+            if (comment.ToFullString().EndsWith("\n", StringComparison.Ordinal) == false)
+            {
+                trivia.Add(SyntaxFactory.EndOfLine(_context.EndOfLine));
+            }
         }
 
         trivia.AddRange(indentationTrivia);

--- a/Reihitsu.Formatter/Pipeline/StructuralTransforms/Rewriter/FieldDeclarationSplitTransform.cs
+++ b/Reihitsu.Formatter/Pipeline/StructuralTransforms/Rewriter/FieldDeclarationSplitTransform.cs
@@ -109,6 +109,21 @@ internal sealed class FieldDeclarationSplitTransform : CSharpSyntaxRewriter
     }
 
     /// <summary>
+    /// Determines whether the provided trivia ends the line it sits on
+    /// </summary>
+    /// <param name="trivia">The trivia to inspect</param>
+    /// <returns><see langword="true"/> if the trivia ends its line; otherwise, <see langword="false"/></returns>
+    private static bool EndsLine(SyntaxTrivia trivia)
+    {
+        // Deciding this on the trivia text rather than on its kind is what lets the line break a single-line
+        // documentation comment carries inside its own structure count just like a plain end-of-line trivia.
+        // BlankLineTriviaUtilities.EndsWithLineBreak answers a deliberately narrower question - it is scoped to
+        // directive, disabled-text and documentation trivia and reports false for a plain end-of-line - so it cannot
+        // serve the callers here, which have to treat both as ending the line.
+        return trivia.ToFullString().EndsWith("\n", StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// Gets the indentation trivia for additional generated fields, which is the whitespace that begins the
     /// physical line the field declaration starts on
     /// </summary>
@@ -130,10 +145,8 @@ internal sealed class FieldDeclarationSplitTransform : CSharpSyntaxRewriter
             runStart--;
         }
 
-        // Testing the trivia text rather than its kind is deliberate: it recognizes the line break embedded in a
-        // single-line documentation comment as readily as a plain end-of-line trivia.
         if (runStart > 0
-            && leadingTrivia[runStart - 1].ToFullString().EndsWith("\n", StringComparison.Ordinal) == false)
+            && EndsLine(leadingTrivia[runStart - 1]) == false)
         {
             // The declaration shares its line with preceding trivia, so the run found above is an inner gap rather
             // than the line's indentation. The whitespace that opens the trivia list opens the line instead.
@@ -186,12 +199,12 @@ internal sealed class FieldDeclarationSplitTransform : CSharpSyntaxRewriter
             trivia.AddRange(indentationTrivia);
             trivia.Add(comment);
 
-            // A single-line documentation comment already terminates its line inside its own structure, so appending
-            // another end-of-line would put a blank line between the comment and the field it documents. The
-            // pipeline's blank-line phase absorbs that break, but the RH7101 code fix runs this transform on its own
-            // and would emit the detached comment verbatim. Test the trivia text rather than its kind: a delimited
-            // documentation comment (/** … */) carries no line break and still needs one appended (issue #592).
-            if (comment.ToFullString().EndsWith("\n", StringComparison.Ordinal) == false)
+            // A single-line documentation comment already terminates its line, so appending another end-of-line would
+            // put a blank line between the comment and the field it documents. The pipeline's blank-line phase
+            // absorbs that break, but the RH7101 code fix runs this transform on its own and would emit the detached
+            // comment verbatim. A delimited documentation comment (/** … */) carries no break and still needs one,
+            // which is why the question is asked of the trivia text rather than of its kind (issue #592).
+            if (EndsLine(comment) == false)
             {
                 trivia.Add(SyntaxFactory.EndOfLine(_context.EndOfLine));
             }


### PR DESCRIPTION
## Summary

`FieldDeclarationSplitTransform` now derives a generated field's indentation from the whitespace that opens the physical line the declaration starts on, and its comment predicate now includes documentation comments so the split stops deleting them.

Three changes, all in `FieldDeclarationSplitTransform`:

- `GetMemberIndentationTrivia` locates the indentation run by asking whether the trivia in front of it ends a line, testing the trivia *text* instead of scanning for an `EndOfLineTrivia` node. A single-line documentation comment terminates its line inside its own structure, so the old scan found no top-level end-of-line, restarted at index 0, and summed the whitespace of every preceding line. The same rewrite also stops the scan accumulating a second whitespace run across an inline comment.
- `GetComments` routes through the shared comment predicate, so a documentation comment attached to a later declarator is re-attached instead of dropped.
- `BuildLeadingTrivia` appends an end-of-line after a re-attached comment only when the comment does not already carry one, and `EndsLine` is the single owner of that question inside the class.

## Why

Closes the mis-indentation reported in #592: a documented multi-variable field placed its later fields at eight spaces on pass 1, so the formatter was not idempotent for that shape and `--check` flagged a file it had just written.

The issue attributes the mis-indentation to `GetComments`'s trivia-kind set. That turned out not to hold — swapping only that predicate leaves every documented fixture still emitting eight spaces, because `GetComments` is not on the path that computes the indentation. The anchor in `GetMemberIndentationTrivia` is the actual cause, and it is fixed here.

Widening `GetComments` is still worth doing, and ships here by explicit decision: it independently fixes a separate defect the issue does not report, where a documentation comment written before a later declarator is silently deleted by the split.

## Linked issues

Closes #592

## Review notes

- **The RH7101 code fix is the surface that matters.** It invokes this transform directly and deliberately skips the pipeline, so no later indentation or blank-line phase repairs its output — the wrong indentation is the final document a user sees there, not a first-pass wart. Every anchor assertion has a code-fix-surface counterpart for that reason.
- **`SyntaxTriviaUtilities.GetLineIndentationTrivia` is deliberately not reused**, despite looking like the canonical helper. It inspects the start of the trivia list where this decision needs the start of the field's own line. It passes every full-pipeline test and regresses three code-fix shapes, one of them to zero indentation.
- **The `BuildLeadingTrivia` line-break guard tests the trivia text, not its kind.** `/** … */` is a documentation comment that carries no line break and still needs one appended, so a guard written as `IsDocumentationCommentTrivia` would merge it into the following field. Both sides of that boundary are asserted on the code-fix surface; no pipeline test can observe the difference, because the blank-line phase absorbs it.
- Behavior is unchanged for undocumented fields, `//` and own-line `/* */` comments, `/** … */` on the declaration, and directive-bearing fields, which `CarriesDirective` still refuses to split. Converged output changes only for the documentation-comment shapes, and only on purpose.
- No diagnostic ID, severity, message, public API, or dependency changed; `documentation/rules/RH7101.md` is unaffected because RH7101's reporting condition is untouched.

## Follow-up work

Two pre-existing defects in the same transform were found while implementing this and deliberately left out of scope, both confirmed identical on `main`:

- A documentation comment written *before* a declarator separator is dropped. It lands in the separator's leading trivia, which no call site reads, so closing it means adding a trivia source rather than widening a predicate.
- A documentation comment written *before* the final `;` is duplicated onto every generated field, because each one reuses the original semicolon token. This leaves the formatter permanently non-idempotent for that shape, so `--check` cannot be satisfied for an affected file at all.
