### PR TITLE
Collapse tab gaps, tighten conditional and pointer member access, and stop rewriting the layout of regions in skipped branches

### DIFF
--- a/Reihitsu.Analyzer.CodeFixes/Rules/Spacing/RH6016MemberAccessSymbolsMustBeSpacedCorrectlyCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Spacing/RH6016MemberAccessSymbolsMustBeSpacedCorrectlyCodeFixProvider.cs
@@ -52,8 +52,10 @@ public class RH6016MemberAccessSymbolsMustBeSpacedCorrectlyCodeFixProvider : Com
 
         if (hasLeadingSpace && hasTrailingSpace)
         {
+            // The flagged symbol is a dot, the question mark of a conditional access or a pointer arrow, so
+            // the replacement has to carry the token's own text rather than a hard-coded "."
             guardSpan = replacementSpan = TextSpan.FromBounds(previousToken.Span.End, nextToken.SpanStart);
-            replacementText = ".";
+            replacementText = token.Text;
         }
         else if (hasLeadingSpace)
         {

--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH6016MemberAccessSymbolsMustBeSpacedCorrectlyFormatterTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH6016MemberAccessSymbolsMustBeSpacedCorrectlyFormatterTests.cs
@@ -46,5 +46,62 @@ public class RH6016MemberAccessSymbolsMustBeSpacedCorrectlyFormatterTests : Form
                                  Diagnostics(RH6016MemberAccessSymbolsMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6016MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies that the formatter tightens a spaced conditional access and stays at that result
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFormatterFixesSpacedConditionalAccess()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method(string value)
+                                    {
+                                        _ = value {|#0:?|}.Length;
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     void Method(string value)
+                                     {
+                                         _ = value?.Length;
+                                     }
+                                 }
+                                 """;
+
+        await VerifyFormatterFixAndIdempotency(testData,
+                                               fixedData,
+                                               Diagnostics(RH6016MemberAccessSymbolsMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6016MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that the formatter leaves code the analyzer accepts untouched, including the question
+    /// marks of a conditional expression and of a nullable type
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFormatterLeavesAnalyzerCleanMemberAccessUntouched()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method(string value, int[] values, bool flag)
+                                    {
+                                        int? nullable = null;
+
+                                        _ = value?.Length;
+                                        _ = values?[0];
+                                        _ = flag ? 1 : 2;
+                                        _ = nullable;
+                                    }
+                                }
+                                """;
+
+        await VerifyFormatterStability(testData);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatting/RH6016MemberAccessSymbolsMustBeSpacedCorrectlyAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH6016MemberAccessSymbolsMustBeSpacedCorrectlyAnalyzerTests.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Reihitsu.Analyzer.CodeFixes.Rules.Spacing;
 using Reihitsu.Analyzer.Rules.Spacing;
 using Reihitsu.Analyzer.Test.Base;
+using Reihitsu.Analyzer.Test.Verifiers;
 
 namespace Reihitsu.Analyzer.Test.Formatting;
 
@@ -323,5 +324,231 @@ public class RH6016MemberAccessSymbolsMustBeSpacedCorrectlyAnalyzerTests : Analy
         Assert.IsEmpty(actions);
     }
 
+    /// <summary>
+    /// Verifies that a space in front of a conditional access operator is detected and fixed
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyConditionalAccessLeadingSpaceIsDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method(string value)
+                                    {
+                                        _ = value {|#0:?|}.Length;
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     void Method(string value)
+                                     {
+                                         _ = value?.Length;
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH6016MemberAccessSymbolsMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6016MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that a spaced conditional access reports its question mark and its dot separately, and that
+    /// applying both fixes tightens the whole operator
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifySpacedConditionalAccessReportsBothSymbolsAndIsFixed()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method(string value)
+                                    {
+                                        _ = value {|#0:?|}{|#1:.|} Length;
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     void Method(string value)
+                                     {
+                                         _ = value?.Length;
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH6016MemberAccessSymbolsMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6016MessageFormat, 2));
+    }
+
+    /// <summary>
+    /// Verifies that a space in front of a conditional element access is detected and fixed
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyConditionalElementAccessLeadingSpaceIsDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method(int[] values)
+                                    {
+                                        _ = values {|#0:?|}[0];
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     void Method(int[] values)
+                                     {
+                                         _ = values?[0];
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH6016MemberAccessSymbolsMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6016MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that spaces around a pointer member access are detected and fixed
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyPointerMemberAccessSpacesAreDetectedAndFixed()
+    {
+        const string testData = """
+                                internal unsafe class TestClass
+                                {
+                                    private struct Data
+                                    {
+                                        public int Value;
+                                    }
+
+                                    private int Method(Data* pointer)
+                                    {
+                                        return pointer {|#0:->|} Value;
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal unsafe class TestClass
+                                 {
+                                     private struct Data
+                                     {
+                                         public int Value;
+                                     }
+
+                                     private int Method(Data* pointer)
+                                     {
+                                         return pointer->Value;
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, AllowUnsafe, Diagnostics(RH6016MemberAccessSymbolsMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6016MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that a tight conditional access does not produce diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyTightConditionalAccessDoesNotProduceDiagnostics()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method(string value, int[] values)
+                                    {
+                                        _ = value?.Length;
+                                        _ = values?[0];
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that the question mark of a conditional expression does not produce diagnostics, although it
+    /// carries the same token kind as the conditional access operator
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyTernaryQuestionMarkDoesNotProduceDiagnostics()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method(bool flag)
+                                    {
+                                        _ = flag ? 1 : 2;
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that the question mark of a nullable type does not produce diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNullableTypeQuestionMarkDoesNotProduceDiagnostics()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method()
+                                    {
+                                        int? value = null;
+
+                                        _ = value;
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that a conditional access chain broken across lines does not produce diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyLineBrokenConditionalAccessDoesNotProduceDiagnostics()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method(string value)
+                                    {
+                                        _ = value
+                                            ?.Trim()
+                                            ?.Length;
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
     #endregion // Tests
+
+    #region Methods
+
+    /// <summary>
+    /// Enables unsafe code for the verifier so sources using pointer types compile
+    /// </summary>
+    /// <param name="test">Test</param>
+    private static void AllowUnsafe(CSharpCodeFixVerifierTest<RH6016MemberAccessSymbolsMustBeSpacedCorrectlyAnalyzer, RH6016MemberAccessSymbolsMustBeSpacedCorrectlyCodeFixProvider> test)
+    {
+        test.SolutionTransforms.Add(ApplyAllowUnsafeToTestProject);
+    }
+
+    #endregion // Methods
 }

--- a/Reihitsu.Analyzer/Rules/Spacing/RH6016MemberAccessSymbolsMustBeSpacedCorrectlyAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Spacing/RH6016MemberAccessSymbolsMustBeSpacedCorrectlyAnalyzer.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 using Reihitsu.Analyzer.Base;
@@ -38,6 +39,21 @@ public class RH6016MemberAccessSymbolsMustBeSpacedCorrectlyAnalyzer : Diagnostic
     #region Methods
 
     /// <summary>
+    /// Determines whether the token is a member-access symbol whose spacing this rule owns: the dot of a
+    /// plain, bound or qualified access, the question mark that opens a conditional access, or the arrow
+    /// of a pointer access. The parent check on the question mark is what separates the conditional access
+    /// from a conditional expression and from a nullable type, which keep their spacing
+    /// </summary>
+    /// <param name="token">Token to inspect</param>
+    /// <returns><see langword="true"/> if the token is a member-access symbol</returns>
+    private static bool IsMemberAccessSymbol(SyntaxToken token)
+    {
+        return token.IsKind(SyntaxKind.DotToken)
+               || (token.IsKind(SyntaxKind.QuestionToken) && token.Parent is ConditionalAccessExpressionSyntax)
+               || (token.IsKind(SyntaxKind.MinusGreaterThanToken) && token.Parent is MemberAccessExpressionSyntax);
+    }
+
+    /// <summary>
     /// Analyzes the syntax tree
     /// </summary>
     /// <param name="context">Context</param>
@@ -46,7 +62,7 @@ public class RH6016MemberAccessSymbolsMustBeSpacedCorrectlyAnalyzer : Diagnostic
         var root = context.Tree.GetRoot(context.CancellationToken);
         var sourceText = context.Tree.GetText(context.CancellationToken);
 
-        foreach (var token in root.DescendantTokens().Where(currentToken => currentToken.IsKind(SyntaxKind.DotToken)))
+        foreach (var token in root.DescendantTokens().Where(IsMemberAccessSymbol))
         {
             var (hasLeadingSpace, hasTrailingSpace) = AdjacentTokenSpacingUtilities.DetermineSameLineAdjacentSpacing(token, sourceText);
 

--- a/Reihitsu.Core.Test/SyntaxTriviaUtilitiesTests.cs
+++ b/Reihitsu.Core.Test/SyntaxTriviaUtilitiesTests.cs
@@ -664,6 +664,39 @@ public class SyntaxTriviaUtilitiesTests
         Assert.AreEqual(token, result);
     }
 
+    /// <summary>
+    /// Verifies that a region directive inside a branch that was not taken is reported as inactive
+    /// </summary>
+    [TestMethod]
+    public void IsInactiveDirectiveReturnsTrueForDirectiveInSkippedBranch()
+    {
+        var trivia = GetFirstTrivia("class C\n{\n#if false\n    #region Test\n    #endregion // Test\n#endif\n}", SyntaxKind.RegionDirectiveTrivia);
+
+        Assert.IsTrue(SyntaxTriviaUtilities.IsInactiveDirective(trivia));
+    }
+
+    /// <summary>
+    /// Verifies that a region directive outside any conditional branch is not reported as inactive
+    /// </summary>
+    [TestMethod]
+    public void IsInactiveDirectiveReturnsFalseForUnconditionalDirective()
+    {
+        var trivia = GetFirstTrivia("class C\n{\n    #region Test\n    #endregion // Test\n}", SyntaxKind.RegionDirectiveTrivia);
+
+        Assert.IsFalse(SyntaxTriviaUtilities.IsInactiveDirective(trivia));
+    }
+
+    /// <summary>
+    /// Verifies that trivia without a directive structure is not reported as inactive
+    /// </summary>
+    [TestMethod]
+    public void IsInactiveDirectiveReturnsFalseForComment()
+    {
+        var trivia = GetFirstTrivia("class C\n{\n    // note\n}", SyntaxKind.SingleLineCommentTrivia);
+
+        Assert.IsFalse(SyntaxTriviaUtilities.IsInactiveDirective(trivia));
+    }
+
     #endregion // Tests
 
     #region Methods

--- a/Reihitsu.Core/SyntaxTriviaUtilities.cs
+++ b/Reihitsu.Core/SyntaxTriviaUtilities.cs
@@ -4,6 +4,7 @@ using System.Linq;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Reihitsu.Core;
@@ -71,6 +72,22 @@ public static class SyntaxTriviaUtilities
     {
         return trivia.IsKind(SyntaxKind.RegionDirectiveTrivia)
                || trivia.IsKind(SyntaxKind.EndRegionDirectiveTrivia);
+    }
+
+    /// <summary>
+    /// Determines whether a trivia is a preprocessor directive that the compiler excluded from the
+    /// build, because it sits inside a branch that was not taken. Roslyn still parses such a directive
+    /// into the tree — unlike the code around it, which collapses into a single disabled-text trivia —
+    /// so a rewriter that walks directives reaches it unless it asks. Its surroundings are untouched
+    /// disabled text, and any line break inserted next to it merges into that text where the
+    /// "is there already a blank line" queries cannot see it, so layout edits repeat on every run
+    /// </summary>
+    /// <param name="trivia">The trivia to check</param>
+    /// <returns><see langword="true"/> if the trivia is a directive inside an inactive branch; otherwise, <see langword="false"/></returns>
+    public static bool IsInactiveDirective(SyntaxTrivia trivia)
+    {
+        return trivia.HasStructure
+               && trivia.GetStructure() is DirectiveTriviaSyntax { IsActive: false };
     }
 
     /// <summary>

--- a/Reihitsu.Formatter.Test/Regression/BlankLines/BracedSwitchSectionBlankLineTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/BlankLines/BracedSwitchSectionBlankLineTests.cs
@@ -1,0 +1,162 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Formatter.Test.Helpers;
+
+namespace Reihitsu.Formatter.Test.Regression.BlankLines;
+
+/// <summary>
+/// Tests covering the blank line between two braced switch sections. Brace insertion keeps the
+/// terminal break outside the block, so the break-spacing rule sees it as a direct section
+/// statement; a break written inside the block is the shape RH7501 reports and RH5011 exempts,
+/// and the formatter leaves it to the code fix rather than spacing around it
+/// </summary>
+[TestClass]
+public class BracedSwitchSectionBlankLineTests : FormatterTestsBase
+{
+    #region Methods
+
+    /// <summary>
+    /// Verifies that a blank line is inserted between two braced switch sections
+    /// </summary>
+    [TestMethod]
+    public void BracedSwitchSectionsAreSeparatedByBlankLine()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M(int value)
+                                 {
+                                     switch (value)
+                                     {
+                                         case 1:
+                                             {
+                                                 M(0);
+                                             }
+
+                                             break;
+                                         case 2:
+                                             {
+                                                 M(1);
+                                             }
+
+                                             break;
+                                     }
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                class C
+                                {
+                                    void M(int value)
+                                    {
+                                        switch (value)
+                                        {
+                                            case 1:
+                                                {
+                                                    M(0);
+                                                }
+
+                                                break;
+
+                                            case 2:
+                                                {
+                                                    M(1);
+                                                }
+
+                                                break;
+                                        }
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a blank line is inserted between two unbraced switch sections
+    /// </summary>
+    [TestMethod]
+    public void UnbracedSwitchSectionsAreSeparatedByBlankLine()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M(int value)
+                                 {
+                                     switch (value)
+                                     {
+                                         case 1:
+                                             M(0);
+                                             break;
+                                         case 2:
+                                             M(1);
+                                             break;
+                                     }
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                class C
+                                {
+                                    void M(int value)
+                                    {
+                                        switch (value)
+                                        {
+                                            case 1:
+                                                M(0);
+                                                break;
+
+                                            case 2:
+                                                M(1);
+                                                break;
+                                        }
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a break written inside an explicit case block is left alone. Moving it out is
+    /// RH7501's code fix, and adding a blank line around the shape it reports would format code the
+    /// repository asks the author to delete
+    /// </summary>
+    [TestMethod]
+    public void BreakInsideExplicitCaseBlockIsLeftToRH7501()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M(int value)
+                                 {
+                                     switch (value)
+                                     {
+                                         case 1:
+                                             {
+                                                 M(0);
+
+                                                 break;
+                                             }
+                                         case 2:
+                                             {
+                                                 M(1);
+
+                                                 break;
+                                             }
+                                     }
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Formatter.Test/Regression/FullPipeline/DocumentationCommentNestedNormalizationTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/FullPipeline/DocumentationCommentNestedNormalizationTests.cs
@@ -1,0 +1,226 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Formatter.Test.Helpers;
+
+namespace Reihitsu.Formatter.Test.Regression.FullPipeline;
+
+/// <summary>
+/// Tests covering documentation comments whose normalization candidates are nested inside one
+/// another, and the <c>///</c> exterior of a comment written at a member's own indentation. Both
+/// used to need a second pipeline run to reach their fixed point
+/// </summary>
+[TestClass]
+public class DocumentationCommentNestedNormalizationTests : FormatterTestsBase
+{
+    #region Methods
+
+    /// <summary>
+    /// Verifies that a code element nested inside a remarks element is normalized in the same run
+    /// as the element that contains it
+    /// </summary>
+    [TestMethod]
+    public void NestedCodeElementIsNormalizedInTheSameRun()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 /// <summary>
+                                 /// Text
+                                 /// </summary>
+                                 /// <remarks>Lead
+                                 /// <code>first
+                                 /// second</code>
+                                 /// </remarks>
+                                 void M()
+                                 {
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                class C
+                                {
+                                    /// <summary>
+                                    /// Text
+                                    /// </summary>
+                                    /// <remarks>
+                                    /// Lead
+                                    /// <code>
+                                    /// first
+                                    /// second
+                                    /// </code>
+                                    /// </remarks>
+                                    void M()
+                                    {
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a candidate nested two levels deep is normalized in the same run
+    /// </summary>
+    [TestMethod]
+    public void TwiceNestedElementIsNormalizedInTheSameRun()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 /// <summary>
+                                 /// Text
+                                 /// </summary>
+                                 /// <remarks>Outer
+                                 /// <example>Middle
+                                 /// <code>first
+                                 /// second</code>
+                                 /// </example>
+                                 /// </remarks>
+                                 void M()
+                                 {
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                class C
+                                {
+                                    /// <summary>
+                                    /// Text
+                                    /// </summary>
+                                    /// <remarks>
+                                    /// Outer
+                                    /// <example>
+                                    /// Middle
+                                    /// <code>
+                                    /// first
+                                    /// second
+                                    /// </code>
+                                    /// </example>
+                                    /// </remarks>
+                                    void M()
+                                    {
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a single, unnested candidate is still normalized — the other side of the
+    /// boundary the nesting filter is taken on
+    /// </summary>
+    [TestMethod]
+    public void UnnestedElementIsNormalized()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 /// <summary>
+                                 /// Text
+                                 /// </summary>
+                                 /// <remarks>Lead
+                                 /// more
+                                 /// </remarks>
+                                 void M()
+                                 {
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                class C
+                                {
+                                    /// <summary>
+                                    /// Text
+                                    /// </summary>
+                                    /// <remarks>
+                                    /// Lead
+                                    /// more
+                                    /// </remarks>
+                                    void M()
+                                    {
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a documentation exterior written at a member's own indentation gains its
+    /// separating space. The prefix pattern used to anchor at the line start, so only a comment at
+    /// column zero was ever normalized
+    /// </summary>
+    [TestMethod]
+    public void IndentedDocumentationExteriorGainsItsSpace()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 ///<summary>
+                                 ///Text
+                                 ///</summary>
+                                 void M()
+                                 {
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                class C
+                                {
+                                    /// <summary>
+                                    /// Text
+                                    /// </summary>
+                                    void M()
+                                    {
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a documentation exterior at column zero gains its separating space
+    /// </summary>
+    [TestMethod]
+    public void ColumnZeroDocumentationExteriorGainsItsSpace()
+    {
+        // Arrange
+        const string input = """
+                             ///<summary>
+                             ///Text
+                             ///</summary>
+                             class C
+                             {
+                                 void M()
+                                 {
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                /// <summary>
+                                /// Text
+                                /// </summary>
+                                class C
+                                {
+                                    void M()
+                                    {
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Formatter.Test/Regression/Regions/DisabledRegionLayoutTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Regions/DisabledRegionLayoutTests.cs
@@ -1,0 +1,218 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Formatter.Test.Helpers;
+
+namespace Reihitsu.Formatter.Test.Regression.Regions;
+
+/// <summary>
+/// Tests covering region directives that sit inside an inactive conditional compilation branch.
+/// The naming rewrite stays, because RH7301 and RH7302 report those directives too, but the layout
+/// rewrites do not: the blank lines they insert land inside the surrounding disabled text, where the
+/// "is there already a blank line" query cannot see them, so every run inserted another one
+/// </summary>
+[TestClass]
+public class DisabledRegionLayoutTests : FormatterTestsBase
+{
+    #region Fields
+
+    /// <summary>
+    /// Parse options that activate the <c>DEBUG</c> branch of a fixture
+    /// </summary>
+    private static readonly CSharpParseOptions _withDebug = new CSharpParseOptions().WithPreprocessorSymbols("DEBUG");
+
+    #endregion // Fields
+
+    #region Methods
+
+    /// <summary>
+    /// Verifies that a canonically named region inside disabled code survives formatting byte for byte
+    /// </summary>
+    [TestMethod]
+    public void CanonicalRegionInsideDisabledCodeIsUnchanged()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                             #if false
+                                 #region Test
+
+                                 void M()
+                                 {
+                                 }
+
+                                 #endregion // Test
+                             #endif
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a region inside disabled code is renamed without being padded with blank lines
+    /// </summary>
+    [TestMethod]
+    public void RegionInsideDisabledCodeIsRenamedWithoutBlankLinePadding()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                             #if false
+                                 #region test
+
+                                 void M()
+                                 {
+                                 }
+
+                                 #endregion
+                             #endif
+                             }
+                             """;
+        const string expected = """
+                                class C
+                                {
+                                #if false
+                                    #region Test
+
+                                    void M()
+                                    {
+                                    }
+
+                                    #endregion // Test
+                                #endif
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a region inside disabled code with no blank lines at all stays that way
+    /// </summary>
+    [TestMethod]
+    public void EmptyRegionInsideDisabledCodeKeepsItsLineCount()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                             #if false
+                                 #region Test
+                                 #endregion // Test
+                             #endif
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a region inside a method body in disabled code is not removed, although the
+    /// same region in active code would be
+    /// </summary>
+    [TestMethod]
+    public void RegionInsideDisabledMethodBodyIsNotRemoved()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                             #if false
+                                 void M()
+                                 {
+                                     #region Test
+
+                                     var x = 1;
+
+                                     #endregion // Test
+                                 }
+                             #endif
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a region inside an active conditional branch is still padded with blank lines —
+    /// the other side of the boundary the <c>IsActive</c> guard is taken on
+    /// </summary>
+    [TestMethod]
+    public void RegionInsideActiveConditionalIsStillFormatted()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                             #if DEBUG
+                                 #region test
+                                 void M()
+                                 {
+                                 }
+                                 #endregion
+                             #endif
+                             }
+                             """;
+        const string expected = """
+                                class C
+                                {
+                                #if DEBUG
+                                    #region Test
+
+                                    void M()
+                                    {
+                                    }
+
+                                    #endregion // Test
+
+                                #endif
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected, _withDebug);
+    }
+
+    /// <summary>
+    /// Verifies that a region in unconditional code is still padded with blank lines
+    /// </summary>
+    [TestMethod]
+    public void RegionInUnconditionalCodeIsStillFormatted()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 #region test
+                                 void M()
+                                 {
+                                 }
+                                 #endregion
+                             }
+                             """;
+        const string expected = """
+                                class C
+                                {
+                                    #region Test
+
+                                    void M()
+                                    {
+                                    }
+
+                                    #endregion // Test
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Formatter.Test/Regression/Spacing/MemberAccessSymbolSpacingTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Spacing/MemberAccessSymbolSpacingTests.cs
@@ -1,0 +1,300 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Formatter.Test.Helpers;
+
+namespace Reihitsu.Formatter.Test.Regression.Spacing;
+
+/// <summary>
+/// Tests covering the gap in front of a member-access symbol. The chain rewriter already tightens
+/// the gap that follows a conditional-access or pointer member access, so only the leading gap is
+/// left for the horizontal spacing phase; leaving it out produced <c>x ?.Foo</c> and <c>p -&gt;V</c>
+/// </summary>
+[TestClass]
+public class MemberAccessSymbolSpacingTests : FormatterTestsBase
+{
+    #region Methods
+
+    /// <summary>
+    /// Verifies that the space in front of a conditional-access operator is removed
+    /// </summary>
+    [TestMethod]
+    public void SpaceBeforeConditionalAccessIsRemoved()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M(string value)
+                                 {
+                                     _ = value ?.Length;
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                class C
+                                {
+                                    void M(string value)
+                                    {
+                                        _ = value?.Length;
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that spaces on both sides of a conditional-access operator are removed
+    /// </summary>
+    [TestMethod]
+    public void SpacesAroundConditionalAccessAreRemoved()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M(string value)
+                                 {
+                                     _ = value ?. Length;
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                class C
+                                {
+                                    void M(string value)
+                                    {
+                                        _ = value?.Length;
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that the space in front of a conditional element access is removed
+    /// </summary>
+    [TestMethod]
+    public void SpaceBeforeConditionalElementAccessIsRemoved()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M(int[] values)
+                                 {
+                                     _ = values ?[0];
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                class C
+                                {
+                                    void M(int[] values)
+                                    {
+                                        _ = values?[0];
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that the space in front of a conditional invocation is removed
+    /// </summary>
+    [TestMethod]
+    public void SpaceBeforeConditionalInvocationIsRemoved()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M(C other)
+                                 {
+                                     other ?.M(null);
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                class C
+                                {
+                                    void M(C other)
+                                    {
+                                        other?.M(null);
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that spaces around a pointer member access are removed
+    /// </summary>
+    [TestMethod]
+    public void SpacesAroundPointerMemberAccessAreRemoved()
+    {
+        // Arrange
+        const string input = """
+                             unsafe class C
+                             {
+                                 struct Data
+                                 {
+                                     public int Value;
+                                 }
+
+                                 void M(Data* pointer)
+                                 {
+                                     _ = pointer -> Value;
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                unsafe class C
+                                {
+                                    struct Data
+                                    {
+                                        public int Value;
+                                    }
+
+                                    void M(Data* pointer)
+                                    {
+                                        _ = pointer->Value;
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that an already tight conditional access is left unchanged
+    /// </summary>
+    [TestMethod]
+    public void TightConditionalAccessIsLeftUnchanged()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M(string value)
+                                 {
+                                     _ = value?.Length;
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that the question mark of a ternary keeps its surrounding spaces — the other side of
+    /// the boundary the conditional-access predicate is taken on
+    /// </summary>
+    [TestMethod]
+    public void TernaryQuestionMarkKeepsItsSpaces()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M(bool flag)
+                                 {
+                                     _ = flag ? 1 : 2;
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a nullable type question mark stays attached to its type
+    /// </summary>
+    [TestMethod]
+    public void NullableTypeQuestionMarkStaysAttached()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     int? value = null;
+
+                                     _ = value;
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a conditional access chain broken across lines is aligned by the chain rewriter
+    /// rather than joined by the spacing phase, which only owns gaps between tokens that share a line
+    /// </summary>
+    [TestMethod]
+    public void ConditionalAccessAcrossLinesIsAligned()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M(string value)
+                                 {
+                                     _ = value
+                                         ?.Trim()
+                                         ?.Length;
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                class C
+                                {
+                                    void M(string value)
+                                    {
+                                        _ = value?.Trim()
+                                                 ?.Length;
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that an aligned conditional access chain is left untouched
+    /// </summary>
+    [TestMethod]
+    public void AlignedConditionalAccessChainIsLeftUnchanged()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M(string value)
+                                 {
+                                     _ = value?.Trim()
+                                              ?.Length;
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Formatter.Test/Regression/Spacing/TabGapSpacingTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Spacing/TabGapSpacingTests.cs
@@ -1,0 +1,103 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Formatter.Test.Helpers;
+
+namespace Reihitsu.Formatter.Test.Regression.Spacing;
+
+/// <summary>
+/// Tests covering tab characters that sit in the gap between two tokens on the same line. The
+/// horizontal spacing phase collapses such a gap to a single space; the cleanup phase would
+/// otherwise expand a surviving tab to four spaces, which the next run then collapses again
+/// </summary>
+[TestClass]
+public class TabGapSpacingTests : FormatterTestsBase
+{
+    #region Methods
+
+    /// <summary>
+    /// Verifies that a single tab between two tokens is collapsed to one space
+    /// </summary>
+    [TestMethod]
+    public void SingleTabBetweenTokensCollapsesToOneSpace()
+    {
+        // Arrange
+        const string input = "class C\n{\n    void M()\n    {\n        var\tx = 1;\n    }\n}";
+        const string expected = "class C\n{\n    void M()\n    {\n        var x = 1;\n    }\n}";
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that two tabs between two tokens are collapsed to one space
+    /// </summary>
+    [TestMethod]
+    public void TwoTabsBetweenTokensCollapseToOneSpace()
+    {
+        // Arrange
+        const string input = "class C\n{\n    void M()\n    {\n        var\t\tx = 1;\n    }\n}";
+        const string expected = "class C\n{\n    void M()\n    {\n        var x = 1;\n    }\n}";
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a tab mixed with a space between two tokens is collapsed to one space
+    /// </summary>
+    [TestMethod]
+    public void TabFollowedBySpaceBetweenTokensCollapsesToOneSpace()
+    {
+        // Arrange
+        const string input = "class C\n{\n    void M()\n    {\n        var\t x = 1;\n    }\n}";
+        const string expected = "class C\n{\n    void M()\n    {\n        var x = 1;\n    }\n}";
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a single space between two tokens is left untouched — the other side of the
+    /// boundary the collapse decision is taken on
+    /// </summary>
+    [TestMethod]
+    public void SingleSpaceBetweenTokensIsLeftUnchanged()
+    {
+        // Arrange
+        const string input = "class C\n{\n    void M()\n    {\n        var x = 1;\n    }\n}";
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a tab in a gap a spacing rule already owns is normalized by that rule
+    /// </summary>
+    [TestMethod]
+    public void TabBeforeBinaryOperatorIsNormalizedToSingleSpace()
+    {
+        // Arrange
+        const string input = "class C\n{\n    void M()\n    {\n        var x = 1\t+ 2;\n    }\n}";
+        const string expected = "class C\n{\n    void M()\n    {\n        var x = 1 + 2;\n    }\n}";
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a tab used as indentation is still expanded by the cleanup phase rather than
+    /// collapsed — the gap rule applies between tokens, not in front of the first token on a line
+    /// </summary>
+    [TestMethod]
+    public void TabIndentationIsStillExpandedToSpaces()
+    {
+        // Arrange
+        const string input = "class C\n{\n\tvoid M()\n\t{\n\t\tint x = 1;\n\t}\n}";
+        const string expected = "class C\n{\n    void M()\n    {\n        int x = 1;\n    }\n}";
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Formatter/Pipeline/BlankLines/Rewriter/BlankLineRegionDirectiveRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/BlankLines/Rewriter/BlankLineRegionDirectiveRewriter.cs
@@ -55,18 +55,32 @@ internal sealed class BlankLineRegionDirectiveRewriter : CSharpSyntaxRewriter
     #region Methods
 
     /// <summary>
-    /// Determines whether the leading trivia of the specified token contains a region or end-region directive
+    /// Determines whether the trivia is a region or end-region directive the compiler kept. A directive
+    /// inside a branch that was not taken sits between disabled-text trivia, so a line break inserted
+    /// next to it merges into that text where the blank-line queries cannot find it again and the next
+    /// run inserts another one (issue #434)
     /// </summary>
-    /// <param name="token">The token to inspect</param>
-    /// <returns><see langword="true"/> if any region directive trivia is found in the leading trivia</returns>
-    private static bool HasRegionDirectiveInLeadingTrivia(SyntaxToken token)
+    /// <param name="trivia">The trivia to inspect</param>
+    /// <returns><see langword="true"/> if the trivia is an active region directive</returns>
+    private static bool IsActiveRegionDirective(SyntaxTrivia trivia)
     {
-        return token.LeadingTrivia.Any(SyntaxTriviaUtilities.IsRegionDirective);
+        return SyntaxTriviaUtilities.IsRegionDirective(trivia)
+               && SyntaxTriviaUtilities.IsInactiveDirective(trivia) == false;
     }
 
     /// <summary>
-    /// Ensures a blank line follows every region directive in the leading trivia, except an <c>#endregion</c> directive
-    /// that directly precedes the closing brace or the end of the file
+    /// Determines whether the leading trivia of the specified token contains an active region or end-region directive
+    /// </summary>
+    /// <param name="token">The token to inspect</param>
+    /// <returns><see langword="true"/> if any active region directive trivia is found in the leading trivia</returns>
+    private static bool HasRegionDirectiveInLeadingTrivia(SyntaxToken token)
+    {
+        return token.LeadingTrivia.Any(IsActiveRegionDirective);
+    }
+
+    /// <summary>
+    /// Ensures a blank line follows every active region directive in the leading trivia, except an <c>#endregion</c>
+    /// directive that directly precedes the closing brace or the end of the file
     /// </summary>
     /// <param name="token">The token whose leading trivia should be normalized</param>
     /// <returns>The token with the required blank lines inserted after its region directives</returns>
@@ -78,7 +92,7 @@ internal sealed class BlankLineRegionDirectiveRewriter : CSharpSyntaxRewriter
 
         for (var triviaIndex = trivia.Count - 1; triviaIndex >= 0; triviaIndex--)
         {
-            if (SyntaxTriviaUtilities.IsRegionDirective(trivia[triviaIndex]) == false)
+            if (IsActiveRegionDirective(trivia[triviaIndex]) == false)
             {
                 continue;
             }

--- a/Reihitsu.Formatter/Pipeline/BlankLines/Rewriter/BlankLineTriviaBoundaryRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/BlankLines/Rewriter/BlankLineTriviaBoundaryRewriter.cs
@@ -274,7 +274,13 @@ internal sealed class BlankLineTriviaBoundaryRewriter : CSharpSyntaxRewriter
 
         for (var triviaIndex = 0; triviaIndex < trivia.Count; triviaIndex++)
         {
-            if (trivia[triviaIndex].IsKind(SyntaxKind.EndRegionDirectiveTrivia))
+            // The leading-trivia counterpart in BlankLineEditor.EnsureBlankLineBeforeFirstDirective passes over
+            // directives inside a branch the compiler skipped, because the line break it inserts merges into the
+            // surrounding disabled text and is inserted again on the next run. Disabled text attaches as leading
+            // trivia of the following token, so no fixture reaches this list with such a directive - the guard is
+            // here so the two copies of the policy cannot drift apart (issue #434)
+            if (trivia[triviaIndex].IsKind(SyntaxKind.EndRegionDirectiveTrivia)
+                && SyntaxTriviaUtilities.IsInactiveDirective(trivia[triviaIndex]) == false)
             {
                 directiveIndex = triviaIndex;
 

--- a/Reihitsu.Formatter/Pipeline/BlankLines/Utilities/BlankLineEditor.cs
+++ b/Reihitsu.Formatter/Pipeline/BlankLines/Utilities/BlankLineEditor.cs
@@ -220,7 +220,9 @@ internal sealed class BlankLineEditor
     }
 
     /// <summary>
-    /// Ensures a blank line exists before the first directive of the specified kind in the token's leading trivia
+    /// Ensures a blank line exists before the first directive of the specified kind in the token's leading
+    /// trivia. Directives inside a branch the compiler skipped are passed over, so the first match is the
+    /// first directive that is actually part of the build
     /// </summary>
     /// <param name="token">The token whose leading trivia should be checked</param>
     /// <param name="directiveKind">Kind of the directive that requires a preceding blank line</param>
@@ -247,7 +249,11 @@ internal sealed class BlankLineEditor
 
         for (var triviaIndex = 0; triviaIndex < trivia.Count; triviaIndex++)
         {
-            if (trivia[triviaIndex].IsKind(directiveKind))
+            // A directive inside a branch the compiler skipped is surrounded by disabled text, so the inserted
+            // line break merges into that text and HasBlankLineImmediatelyBeforeIndex can never see it again -
+            // the next run inserts another one (issue #434)
+            if (trivia[triviaIndex].IsKind(directiveKind)
+                && SyntaxTriviaUtilities.IsInactiveDirective(trivia[triviaIndex]) == false)
             {
                 directiveIndex = triviaIndex;
 

--- a/Reihitsu.Formatter/Pipeline/DocumentationComments/DocumentationCommentFormattingPhase.cs
+++ b/Reihitsu.Formatter/Pipeline/DocumentationComments/DocumentationCommentFormattingPhase.cs
@@ -17,10 +17,22 @@ namespace Reihitsu.Formatter.Pipeline.DocumentationComments;
 /// <summary>
 /// Normalizes XML documentation comments to repository-specific layout rules. Element-level layout
 /// decisions live in <see cref="DocCommentElementNormalizer"/>; this phase locates the candidate
-/// elements, splices in their normalized text and fixes the <c>///</c> line prefixes
+/// elements, splices in their normalized text — repeating until no candidate is left, because only
+/// the outermost ones can be rebuilt per round — and fixes the <c>///</c> line prefixes
 /// </summary>
 internal sealed class DocumentationCommentFormattingPhase : IFormattingPhase
 {
+    #region Constants
+
+    /// <summary>
+    /// Upper bound on the rebuild rounds a single comment may take. Each round resolves one nesting
+    /// level, so real documentation finishes in one or two; the bound only guards against a rebuild
+    /// that would otherwise keep reporting the same element as a candidate
+    /// </summary>
+    private const int MaximumNormalizationRounds = 16;
+
+    #endregion // Constants
+
     #region Methods
 
     /// <summary>
@@ -192,6 +204,124 @@ internal sealed class DocumentationCommentFormattingPhase : IFormattingPhase
     }
 
     /// <summary>
+    /// Rebuilds the outermost normalization candidates of a documentation comment. A candidate nested
+    /// inside another candidate is skipped, because rebuilding the outer element already replaces the
+    /// text the inner one occupies and both replacements would overwrite each other
+    /// </summary>
+    /// <param name="commentText">Text of the documentation comment</param>
+    /// <param name="commentSpan">Span the comment text occupies in <paramref name="sourceText"/></param>
+    /// <param name="documentationComment">Structured documentation comment</param>
+    /// <param name="sourceText">Source text</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The rebuilt comment text, or <see langword="null"/> if no element required rebuilding</returns>
+    private static string NormalizeOutermostElements(string commentText, TextSpan commentSpan, DocumentationCommentTriviaSyntax documentationComment, SourceText sourceText, CancellationToken cancellationToken)
+    {
+        var candidates = documentationComment.DescendantNodes()
+                                             .OfType<XmlElementSyntax>()
+                                             .Where(obj => DocCommentElementNormalizer.RequiresNormalization(obj, sourceText))
+                                             .ToList();
+
+        if (candidates.Count == 0)
+        {
+            return null;
+        }
+
+        var candidateSet = new HashSet<XmlElementSyntax>(candidates);
+        var topLevelCandidates = candidates.Where(obj => obj.Ancestors().OfType<XmlElementSyntax>().Any(candidateSet.Contains) == false)
+                                           .OrderByDescending(obj => obj.Span.Start)
+                                           .ToList();
+        var normalizedCommentText = commentText;
+
+        foreach (var element in topLevelCandidates)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var replacementText = DocCommentElementNormalizer.BuildReplacement(element, sourceText);
+            var relativeStart = element.Span.Start - commentSpan.Start;
+            var relativeEnd = element.Span.End - commentSpan.Start;
+
+            normalizedCommentText = $"{normalizedCommentText.Substring(0, relativeStart)}{replacementText}{normalizedCommentText.Substring(relativeEnd)}";
+        }
+
+        return normalizedCommentText;
+    }
+
+    /// <summary>
+    /// Attempts to read the rebuilt comment text back into a structured documentation comment, so the
+    /// next round measures the elements against the text that was just written rather than the original
+    /// </summary>
+    /// <param name="commentText">Rebuilt comment text</param>
+    /// <param name="commentTrivia">Parsed documentation comment trivia</param>
+    /// <param name="documentationComment">Structured documentation comment</param>
+    /// <returns><see langword="true"/> when the text parses back into a single documentation comment covering all of it</returns>
+    private static bool TryReadBackDocumentationComment(string commentText, out SyntaxTrivia commentTrivia, out DocumentationCommentTriviaSyntax documentationComment)
+    {
+        var parsedTrivia = SyntaxFactory.ParseLeadingTrivia(commentText);
+
+        if (parsedTrivia.Count > 0
+            && parsedTrivia[0].IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia)
+            && parsedTrivia[0].GetStructure() is DocumentationCommentTriviaSyntax structure
+            && parsedTrivia[0].FullSpan == new TextSpan(0, commentText.Length))
+        {
+            commentTrivia = parsedTrivia[0];
+            documentationComment = structure;
+
+            return true;
+        }
+
+        commentTrivia = default;
+        documentationComment = null;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Rebuilds normalization candidates until none is left. Only the outermost candidates can be
+    /// rebuilt in one round, so a <c>&lt;code&gt;</c> that needs alignment inside a <c>&lt;remarks&gt;</c>
+    /// that needs alignment used to be reached by the next pipeline run instead, which broke the
+    /// two-run convergence invariant (issue #434). A round that changes nothing ends the loop, so the
+    /// cost is one extra parse per nesting level and none at all for the common single-candidate comment
+    /// </summary>
+    /// <param name="documentationCommentTrivia">Documentation comment trivia</param>
+    /// <param name="documentationComment">Structured documentation comment</param>
+    /// <param name="sourceText">Source text</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The rebuilt comment text, or <see langword="null"/> if no element required rebuilding</returns>
+    private static string NormalizeElementsUntilStable(SyntaxTrivia documentationCommentTrivia, DocumentationCommentTriviaSyntax documentationComment, SourceText sourceText, CancellationToken cancellationToken)
+    {
+        var currentComment = documentationComment;
+        var currentSourceText = sourceText;
+        var currentSpan = documentationCommentTrivia.FullSpan;
+        var currentText = sourceText.ToString(currentSpan);
+        string normalizedCommentText = null;
+
+        for (var round = 0; round < MaximumNormalizationRounds; round++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var roundText = NormalizeOutermostElements(currentText, currentSpan, currentComment, currentSourceText, cancellationToken);
+
+            if (roundText == null)
+            {
+                break;
+            }
+
+            normalizedCommentText = roundText;
+
+            if (TryReadBackDocumentationComment(roundText, out var roundTrivia, out currentComment) == false)
+            {
+                break;
+            }
+
+            currentSourceText = SourceText.From(roundText);
+            currentSpan = roundTrivia.FullSpan;
+            currentText = roundText;
+        }
+
+        return normalizedCommentText;
+    }
+
+    /// <summary>
     /// Normalizes a documentation comment if any supported XML element requires it
     /// </summary>
     /// <param name="documentationCommentTrivia">Documentation comment trivia</param>
@@ -201,32 +331,9 @@ internal sealed class DocumentationCommentFormattingPhase : IFormattingPhase
     /// <returns>The normalized comment text, or <see langword="null"/> if no change is required</returns>
     private static string NormalizeDocumentationComment(SyntaxTrivia documentationCommentTrivia, DocumentationCommentTriviaSyntax documentationComment, SourceText sourceText, CancellationToken cancellationToken)
     {
-        var candidates = documentationComment.DescendantNodes()
-                                             .OfType<XmlElementSyntax>()
-                                             .Where(obj => DocCommentElementNormalizer.RequiresNormalization(obj, sourceText))
-                                             .ToList();
-        var normalizedCommentText = sourceText.ToString(documentationCommentTrivia.FullSpan);
-        var changed = false;
-
-        if (candidates.Count > 0)
-        {
-            var candidateSet = new HashSet<XmlElementSyntax>(candidates);
-            var topLevelCandidates = candidates.Where(obj => obj.Ancestors().OfType<XmlElementSyntax>().Any(candidateSet.Contains) == false)
-                                               .OrderByDescending(obj => obj.Span.Start)
-                                               .ToList();
-
-            foreach (var element in topLevelCandidates)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var replacementText = DocCommentElementNormalizer.BuildReplacement(element, sourceText);
-                var relativeStart = element.Span.Start - documentationCommentTrivia.FullSpan.Start;
-                var relativeEnd = element.Span.End - documentationCommentTrivia.FullSpan.Start;
-
-                normalizedCommentText = $"{normalizedCommentText.Substring(0, relativeStart)}{replacementText}{normalizedCommentText.Substring(relativeEnd)}";
-                changed = true;
-            }
-        }
+        var rebuiltCommentText = NormalizeElementsUntilStable(documentationCommentTrivia, documentationComment, sourceText, cancellationToken);
+        var normalizedCommentText = rebuiltCommentText ?? sourceText.ToString(documentationCommentTrivia.FullSpan);
+        var changed = rebuiltCommentText != null;
 
         // The match timeout is a safety net against pathological input, not a performance budget. This prefix
         // pattern is anchored on /// and cannot backtrack catastrophically, so the value is deliberately generous:

--- a/Reihitsu.Formatter/Pipeline/HorizontalSpacing/Rules/NoSpaceSpacingRule.cs
+++ b/Reihitsu.Formatter/Pipeline/HorizontalSpacing/Rules/NoSpaceSpacingRule.cs
@@ -8,8 +8,9 @@ namespace Reihitsu.Formatter.Pipeline.HorizontalSpacing.Rules;
 
 /// <summary>
 /// Removes spacing between tokens that must stay adjacent, such as inside parentheses and brackets,
-/// before commas and semicolons, around generic angle brackets, member-access dots, nullable
-/// question marks, and tight unary operators
+/// before commas and semicolons, around generic angle brackets, member-access symbols (the dot, the
+/// conditional-access question mark and the pointer arrow), nullable question marks, and tight unary
+/// operators
 /// </summary>
 internal sealed class NoSpaceSpacingRule : ISpacingRule
 {
@@ -78,16 +79,57 @@ internal sealed class NoSpaceSpacingRule : ISpacingRule
     }
 
     /// <summary>
+    /// Determines whether the token is a member-access symbol: the dot of a plain, bound or qualified
+    /// access, the question mark that opens a conditional access, or the arrow of a pointer access.
+    /// The chain rewriter already closes the gap that follows a conditional access or an arrow, so
+    /// leaving them out here tightened one side only and produced <c>x ?.Foo</c> and <c>p -&gt;V</c>
+    /// (issue #434)
+    /// </summary>
+    /// <param name="token">The token to inspect</param>
+    /// <returns><see langword="true"/> if the token is a member-access symbol; otherwise, <see langword="false"/></returns>
+    private static bool IsMemberAccessToken(SyntaxToken token)
+    {
+        return IsMemberAccessDotToken(token)
+               || IsConditionalAccessToken(token)
+               || IsPointerMemberAccessToken(token);
+    }
+
+    /// <summary>
     /// Determines whether the token is a member-access dot token
     /// </summary>
     /// <param name="token">The token to inspect</param>
     /// <returns><see langword="true"/> if the token is a member-access dot; otherwise, <see langword="false"/></returns>
-    private static bool IsMemberAccessToken(SyntaxToken token)
+    private static bool IsMemberAccessDotToken(SyntaxToken token)
     {
         return token.IsKind(SyntaxKind.DotToken)
                && (token.Parent is MemberAccessExpressionSyntax
+                   || token.Parent is MemberBindingExpressionSyntax
                    || token.Parent is QualifiedNameSyntax
                    || token.Parent is AliasQualifiedNameSyntax);
+    }
+
+    /// <summary>
+    /// Determines whether the token is the question mark that opens a conditional access. The parent
+    /// check is what separates it from the question mark of a conditional expression and of a nullable
+    /// type, both of which keep their spacing
+    /// </summary>
+    /// <param name="token">The token to inspect</param>
+    /// <returns><see langword="true"/> if the token opens a conditional access; otherwise, <see langword="false"/></returns>
+    private static bool IsConditionalAccessToken(SyntaxToken token)
+    {
+        return token.IsKind(SyntaxKind.QuestionToken)
+               && token.Parent is ConditionalAccessExpressionSyntax;
+    }
+
+    /// <summary>
+    /// Determines whether the token is the arrow of a pointer member access
+    /// </summary>
+    /// <param name="token">The token to inspect</param>
+    /// <returns><see langword="true"/> if the token is a pointer member access arrow; otherwise, <see langword="false"/></returns>
+    private static bool IsPointerMemberAccessToken(SyntaxToken token)
+    {
+        return token.IsKind(SyntaxKind.MinusGreaterThanToken)
+               && token.Parent is MemberAccessExpressionSyntax;
     }
 
     /// <summary>

--- a/Reihitsu.Formatter/Pipeline/HorizontalSpacing/Utilities/TrailingWhitespaceWriter.cs
+++ b/Reihitsu.Formatter/Pipeline/HorizontalSpacing/Utilities/TrailingWhitespaceWriter.cs
@@ -62,7 +62,10 @@ internal static class TrailingWhitespaceWriter
     }
 
     /// <summary>
-    /// Determines whether trailing trivia requires whitespace normalization
+    /// Determines whether trailing trivia requires whitespace normalization. A whitespace entry counts
+    /// as normalized only when it is exactly one space: measuring its length instead would accept a
+    /// lone tab, which the cleanup phase later expands to four spaces and the next run then collapses,
+    /// so the file never reaches a fixed point (issue #434)
     /// </summary>
     /// <param name="trailing">The trailing trivia list to inspect</param>
     /// <returns><see langword="true"/> if normalization is needed; otherwise, <see langword="false"/></returns>
@@ -74,7 +77,7 @@ internal static class TrailingWhitespaceWriter
         {
             if (trivia.IsKind(SyntaxKind.WhitespaceTrivia))
             {
-                if (trivia.Span.Length > 1 || prevWasWhitespace)
+                if (trivia.IsEquivalentTo(_singleSpace) == false || prevWasWhitespace)
                 {
                     return true;
                 }

--- a/Reihitsu.Formatter/Pipeline/Indentation/Utilities/LayoutComputer.cs
+++ b/Reihitsu.Formatter/Pipeline/Indentation/Utilities/LayoutComputer.cs
@@ -191,7 +191,9 @@ internal static class LayoutComputer
     }
 
     /// <summary>
-    /// Applies indentation entries for region-related directive trivia
+    /// Applies indentation entries for region-related directive trivia. A directive inside a branch the
+    /// compiler skipped is left where the author wrote it: the code around it is untouched disabled
+    /// text, so re-indenting the directive alone would half-format a region nobody compiles (issue #434)
     /// </summary>
     /// <param name="token">The token whose leading trivia is inspected</param>
     /// <param name="parent">The syntax node that owns the token</param>
@@ -200,7 +202,8 @@ internal static class LayoutComputer
     /// <param name="baseColumn">The base indentation column</param>
     private static void SetDirectiveIndentation(SyntaxToken token, SyntaxNode parent, int indentLevel, LayoutModel model, int baseColumn)
     {
-        foreach (var directiveTrivia in token.LeadingTrivia.Where(SyntaxTriviaUtilities.IsRegionDirective))
+        foreach (var directiveTrivia in token.LeadingTrivia.Where(static trivia => SyntaxTriviaUtilities.IsRegionDirective(trivia)
+                                                                                   && SyntaxTriviaUtilities.IsInactiveDirective(trivia) == false))
         {
             var directiveIndent = SyntaxIndentationUtilities.GetTriviaIndentLevel(parent, directiveTrivia, indentLevel);
 

--- a/Reihitsu.Formatter/Pipeline/RegionFormatting/Utilities/NestedRegionRemovalStep.cs
+++ b/Reihitsu.Formatter/Pipeline/RegionFormatting/Utilities/NestedRegionRemovalStep.cs
@@ -19,7 +19,9 @@ internal static class NestedRegionRemovalStep
     #region Methods
 
     /// <summary>
-    /// Removes region directives placed within element bodies
+    /// Removes region directives placed within element bodies. A region inside a branch the compiler
+    /// skipped is left in place, because deleting its line would remove source the formatter otherwise
+    /// leaves untouched
     /// </summary>
     /// <param name="root">The syntax root</param>
     /// <param name="cancellationToken">Cancellation token</param>
@@ -34,7 +36,10 @@ internal static class NestedRegionRemovalStep
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (trivia.IsKind(SyntaxKind.RegionDirectiveTrivia) == false)
+            // Removing a region the compiler skipped would delete a line of code the formatter is otherwise
+            // leaving alone, and the surrounding disabled text keeps no record of what was there (issue #434)
+            if (trivia.IsKind(SyntaxKind.RegionDirectiveTrivia) == false
+                || SyntaxTriviaUtilities.IsInactiveDirective(trivia))
             {
                 continue;
             }

--- a/Reihitsu.Formatter/Pipeline/RegionFormatting/Utilities/RegionNamingRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/RegionFormatting/Utilities/RegionNamingRewriter.cs
@@ -12,6 +12,12 @@ namespace Reihitsu.Formatter.Pipeline.RegionFormatting.Utilities;
 /// changes through trivia replacement. Removing regions nested inside element bodies belongs to
 /// <see cref="NestedRegionRemovalStep"/>
 /// </summary>
+/// <remarks>
+/// Unlike the layout steps around it, this one deliberately reaches directives inside a branch the
+/// compiler skipped. RH7301 and RH7302 report those directives, so refusing to name them would leave
+/// a diagnostic the formatter declines to fix. The layout steps have no such counterpart — the
+/// blank-line rules stay silent inside disabled code — which is why they skip it instead (issue #434)
+/// </remarks>
 internal static class RegionNamingRewriter
 {
     #region Methods

--- a/documentation/rules/RH6016.md
+++ b/documentation/rules/RH6016.md
@@ -9,15 +9,17 @@
 
 ## Description
 
-No space may appear immediately before or after the member access operator `.`.
+No space may appear immediately before or after a member access symbol. The rule covers the member access operator `.`, the `?` that opens a conditional access (`?.` and `?[`), and the pointer member access operator `->`.
+
+The `?` of a conditional expression (`flag ? 1 : 2`) and the `?` of a nullable type (`int?`) are not member access symbols and keep their own spacing; the latter is covered by [RH6015](RH6015.md).
 
 ## Why is this a problem?
 
-Spaces around `.` visually break the connection between an expression and its member, making member access chains harder to read.
+Spaces around a member access symbol visually break the connection between an expression and its member, making member access chains harder to read.
 
 ## How to fix it
 
-Remove any spaces surrounding the member access operator. The code fix applies this change automatically.
+Remove any spaces surrounding the member access symbol. The code fix applies this change automatically.
 
 ## Examples
 
@@ -26,9 +28,11 @@ Remove any spaces surrounding the member access operator. The code fix applies t
 ```cs
 internal class TestClass
 {
-    void Method()
+    void Method(string text, int[] values)
     {
         _ = string .Empty;
+        _ = text ?.Length;
+        _ = values ?[0];
     }
 }
 ```
@@ -38,9 +42,11 @@ internal class TestClass
 ```cs
 internal class TestClass
 {
-    void Method()
+    void Method(string text, int[] values)
     {
         _ = string.Empty;
+        _ = text?.Length;
+        _ = values?[0];
     }
 }
 ```


### PR DESCRIPTION
## Summary

Closes the four formatter defects from #434 that still reproduce, and pins the two that no longer do with characterization tests.

- **Tab in a token gap** — `TrailingWhitespaceWriter.NeedsTrailingSpaceNormalization` accepted any single-character whitespace as normalized, so a lone tab survived, the cleanup phase expanded it to four spaces, and the next run collapsed those to one. It now compares against a single space.
- **Member access symbols** — the chain rewriter already tightens the gap *after* a conditional or pointer access, so `x ?.Foo`, `x ?[0]` and `p -> V` were tightened on one side only (`p ->V`). `NoSpaceSpacingRule` now owns the leading gap as well, and RH6016 is extended to the conditional-access `?` and the pointer `->` so analyzer-clean code stays formatter-stable.
- **Regions in a skipped branch** — the blank lines inserted next to a `#region` inside `#if false` land in the surrounding disabled text, where the "is there already a blank line" query cannot see them, so every run inserted another one. The blank-line, indentation and nested-removal steps now skip inactive directives. The naming rewrite deliberately does not: RH7301/RH7302 report those directives, RH5031/RH5032 do not.
- **Nested documentation elements** — only the outermost normalization candidate was rebuilt per run, so a `code` element inside a `remarks` element needed a second pipeline run. The phase now repeats until no candidate is left.

Two reported items no longer reproduce and are covered by characterization tests instead of a fix:

- Item 3 (braced switch sections) — since #606 brace insertion keeps the terminal `break` outside the block, and that shape does get its blank line. The remaining uncovered shape is the one RH7501 reports and RH5011 exempts, so it is left to the code fix.
- Item 6 (`///` prefix regex) — #528's rework already allows leading indentation, exactly as the issue predicted.

## Why

Items 1, 4 and 7 each break the two-run convergence invariant, item 4 additionally grows the file without bound and rewrites the layout of code the formatter is supposed to leave alone, and item 2 produced output inconsistent with the same construct written without a conditional access.

## Linked issues

Closes #434

## Review notes

- Two scope decisions were taken with the issue author. Item 4: keep the naming rewrite inside disabled code, because the analyzer reports it — a full skip would leave an RH7301 diagnostic the formatter refuses to fix. Item 2: extend RH6016 alongside the formatter, because `p -> V` is analyzer-clean today and the formatter already rewrites it.
- The issue's claim that "the analyzer side deliberately skips disabled lines" does not hold: only RH6004 has such a guard. RH7301 does report inside `#if false`; RH5031/RH5032 do not. That split is what the item 4 scope follows.
- RH6016 now reports the `?` and the `.` of a spaced `x ?. Foo` separately, so that source produces two diagnostics where it produced one. The code fix replacement carries the flagged token's own text instead of a hard-coded `.`.
- `SyntaxTriviaUtilities.IsInactiveDirective` is new shared Core surface, used by the formatter's layout owners so the predicate has one home rather than several. The guard in `BlankLineTriviaBoundaryRewriter` is unreachable in practice — disabled text attaches as leading trivia — and is there so the two copies of that policy cannot drift apart.

## Follow-up work

A tab in front of a trailing comment (`x = 1;` + tab + `// note`) is still expanded to four spaces by the cleanup phase rather than collapsed: the horizontal spacing phase skips that gap because the tokens are separated by a line break. Out of scope here — it belongs to the cleanup phase's tab expansion, not to the collapse predicate.
