### PR TITLE
Align using groups and CLI target selection

### DIFF
--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH7207UsingDirectivesShouldBeOrganizedIntoGroupsFormatterTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH7207UsingDirectivesShouldBeOrganizedIntoGroupsFormatterTests.cs
@@ -82,5 +82,37 @@ public class RH7207UsingDirectivesShouldBeOrganizedIntoGroupsFormatterTests : Fo
                                  Diagnostics(RH7207UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer.DiagnosticId, AnalyzerResources.RH7207MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies that the formatter separates a global-qualified case variant from the exact System group without detaching its comment
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task GlobalQualifiedCaseVariantMatchesAnalyzerGroupingAndIsIdempotent()
+    {
+        const string input = """
+                             using {|#0:global::SYSTEM.Text|}; // Keep with the case variant
+                             using System.Text;
+
+                             namespace SYSTEM.Text
+                             {
+                                 internal class Placeholder;
+                             }
+                             """;
+        const string fixedData = """
+                                 using System.Text;
+
+                                 using global::SYSTEM.Text; // Keep with the case variant
+
+                                 namespace SYSTEM.Text
+                                 {
+                                     internal class Placeholder;
+                                 }
+                                 """;
+
+        await VerifyFormatterFixAndIdempotency(input,
+                                               fixedData,
+                                               Diagnostics(RH7207UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer.DiagnosticId, AnalyzerResources.RH7207MessageFormat));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatting/RH7207UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH7207UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzerTests.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Reihitsu.Analyzer.CodeFixes.Rules.Organization;
@@ -386,6 +387,65 @@ public class RH7207UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzerTests : Ana
                                  """;
 
         await Verify(testCode, fixedCode, Diagnostics(RH7207UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer.DiagnosticId, AnalyzerResources.RH7207MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that the code fix moves a case-variant global using ahead of a local exact-System using and separates the sections
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task CodeFixPlacesGlobalSectionBeforeLocalExactSystemSection()
+    {
+        const string testCode = """
+                                using {|#0:System.Text|};
+                                global using SYSTEM.Text;
+
+                                namespace SYSTEM.Text
+                                {
+                                    public class Placeholder;
+                                }
+                                """;
+        const string fixedCode = """
+                                 global using SYSTEM.Text;
+
+                                 using System.Text;
+
+                                 namespace SYSTEM.Text
+                                 {
+                                     public class Placeholder;
+                                 }
+                                 """;
+
+        await Verify(testCode,
+                     fixedCode,
+                     test => test.CompilerDiagnostics = CompilerDiagnostics.None,
+                     Diagnostics(RH7207UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer.DiagnosticId, AnalyzerResources.RH7207MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that global status alone creates a group boundary for otherwise matching regular System roots
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task CodeFixSeparatesGlobalAndLocalDirectivesWithSameRoot()
+    {
+        const string testCode = """
+                                global using {|#0:System.Collections|};
+                                using System.Text;
+
+                                public class TestClass;
+                                """;
+        const string fixedCode = """
+                                 global using System.Collections;
+
+                                 using System.Text;
+
+                                 public class TestClass;
+                                 """;
+
+        await Verify(testCode,
+                     fixedCode,
+                     Diagnostics(RH7207UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer.DiagnosticId, AnalyzerResources.RH7207MessageFormat));
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer.Test/Formatting/RH7207UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH7207UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzerTests.cs
@@ -730,6 +730,112 @@ public class RH7207UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzerTests : Ana
     }
 
     /// <summary>
+    /// Verifies that exact and case-variant System roots form separate groups across compilation-unit and block-namespace scopes
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task CaseVariantSystemGroupsAcrossScopesConvergeInOneFixAllIteration()
+    {
+        const string testCode = """
+                                using {|#0:SYSTEM|};
+                                using System;
+
+                                namespace Example
+                                {
+                                    using {|#1:system.Text|};
+                                    using System.Text;
+
+                                    public class TestClass
+                                    {
+                                    }
+                                }
+
+                                namespace SYSTEM
+                                {
+                                    public class Helper
+                                    {
+                                    }
+                                }
+
+                                namespace system.Text
+                                {
+                                    public class Helper
+                                    {
+                                    }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 using System;
+
+                                 using SYSTEM;
+
+                                 namespace Example
+                                 {
+                                     using System.Text;
+
+                                     using system.Text;
+
+                                     public class TestClass
+                                     {
+                                     }
+                                 }
+
+                                 namespace SYSTEM
+                                 {
+                                     public class Helper
+                                     {
+                                     }
+                                 }
+
+                                 namespace system.Text
+                                 {
+                                     public class Helper
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testCode,
+                     fixedCode,
+                     static config => config.NumberOfFixAllIterations = 1,
+                     Diagnostics(RH7207UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer.DiagnosticId, AnalyzerResources.RH7207MessageFormat, 2));
+    }
+
+    /// <summary>
+    /// Verifies that using groups inside a file-scoped namespace are reported and fixed
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task FileScopedNamespaceUsingGroupsAreReportedAndFixed()
+    {
+        const string testCode = """
+                                namespace Example;
+
+                                using {|#0:Microsoft.Win32|};
+                                using System;
+
+                                public class TestClass
+                                {
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 namespace Example;
+
+                                 using System;
+
+                                 using Microsoft.Win32;
+
+                                 public class TestClass
+                                 {
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH7207UsingDirectivesShouldBeOrganizedIntoGroupsAnalyzer.DiagnosticId, AnalyzerResources.RH7207MessageFormat));
+    }
+
+    /// <summary>
     /// Verifies that no diagnostic is reported when using directives are zero in a compilation unit
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer.Test/Ordering/RH7201SystemUsingDirectivesMustBePlacedBeforeOtherUsingDirectivesAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Ordering/RH7201SystemUsingDirectivesMustBePlacedBeforeOtherUsingDirectivesAnalyzerTests.cs
@@ -62,6 +62,48 @@ public class RH7201SystemUsingDirectivesMustBePlacedBeforeOtherUsingDirectivesAn
     }
 
     /// <summary>
+    /// Verifies that a case-variant root namespace remains an ordinary namespace and does not prevent the code fix from moving System first
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task CaseVariantSystemRootDoesNotDisagreeWithCanonicalOrdering()
+    {
+        const string testCode = """
+                                using SYSTEM;
+                                using {|#0:System|};
+
+                                namespace SYSTEM
+                                {
+                                    public class Helper
+                                    {
+                                    }
+                                }
+
+                                public class TestClass
+                                {
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 using System;
+                                 using SYSTEM;
+
+                                 namespace SYSTEM
+                                 {
+                                     public class Helper
+                                     {
+                                     }
+                                 }
+
+                                 public class TestClass
+                                 {
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH7201SystemUsingDirectivesMustBePlacedBeforeOtherUsingDirectivesAnalyzer.DiagnosticId, AnalyzerResources.RH7201MessageFormat));
+    }
+
+    /// <summary>
     /// Verifies no code fix is offered when the using directives cannot be safely reordered because a preprocessor directive is present
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer.Test/Ordering/RH7201SystemUsingDirectivesMustBePlacedBeforeOtherUsingDirectivesAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Ordering/RH7201SystemUsingDirectivesMustBePlacedBeforeOtherUsingDirectivesAnalyzerTests.cs
@@ -86,6 +86,7 @@ public class RH7201SystemUsingDirectivesMustBePlacedBeforeOtherUsingDirectivesAn
 
         const string fixedCode = """
                                  using System;
+
                                  using SYSTEM;
 
                                  namespace SYSTEM
@@ -94,6 +95,147 @@ public class RH7201SystemUsingDirectivesMustBePlacedBeforeOtherUsingDirectivesAn
                                      {
                                      }
                                  }
+
+                                 public class TestClass
+                                 {
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH7201SystemUsingDirectivesMustBePlacedBeforeOtherUsingDirectivesAnalyzer.DiagnosticId, AnalyzerResources.RH7201MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that global-qualified case variants remain ordinary global usings when the exact System group moves first
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task GlobalQualifiedCaseVariantConvergesBehindExactSystemGlobalUsing()
+    {
+        const string testCode = """
+                                global using global::SYSTEM.Text;
+                                global using {|#0:System.Text|};
+
+                                namespace SYSTEM.Text
+                                {
+                                    public class Helper
+                                    {
+                                    }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 global using System.Text;
+
+                                 global using global::SYSTEM.Text;
+
+                                 namespace SYSTEM.Text
+                                 {
+                                     public class Helper
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH7201SystemUsingDirectivesMustBePlacedBeforeOtherUsingDirectivesAnalyzer.DiagnosticId, AnalyzerResources.RH7201MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that the code fix converges across compilation-unit and block-namespace using scopes in one Fix All iteration
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task CaseVariantSystemRootsAcrossScopesConvergeInOneFixAllIteration()
+    {
+        const string testCode = """
+                                using system;
+                                using {|#0:System|};
+
+                                namespace Example
+                                {
+                                    using SYSTEM.Text;
+                                    using {|#1:System.Text|};
+
+                                    public class TestClass
+                                    {
+                                    }
+                                }
+
+                                namespace system
+                                {
+                                    public class Helper
+                                    {
+                                    }
+                                }
+
+                                namespace SYSTEM.Text
+                                {
+                                    public class Helper
+                                    {
+                                    }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 using System;
+
+                                 using system;
+
+                                 namespace Example
+                                 {
+                                     using System.Text;
+
+                                     using SYSTEM.Text;
+
+                                     public class TestClass
+                                     {
+                                     }
+                                 }
+
+                                 namespace system
+                                 {
+                                     public class Helper
+                                     {
+                                     }
+                                 }
+
+                                 namespace SYSTEM.Text
+                                 {
+                                     public class Helper
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testCode,
+                     fixedCode,
+                     static config => config.NumberOfFixAllIterations = 1,
+                     Diagnostics(RH7201SystemUsingDirectivesMustBePlacedBeforeOtherUsingDirectivesAnalyzer.DiagnosticId, AnalyzerResources.RH7201MessageFormat, 2));
+    }
+
+    /// <summary>
+    /// Verifies that System ordering remains registered for using directives inside a file-scoped namespace
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task FileScopedNamespaceSystemUsingIsReportedAndFixed()
+    {
+        const string testCode = """
+                                namespace Example;
+
+                                using Microsoft.Win32;
+                                using {|#0:System|};
+
+                                public class TestClass
+                                {
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 namespace Example;
+
+                                 using System;
+
+                                 using Microsoft.Win32;
 
                                  public class TestClass
                                  {

--- a/Reihitsu.Analyzer.Test/Ordering/RH7203UsingDirectivesMustBeOrderedAlphabeticallyByNamespaceAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Ordering/RH7203UsingDirectivesMustBeOrderedAlphabeticallyByNamespaceAnalyzerTests.cs
@@ -240,6 +240,38 @@ public class RH7203UsingDirectivesMustBeOrderedAlphabeticallyByNamespaceAnalyzer
     }
 
     /// <summary>
+    /// Verifies that member names in a following ordinal-distinct root cannot create a cross-group diagnostic
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task OrdinalDistinctRootGroupsDoNotProduceCrossGroupDiagnostics()
+    {
+        const string testCode = """
+                                using SYSTEM.Alpha;
+                                using SYSTEM.Zulu;
+
+                                using system.Bravo;
+
+                                namespace SYSTEM.Alpha
+                                {
+                                    public class Placeholder;
+                                }
+
+                                namespace SYSTEM.Zulu
+                                {
+                                    public class Placeholder;
+                                }
+
+                                namespace system.Bravo
+                                {
+                                    public class Placeholder;
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
+    /// <summary>
     /// Verifies that the shared using-ordering code fix does not format the following type
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer.Test/Ordering/RH7206UsingStaticDirectivesMustBeOrderedAlphabeticallyAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Ordering/RH7206UsingStaticDirectivesMustBeOrderedAlphabeticallyAnalyzerTests.cs
@@ -45,6 +45,34 @@ public class RH7206UsingStaticDirectivesMustBeOrderedAlphabeticallyAnalyzerTests
     }
 
     /// <summary>
+    /// Verifies that static imports in ordinal-distinct roots are not compared across their group boundary
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task OrdinalDistinctStaticRootGroupsDoNotProduceCrossGroupDiagnostics()
+    {
+        const string testCode = """
+                                using static SYSTEM.Alpha;
+                                using static SYSTEM.Zulu;
+
+                                using static system.Bravo;
+
+                                namespace SYSTEM
+                                {
+                                    public class Alpha;
+                                    public class Zulu;
+                                }
+
+                                namespace system
+                                {
+                                    public class Bravo;
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
+    /// <summary>
     /// Verifies disabled conditional using blocks are exempt when they cannot be safely reordered
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer/Rules/Organization/RH7203UsingDirectivesMustBeOrderedAlphabeticallyByNamespaceAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Organization/RH7203UsingDirectivesMustBeOrderedAlphabeticallyByNamespaceAnalyzer.cs
@@ -60,7 +60,7 @@ public class RH7203UsingDirectivesMustBeOrderedAlphabeticallyByNamespaceAnalyzer
     }
 
     /// <summary>
-    /// Analyze a single using directive group
+    /// Analyze regular using directives within one global/local classification set, comparing only full root groups
     /// </summary>
     /// <param name="context">Context</param>
     /// <param name="usingDirectives">Using directives</param>
@@ -68,20 +68,21 @@ public class RH7203UsingDirectivesMustBeOrderedAlphabeticallyByNamespaceAnalyzer
     /// <param name="usingDirectiveGroup">Group to analyze</param>
     private void AnalyzeGroup(SyntaxNodeAnalysisContext context, SyntaxList<UsingDirectiveSyntax> usingDirectives, bool isGlobalSet, UsingDirectiveOrderingGroup usingDirectiveGroup)
     {
-        string previousSortKey = null;
+        UsingDirectiveSyntax previousUsingDirective = null;
 
         foreach (var usingDirective in usingDirectives.Where(obj => UsingDirectiveOrderingUtilities.IsGlobalUsing(obj) == isGlobalSet)
                                                       .Where(obj => UsingDirectiveOrderingUtilities.GetUsingDirectiveGroup(obj) == usingDirectiveGroup))
         {
             var currentSortKey = UsingDirectiveOrderingUtilities.GetSortKey(usingDirective);
 
-            if (previousSortKey != null
-                && UsingDirectiveOrderingUtilities.CompareSortKeys(currentSortKey, previousSortKey) < 0)
+            if (previousUsingDirective != null
+                && UsingDirectiveOrderingUtilities.AreInSameGroup(previousUsingDirective, usingDirective)
+                && UsingDirectiveOrderingUtilities.CompareSortKeys(currentSortKey, UsingDirectiveOrderingUtilities.GetSortKey(previousUsingDirective)) < 0)
             {
                 context.ReportDiagnostic(CreateDiagnostic(UsingDirectiveOrderingUtilities.GetDiagnosticLocation(usingDirective)));
             }
 
-            previousSortKey = currentSortKey;
+            previousUsingDirective = usingDirective;
         }
     }
 

--- a/Reihitsu.Analyzer/Rules/Organization/RH7206UsingStaticDirectivesMustBeOrderedAlphabeticallyAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Organization/RH7206UsingStaticDirectivesMustBeOrderedAlphabeticallyAnalyzer.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 using Reihitsu.Analyzer.Base;
@@ -53,20 +54,21 @@ public class RH7206UsingStaticDirectivesMustBeOrderedAlphabeticallyAnalyzer : Di
 
         foreach (var isGlobalSet in new[] { false, true })
         {
-            string previousSortKey = null;
+            UsingDirectiveSyntax previousUsingDirective = null;
 
             foreach (var usingDirective in usingDirectives.Where(obj => UsingDirectiveOrderingUtilities.IsGlobalUsing(obj) == isGlobalSet)
                                                           .Where(obj => UsingDirectiveOrderingUtilities.GetUsingDirectiveGroup(obj) == UsingDirectiveOrderingGroup.Static))
             {
                 var currentSortKey = UsingDirectiveOrderingUtilities.GetSortKey(usingDirective);
 
-                if (previousSortKey != null
-                    && UsingDirectiveOrderingUtilities.CompareSortKeys(currentSortKey, previousSortKey) < 0)
+                if (previousUsingDirective != null
+                    && UsingDirectiveOrderingUtilities.AreInSameGroup(previousUsingDirective, usingDirective)
+                    && UsingDirectiveOrderingUtilities.CompareSortKeys(currentSortKey, UsingDirectiveOrderingUtilities.GetSortKey(previousUsingDirective)) < 0)
                 {
                     context.ReportDiagnostic(CreateDiagnostic(UsingDirectiveOrderingUtilities.GetDiagnosticLocation(usingDirective)));
                 }
 
-                previousSortKey = currentSortKey;
+                previousUsingDirective = usingDirective;
             }
         }
     }

--- a/Reihitsu.Cli.Test/EndToEnd/CliEndToEndTests.cs
+++ b/Reihitsu.Cli.Test/EndToEnd/CliEndToEndTests.cs
@@ -66,7 +66,7 @@ public class CliEndToEndTests
     #region Methods
 
     /// <summary>
-    /// Verifies that the --help flag prints usage information and returns success
+    /// Verifies that the --help flag prints usage information, documents dry-run exit behavior, and returns success
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test</returns>
     [TestMethod]
@@ -85,6 +85,7 @@ public class CliEndToEndTests
         // Assert
         Assert.AreEqual(ExitCodes.Success, exitCode);
         Assert.Contains("reihitsu-format", output);
+        Assert.Contains("exit code 1 if changes would be made", output);
         Assert.Contains("--utf8-bom", output);
     }
 
@@ -284,6 +285,34 @@ public class CliEndToEndTests
                                            .ConfigureAwait(false);
 
             Assert.AreNotEqual(NeedsFormattingSource, updatedContent);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that dry-run mode on already formatted files returns success without producing a diff
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test</returns>
+    [TestMethod]
+    public async Task MainDryRunModeOnFormattedFilesReturnsSuccess()
+    {
+        // Arrange
+        using (var tempDir = new TemporaryDirectoryFixture())
+        {
+            tempDir.CreateFile("Formatted.cs", FormattedFileTestData);
+
+            // Act
+            int exitCode;
+            string output;
+
+            using (var capture = new ConsoleCapture())
+            {
+                exitCode = await Program.Main(["--dry-run", tempDir.Path]);
+                output = capture.StandardOutput;
+            }
+
+            // Assert
+            Assert.AreEqual(ExitCodes.Success, exitCode);
+            Assert.DoesNotContain("@@", output);
         }
     }
 
@@ -572,6 +601,172 @@ public class CliEndToEndTests
     }
 
     /// <summary>
+    /// Verifies that explicitly targeted bin and obj directories are processed for every supported path spelling
+    /// </summary>
+    /// <param name="directoryName">The build-output directory name</param>
+    /// <param name="targetSpelling">The path spelling to pass to the CLI</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test</returns>
+    [TestMethod]
+    [DataRow("bin", "relative")]
+    [DataRow("bin", "dot-relative")]
+    [DataRow("bin", "absolute")]
+    [DataRow("obj", "relative")]
+    [DataRow("obj", "dot-relative")]
+    [DataRow("obj", "absolute")]
+    public async Task MainExplicitBuildOutputDirectoryTargetFormatsFile(string directoryName, string targetSpelling)
+    {
+        // Arrange
+        using (var tempDir = new TemporaryDirectoryFixture())
+        {
+            var filePath = tempDir.CreateFile(Path.Combine(directoryName, "Unformatted.cs"), NeedsFormattingSource);
+            var targetPath = CreateTargetPath(tempDir.Path, directoryName, targetSpelling);
+            var previousDirectory = Directory.GetCurrentDirectory();
+
+            try
+            {
+                Directory.SetCurrentDirectory(tempDir.Path);
+
+                // Act
+                int exitCode;
+
+                using (new ConsoleCapture())
+                {
+                    exitCode = await Program.Main([targetPath]);
+                }
+
+                // Assert
+                var actualContent = await File.ReadAllTextAsync(filePath, TestContext.CancellationToken);
+
+                Assert.AreEqual(ExitCodes.Success, exitCode);
+                Assert.AreNotEqual(NeedsFormattingSource, actualContent);
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(previousDirectory);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Verifies that explicitly targeted files inside bin and obj directories are processed for every supported path
+    /// spelling
+    /// </summary>
+    /// <param name="directoryName">The build-output directory name</param>
+    /// <param name="targetSpelling">The path spelling to pass to the CLI</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test</returns>
+    [TestMethod]
+    [DataRow("bin", "relative")]
+    [DataRow("bin", "dot-relative")]
+    [DataRow("bin", "absolute")]
+    [DataRow("obj", "relative")]
+    [DataRow("obj", "dot-relative")]
+    [DataRow("obj", "absolute")]
+    public async Task MainExplicitBuildOutputFileTargetFormatsFile(string directoryName, string targetSpelling)
+    {
+        // Arrange
+        using (var tempDir = new TemporaryDirectoryFixture())
+        {
+            var relativeFilePath = Path.Combine(directoryName, "Unformatted.cs");
+            var filePath = tempDir.CreateFile(relativeFilePath, NeedsFormattingSource);
+            var targetPath = CreateTargetPath(tempDir.Path, relativeFilePath, targetSpelling);
+            var previousDirectory = Directory.GetCurrentDirectory();
+
+            try
+            {
+                Directory.SetCurrentDirectory(tempDir.Path);
+
+                // Act
+                int exitCode;
+
+                using (new ConsoleCapture())
+                {
+                    exitCode = await Program.Main([targetPath]);
+                }
+
+                // Assert
+                var actualContent = await File.ReadAllTextAsync(filePath, TestContext.CancellationToken);
+
+                Assert.AreEqual(ExitCodes.Success, exitCode);
+                Assert.AreNotEqual(NeedsFormattingSource, actualContent);
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(previousDirectory);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Verifies that recursive discovery formats directories whose names merely contain bin or obj
+    /// </summary>
+    /// <param name="directoryName">The ordinary directory name to discover</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test</returns>
+    [TestMethod]
+    [DataRow("binary")]
+    [DataRow("objects")]
+    public async Task MainRecursiveTargetFormatsDirectoriesThatOnlyContainBuildOutputNames(string directoryName)
+    {
+        // Arrange
+        using (var tempDir = new TemporaryDirectoryFixture())
+        {
+            var filePath = tempDir.CreateFile(Path.Combine(directoryName, "Unformatted.cs"), NeedsFormattingSource);
+
+            // Act
+            int exitCode;
+
+            using (new ConsoleCapture())
+            {
+                exitCode = await Program.Main([tempDir.Path]);
+            }
+
+            // Assert
+            var actualContent = await File.ReadAllTextAsync(filePath, TestContext.CancellationToken);
+
+            Assert.AreEqual(ExitCodes.Success, exitCode);
+            Assert.AreNotEqual(NeedsFormattingSource, actualContent);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that recursive discovery applies the platform's path casing rules to bin and obj segments
+    /// </summary>
+    /// <param name="directoryName">The uppercase build-output directory name</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test</returns>
+    [TestMethod]
+    [DataRow("BIN")]
+    [DataRow("OBJ")]
+    public async Task MainRecursiveTargetUsesPlatformCasingForBuildOutputDirectories(string directoryName)
+    {
+        // Arrange
+        using (var tempDir = new TemporaryDirectoryFixture())
+        {
+            var filePath = tempDir.CreateFile(Path.Combine(directoryName, "Unformatted.cs"), NeedsFormattingSource);
+
+            // Act
+            int exitCode;
+
+            using (new ConsoleCapture())
+            {
+                exitCode = await Program.Main([tempDir.Path]);
+            }
+
+            // Assert
+            var actualContent = await File.ReadAllTextAsync(filePath, TestContext.CancellationToken);
+
+            Assert.AreEqual(ExitCodes.Success, exitCode);
+
+            if (OperatingSystem.IsWindows())
+            {
+                Assert.AreEqual(NeedsFormattingSource, actualContent);
+            }
+            else
+            {
+                Assert.AreNotEqual(NeedsFormattingSource, actualContent);
+            }
+        }
+    }
+
+    /// <summary>
     /// Verifies that multiple paths are all processed and included in the summary
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test</returns>
@@ -601,6 +796,24 @@ public class CliEndToEndTests
             Assert.AreEqual(ExitCodes.FormattingNeeded, exitCode);
             Assert.Contains("2", output);
         }
+    }
+
+    /// <summary>
+    /// Creates an explicit target path using the requested spelling
+    /// </summary>
+    /// <param name="rootPath">The absolute root path</param>
+    /// <param name="relativePath">The path relative to <paramref name="rootPath"/></param>
+    /// <param name="targetSpelling">The requested path spelling</param>
+    /// <returns>The target path to pass to the CLI</returns>
+    private static string CreateTargetPath(string rootPath, string relativePath, string targetSpelling)
+    {
+        return targetSpelling switch
+               {
+                   "relative" => relativePath,
+                   "dot-relative" => $".{Path.DirectorySeparatorChar}{relativePath}",
+                   "absolute" => Path.Combine(rootPath, relativePath),
+                   _ => throw new ArgumentOutOfRangeException(nameof(targetSpelling), targetSpelling, "Unsupported target spelling."),
+               };
     }
 
     #endregion // Methods

--- a/Reihitsu.Cli.Test/Integration/FormatCommandHandlerIntegrationTests.cs
+++ b/Reihitsu.Cli.Test/Integration/FormatCommandHandlerIntegrationTests.cs
@@ -336,7 +336,8 @@ public class FormatCommandHandlerIntegrationTests
     }
 
     /// <summary>
-    /// Tests that files in bin/ and obj/ directories are not touched
+    /// Tests that a recursive parent target processes an ordinary sibling without touching or reporting files in
+    /// bin/ and obj/ directories
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test operation</returns>
     [TestMethod]
@@ -345,23 +346,28 @@ public class FormatCommandHandlerIntegrationTests
         // Arrange
         using (var tempDir = new TemporaryDirectoryFixture())
         {
-            var normalPath = tempDir.CreateFile("src\\Test.cs", ValidInputTestData);
-            var binPath = tempDir.CreateFile("bin\\Debug\\Test.cs", ValidInputTestData);
-            var objPath = tempDir.CreateFile("obj\\Debug\\Test.cs", ValidInputTestData);
+            var normalPath = tempDir.CreateFile(Path.Combine("src", "Test.cs"), ValidInputTestData);
+            var binPath = tempDir.CreateFile(Path.Combine("bin", "Debug", "Test.cs"), ValidInputTestData);
+            var objPath = tempDir.CreateFile(Path.Combine("obj", "Debug", "Test.cs"), ValidInputTestData);
 
-            var handler = CreateHandler([tempDir.Path]);
+            var handler = CreateHandler([tempDir.Path], out var console);
 
             // Act
-            await handler.ExecuteAsync(TestContext.CancellationToken);
+            var exitCode = await handler.ExecuteAsync(TestContext.CancellationToken);
 
             // Assert
             var normalContent = await File.ReadAllTextAsync(normalPath, TestContext.CancellationToken);
             var binContent = await File.ReadAllTextAsync(binPath, TestContext.CancellationToken);
             var objContent = await File.ReadAllTextAsync(objPath, TestContext.CancellationToken);
+            var output = string.Join(Environment.NewLine, console.StandardOutput);
 
+            Assert.AreEqual(ExitCodes.Success, exitCode);
             Assert.AreEqual(ValidInputResultData, normalContent);
             Assert.AreEqual(ValidInputTestData, binContent);
             Assert.AreEqual(ValidInputTestData, objContent);
+            Assert.Contains(normalPath, output);
+            Assert.DoesNotContain(binPath, output);
+            Assert.DoesNotContain(objPath, output);
         }
     }
 

--- a/Reihitsu.Cli/ExitCodes.cs
+++ b/Reihitsu.Cli/ExitCodes.cs
@@ -13,7 +13,7 @@ internal static class ExitCodes
     public const int Success = 0;
 
     /// <summary>
-    /// Exit code indicating that one or more files need formatting (--check mode)
+    /// Exit code indicating that one or more files need formatting (--check or --dry-run mode)
     /// </summary>
     public const int FormattingNeeded = 1;
 

--- a/Reihitsu.Cli/FormatCommandHandler.cs
+++ b/Reihitsu.Cli/FormatCommandHandler.cs
@@ -210,16 +210,29 @@ internal sealed class FormatCommandHandler
     }
 
     /// <summary>
-    /// Determines whether the specified file path is within a build output directory (bin/ or obj/)
+    /// Determines whether a recursively discovered file is within a build output directory below the explicit
+    /// directory target
     /// </summary>
     /// <param name="filePath">The file path to check</param>
+    /// <param name="selectionRoot">The explicitly selected directory path</param>
+    /// <param name="pathComparer">The platform-specific path comparer</param>
     /// <returns><see langword="true"/> if the file is in a build output directory; otherwise, <see langword="false"/></returns>
-    private static bool IsInBuildOutputDirectory(string filePath)
+    private static bool IsInBuildOutputDirectory(string filePath, string selectionRoot, StringComparer pathComparer)
     {
-        var normalizedPath = filePath.Replace('\\', '/');
+        var relativePath = Path.GetRelativePath(selectionRoot, filePath);
+        var segments = relativePath.Split(['\\', '/'], StringSplitOptions.RemoveEmptyEntries);
 
-        return normalizedPath.Contains("/bin/", StringComparison.OrdinalIgnoreCase)
-               || normalizedPath.Contains("/obj/", StringComparison.OrdinalIgnoreCase);
+        // The final segment is the file name. Only recursively discovered directory segments are exclusions; the
+        // explicitly selected root is absent from the relative path and therefore always remains eligible.
+        for (var index = 0; index < segments.Length - 1; index++)
+        {
+            if (pathComparer.Equals(segments[index], "bin") || pathComparer.Equals(segments[index], "obj"))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>
@@ -466,12 +479,17 @@ internal sealed class FormatCommandHandler
             }
             else if (_fileSystem.DirectoryExists(path))
             {
-                var directoryFiles = _fileSystem.EnumerateFiles(path, "*.cs", SearchOption.AllDirectories)
-                                                .Where(file => IsInBuildOutputDirectory(file) == false);
+                var selectionRoot = _fileSystem.GetFullPath(path);
+                var directoryFiles = _fileSystem.EnumerateFiles(path, "*.cs", SearchOption.AllDirectories);
 
                 foreach (var directoryFile in directoryFiles)
                 {
-                    AddFile(_fileSystem.GetFullPath(directoryFile), files, seen);
+                    var fullPath = _fileSystem.GetFullPath(directoryFile);
+
+                    if (IsInBuildOutputDirectory(fullPath, selectionRoot, comparer) == false)
+                    {
+                        AddFile(fullPath, files, seen);
+                    }
                 }
             }
         }

--- a/Reihitsu.Cli/Program.cs
+++ b/Reihitsu.Cli/Program.cs
@@ -16,7 +16,7 @@ internal static class Program
     /// Main entry point
     /// </summary>
     /// <param name="args">Command-line arguments</param>
-    /// <returns>Exit code: 0 = success, 1 = formatting needed (--check), 2 = error</returns>
+    /// <returns>Exit code: 0 = success, 1 = formatting needed (--check/--dry-run), 2 = error</returns>
     public static async Task<int> Main(string[] args)
     {
         var result = ParseArguments(args);
@@ -199,7 +199,7 @@ internal static class Program
         writer.WriteLine();
         writer.WriteLine("Options:");
         writer.WriteLine("  --check      Check if files are formatted (exit code 1 if not); don't write changes");
-        writer.WriteLine("  --dry-run    Show what would change without applying (cannot be combined with --check)");
+        writer.WriteLine("  --dry-run    Show what would change without applying (exit code 1 if changes would be made; cannot be combined with --check)");
         writer.WriteLine("  --verbose    Show detailed output for each file");
         writer.WriteLine($"  --force      Skip the confirmation prompt shown when more than {FormatCommandHandler.LargeRunConfirmationThreshold} files would be formatted");
         writer.WriteLine("  --utf8-bom   Write processed files as UTF-8 with a byte order mark");

--- a/Reihitsu.Cli/README.MD
+++ b/Reihitsu.Cli/README.MD
@@ -25,7 +25,7 @@ reihitsu-format [options] [<paths>...]
 | Option      | Description                                                        |
 |-------------|--------------------------------------------------------------------|
 | `--check`   | Check if files are formatted correctly. Does not write changes. Returns exit code `1` if formatting is needed. |
-| `--dry-run` | Show what would change without applying any modifications.         |
+| `--dry-run` | Show what would change without applying any modifications. Returns exit code `1` if changes would be made. |
 | `--verbose` | Show detailed output for each file.                                |
 | `--force`   | Skip the confirmation prompt that is shown when a run would format more than 25 files. Required for large runs when standard input is not interactive (e.g. CI). |
 | `--utf8-bom` | Normalize processed files to UTF-8 with a byte order mark. Encoding-only changes are reported in `--check` and `--dry-run` modes. |
@@ -36,7 +36,7 @@ reihitsu-format [options] [<paths>...]
 | Code | Meaning                                        |
 |------|------------------------------------------------|
 | `0`  | Success — all files are formatted correctly.   |
-| `1`  | Formatting needed (when using `--check`).      |
+| `1`  | Formatting needed (when using `--check` or `--dry-run`). |
 | `2`  | Error occurred.                                |
 
 ## Examples

--- a/Reihitsu.Core.Test/UsingDirectiveOrderingUtilitiesTests.cs
+++ b/Reihitsu.Core.Test/UsingDirectiveOrderingUtilitiesTests.cs
@@ -109,6 +109,91 @@ public class UsingDirectiveOrderingUtilitiesTests
     }
 
     /// <summary>
+    /// Verifies that only the exact System root receives priority and shares a group with its child namespaces
+    /// </summary>
+    [TestMethod]
+    public void ExactSystemRootOrdersFirstAndGroupsOnlyWithItsChildren()
+    {
+        var usingDirectives = CoreSyntaxTestHelper.ParseCompilationUnit("""
+                                                                        using SYSTEM;
+                                                                        using System.Text;
+                                                                        using System;
+                                                                        """)
+                                                  .Usings;
+
+        var canonical = UsingDirectiveOrderingUtilities.ComputeCanonicalOrder(usingDirectives);
+        var exactSystem = usingDirectives.Single(usingDirective => usingDirective.Name.ToString() == "System");
+        var systemChild = usingDirectives.Single(usingDirective => usingDirective.Name.ToString() == "System.Text");
+        var caseVariant = usingDirectives.Single(usingDirective => usingDirective.Name.ToString() == "SYSTEM");
+
+        CollectionAssert.AreEqual(new[] { "using System;", "using System.Text;", "using SYSTEM;" },
+                                  canonical.Select(obj => obj.ToString()).ToArray());
+        Assert.IsTrue(UsingDirectiveOrderingUtilities.IsSystemNamespaceUsing(exactSystem));
+        Assert.AreEqual(UsingDirectiveOrderingGroup.SystemNamespace, UsingDirectiveOrderingUtilities.GetUsingDirectiveGroup(exactSystem));
+        Assert.IsTrue(UsingDirectiveOrderingUtilities.AreInSameGroup(exactSystem, systemChild));
+        Assert.IsFalse(UsingDirectiveOrderingUtilities.AreInSameGroup(exactSystem, caseVariant));
+        Assert.AreEqual(string.Empty, UsingDirectiveOrderingUtilities.GetNamespaceGroupOrderKey(exactSystem));
+        Assert.AreEqual("SYSTEM", UsingDirectiveOrderingUtilities.GetNamespaceGroupOrderKey(caseVariant));
+    }
+
+    /// <summary>
+    /// Verifies that every non-exact casing of the System root is classified as an ordinary namespace
+    /// </summary>
+    [TestMethod]
+    public void EveryNonExactSystemCasingIsClassifiedAsAnOrdinaryNamespace()
+    {
+        const string root = "system";
+
+        for (var casingMask = 0; casingMask < 1 << root.Length; casingMask++)
+        {
+            var rootNamespace = new string(root.Select((character, index) => (casingMask & (1 << index)) == 0
+                                                                                 ? character
+                                                                                 : char.ToUpperInvariant(character))
+                                               .ToArray());
+
+            if (rootNamespace == "System")
+            {
+                continue;
+            }
+
+            var usingDirective = CoreSyntaxTestHelper.ParseCompilationUnit($"using {rootNamespace};")
+                                                     .Usings
+                                                     .Single();
+
+            Assert.IsFalse(UsingDirectiveOrderingUtilities.IsSystemNamespaceUsing(usingDirective), rootNamespace);
+            Assert.AreEqual(UsingDirectiveOrderingGroup.OtherNamespace,
+                            UsingDirectiveOrderingUtilities.GetUsingDirectiveGroup(usingDirective),
+                            rootNamespace);
+            Assert.AreEqual(rootNamespace, UsingDirectiveOrderingUtilities.GetRootNamespace(usingDirective), rootNamespace);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that child and global-qualified namespaces use the same ordinal System-root boundary
+    /// </summary>
+    [TestMethod]
+    public void ChildAndGlobalQualifiedNamespacesHonorExactSystemRootBoundary()
+    {
+        var usingDirectives = CoreSyntaxTestHelper.ParseCompilationUnit("""
+                                                                        using System.Text;
+                                                                        using SYSTEM.Text;
+                                                                        using global::System.Collections;
+                                                                        using global::system.Collections;
+                                                                        """)
+                                                  .Usings;
+
+        Assert.IsTrue(UsingDirectiveOrderingUtilities.IsSystemNamespaceUsing(usingDirectives[0]));
+        Assert.IsFalse(UsingDirectiveOrderingUtilities.IsSystemNamespaceUsing(usingDirectives[1]));
+        Assert.IsTrue(UsingDirectiveOrderingUtilities.IsSystemNamespaceUsing(usingDirectives[2]));
+        Assert.IsFalse(UsingDirectiveOrderingUtilities.IsSystemNamespaceUsing(usingDirectives[3]));
+        Assert.IsTrue(UsingDirectiveOrderingUtilities.AreInSameGroup(usingDirectives[0], usingDirectives[2]));
+        Assert.IsFalse(UsingDirectiveOrderingUtilities.AreInSameGroup(usingDirectives[0], usingDirectives[1]));
+        Assert.IsFalse(UsingDirectiveOrderingUtilities.AreInSameGroup(usingDirectives[2], usingDirectives[3]));
+        Assert.AreEqual("SYSTEM", UsingDirectiveOrderingUtilities.GetNamespaceGroupOrderKey(usingDirectives[1]));
+        Assert.AreEqual("system", UsingDirectiveOrderingUtilities.GetNamespaceGroupOrderKey(usingDirectives[3]));
+    }
+
+    /// <summary>
     /// Verifies that aliases are grouped by the root namespace of their target
     /// </summary>
     [TestMethod]

--- a/Reihitsu.Core.Test/UsingDirectiveOrderingUtilitiesTests.cs
+++ b/Reihitsu.Core.Test/UsingDirectiveOrderingUtilitiesTests.cs
@@ -28,7 +28,7 @@ public class UsingDirectiveOrderingUtilitiesTests
     /// <summary>
     /// Expected reordered compilation-unit usings
     /// </summary>
-    private static readonly string[] _compilationUnitReorderedOrder = ["using System;", "global using A;", "using Zeta;", "global using B;", "using static System.Math;", "using Alias = Example.Tools;"];
+    private static readonly string[] _compilationUnitReorderedOrder = ["global using A;", "global using B;", "using System;", "using Zeta;", "using static System.Math;", "using Alias = Example.Tools;"];
 
     /// <summary>
     /// Expected reordered namespace usings
@@ -191,6 +191,71 @@ public class UsingDirectiveOrderingUtilitiesTests
         Assert.IsFalse(UsingDirectiveOrderingUtilities.AreInSameGroup(usingDirectives[2], usingDirectives[3]));
         Assert.AreEqual("SYSTEM", UsingDirectiveOrderingUtilities.GetNamespaceGroupOrderKey(usingDirectives[1]));
         Assert.AreEqual("system", UsingDirectiveOrderingUtilities.GetNamespaceGroupOrderKey(usingDirectives[3]));
+    }
+
+    /// <summary>
+    /// Verifies that global directives form the leading section and that local exact-System priority cannot outrank it
+    /// </summary>
+    [TestMethod]
+    public void ComputeCanonicalOrderPlacesEveryGlobalUsingBeforeEveryLocalUsing()
+    {
+        var usingDirectives = CoreSyntaxTestHelper.ParseCompilationUnit("""
+                                                                        using System.Text;
+                                                                        global using Alias = Beta.Type;
+                                                                        global using static Alpha.Helper;
+                                                                        global using SYSTEM.Text;
+                                                                        global using System.Collections;
+                                                                        """)
+                                                  .Usings;
+
+        var canonical = UsingDirectiveOrderingUtilities.ComputeCanonicalOrder(usingDirectives);
+
+        CollectionAssert.AreEqual(new[]
+                                  {
+                                      "global using System.Collections;",
+                                      "global using SYSTEM.Text;",
+                                      "global using static Alpha.Helper;",
+                                      "global using Alias = Beta.Type;",
+                                      "using System.Text;"
+                                  },
+                                  canonical.Select(obj => obj.ToString()).ToArray());
+        Assert.IsFalse(UsingDirectiveOrderingUtilities.AreInSameGroup(usingDirectives[0], usingDirectives[4]));
+    }
+
+    /// <summary>
+    /// Verifies that ordinal-distinct roots remain contiguous before member names are considered for every using type
+    /// </summary>
+    [TestMethod]
+    public void ComputeCanonicalOrderKeepsOrdinalRootGroupsContiguousForEveryUsingType()
+    {
+        var usingDirectives = CoreSyntaxTestHelper.ParseCompilationUnit("""
+                                                                        using SYSTEM.Zulu;
+                                                                        using system.Bravo;
+                                                                        using SYSTEM.Alpha;
+                                                                        using static SYSTEM.Zulu;
+                                                                        using static system.Bravo;
+                                                                        using static SYSTEM.Alpha;
+                                                                        using ZuluAlias = SYSTEM.Zulu;
+                                                                        using BravoAlias = system.Bravo;
+                                                                        using AlphaAlias = SYSTEM.Alpha;
+                                                                        """)
+                                                  .Usings;
+
+        var canonical = UsingDirectiveOrderingUtilities.ComputeCanonicalOrder(usingDirectives);
+
+        CollectionAssert.AreEqual(new[]
+                                  {
+                                      "using SYSTEM.Alpha;",
+                                      "using SYSTEM.Zulu;",
+                                      "using system.Bravo;",
+                                      "using static SYSTEM.Alpha;",
+                                      "using static SYSTEM.Zulu;",
+                                      "using static system.Bravo;",
+                                      "using AlphaAlias = SYSTEM.Alpha;",
+                                      "using ZuluAlias = SYSTEM.Zulu;",
+                                      "using BravoAlias = system.Bravo;"
+                                  },
+                                  canonical.Select(obj => obj.ToString()).ToArray());
     }
 
     /// <summary>

--- a/Reihitsu.Core/UsingDirectiveOrderingUtilities.cs
+++ b/Reihitsu.Core/UsingDirectiveOrderingUtilities.cs
@@ -134,14 +134,15 @@ public static class UsingDirectiveOrderingUtilities
     }
 
     /// <summary>
-    /// Determines whether two using directives belong to the same group (same using type and root namespace)
+    /// Determines whether two using directives belong to the same group (same global status, using type and root namespace)
     /// </summary>
     /// <param name="left">Left using directive</param>
     /// <param name="right">Right using directive</param>
     /// <returns><see langword="true"/> if both directives belong to the same group</returns>
     public static bool AreInSameGroup(UsingDirectiveSyntax left, UsingDirectiveSyntax right)
     {
-        return GetUsingTypeOrder(left) == GetUsingTypeOrder(right)
+        return IsGlobalUsing(left) == IsGlobalUsing(right)
+               && GetUsingTypeOrder(left) == GetUsingTypeOrder(right)
                && string.Equals(GetRootNamespace(left), GetRootNamespace(right), StringComparison.Ordinal);
     }
 
@@ -157,8 +158,10 @@ public static class UsingDirectiveOrderingUtilities
                                                                               UsingDirective = usingDirective,
                                                                               DirectiveIndex = directiveIndex,
                                                                           })
-                              .OrderBy(obj => GetUsingTypeOrder(obj.UsingDirective))
+                              .OrderBy(obj => IsGlobalUsing(obj.UsingDirective) ? 0 : 1)
+                              .ThenBy(obj => GetUsingTypeOrder(obj.UsingDirective))
                               .ThenBy(obj => GetNamespaceGroupOrderKey(obj.UsingDirective), StringComparer.OrdinalIgnoreCase)
+                              .ThenBy(obj => GetRootNamespace(obj.UsingDirective), StringComparer.Ordinal)
                               .ThenBy(obj => GetSortKey(obj.UsingDirective), StringComparer.OrdinalIgnoreCase)
                               .ThenBy(obj => obj.DirectiveIndex)
                               .Select(obj => obj.UsingDirective)
@@ -220,18 +223,8 @@ public static class UsingDirectiveOrderingUtilities
     {
         var orderedGlobalUsings = OrderSubset(usingDirectives.Where(IsGlobalUsing).ToList());
         var orderedLocalUsings = OrderSubset(usingDirectives.Where(obj => IsGlobalUsing(obj) == false).ToList());
-        var reorderedUsings = new List<UsingDirectiveSyntax>(usingDirectives.Count);
-        var globalUsingIndex = 0;
-        var localUsingIndex = 0;
 
-        foreach (var usingDirective in usingDirectives)
-        {
-            reorderedUsings.Add(IsGlobalUsing(usingDirective)
-                                    ? orderedGlobalUsings[globalUsingIndex++]
-                                    : orderedLocalUsings[localUsingIndex++]);
-        }
-
-        return SyntaxFactory.List(reorderedUsings);
+        return SyntaxFactory.List(orderedGlobalUsings.Concat(orderedLocalUsings));
     }
 
     /// <summary>

--- a/Reihitsu.Core/UsingDirectiveOrderingUtilities.cs
+++ b/Reihitsu.Core/UsingDirectiveOrderingUtilities.cs
@@ -128,7 +128,7 @@ public static class UsingDirectiveOrderingUtilities
     {
         var rootNamespace = GetRootNamespace(usingDirective);
 
-        return string.Equals(rootNamespace, "System", StringComparison.OrdinalIgnoreCase)
+        return string.Equals(rootNamespace, "System", StringComparison.Ordinal)
                    ? string.Empty
                    : rootNamespace;
     }
@@ -142,7 +142,7 @@ public static class UsingDirectiveOrderingUtilities
     public static bool AreInSameGroup(UsingDirectiveSyntax left, UsingDirectiveSyntax right)
     {
         return GetUsingTypeOrder(left) == GetUsingTypeOrder(right)
-               && string.Equals(GetRootNamespace(left), GetRootNamespace(right), StringComparison.OrdinalIgnoreCase);
+               && string.Equals(GetRootNamespace(left), GetRootNamespace(right), StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/Reihitsu.Formatter.Test/Regression/UsingDirectives/UsingDirectiveOrderingTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/UsingDirectives/UsingDirectiveOrderingTests.cs
@@ -39,6 +39,37 @@ public class UsingDirectiveOrderingTests : FormatterTestsBase
     }
 
     /// <summary>
+    /// Verifies that an exact System child is ordered before a separately grouped global-qualified case variant while its comment stays attached
+    /// </summary>
+    [TestMethod]
+    public void GlobalQualifiedCaseVariantIsSeparatedFromExactSystemGroup()
+    {
+        // Arrange
+        const string input = """
+                             using global::SYSTEM.Text; // Keep with the case variant
+                             using System.Text;
+
+                             namespace SYSTEM.Text
+                             {
+                                 internal class Placeholder;
+                             }
+                             """;
+        const string expected = """
+                                using System.Text;
+
+                                using global::SYSTEM.Text; // Keep with the case variant
+
+                                namespace SYSTEM.Text
+                                {
+                                    internal class Placeholder;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
     /// Verifies that a using block with a nullable directive on a later directive is not reordered
     /// </summary>
     [TestMethod]

--- a/Reihitsu.Formatter.Test/Regression/UsingDirectives/UsingDirectiveOrderingTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/UsingDirectives/UsingDirectiveOrderingTests.cs
@@ -70,6 +70,48 @@ public class UsingDirectiveOrderingTests : FormatterTestsBase
     }
 
     /// <summary>
+    /// Verifies that every global using type precedes local usings while ordinal root groups stay contiguous
+    /// </summary>
+    [TestMethod]
+    public void GlobalSectionPrecedesLocalSectionAndKeepsOrdinalRootsContiguous()
+    {
+        // Arrange
+        const string input = """
+                             using System.Text;
+                             global using System.Collections;
+                             global using SYSTEM.Zulu; // Keep with SYSTEM
+                             global using system.Bravo;
+                             global using SYSTEM.Alpha;
+                             global using static Delta.Helper;
+                             global using Alias = Echo.Type;
+                             using SYSTEM.Bravo;
+
+                             class C;
+                             """;
+        const string expected = """
+                                global using System.Collections;
+
+                                global using SYSTEM.Alpha;
+                                global using SYSTEM.Zulu; // Keep with SYSTEM
+
+                                global using system.Bravo;
+
+                                global using static Delta.Helper;
+
+                                global using Alias = Echo.Type;
+
+                                using System.Text;
+
+                                using SYSTEM.Bravo;
+
+                                class C;
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
     /// Verifies that a using block with a nullable directive on a later directive is not reordered
     /// </summary>
     [TestMethod]

--- a/documentation/rules/RH7206.md
+++ b/documentation/rules/RH7206.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-This rule requires `using static` directives to be sorted alphabetically by type name.
+This rule requires `using static` directives within the same global-or-local root-namespace group to be sorted alphabetically by type name. Root-namespace groups themselves are ordered by [RH7207](RH7207.md).
 
 ## Why is this a problem?
 
@@ -17,7 +17,7 @@ Alphabetical ordering makes static import blocks easier to scan and keeps them c
 
 ## How to fix it
 
-Sort `using static` directives alphabetically.
+Sort `using static` directives alphabetically within each root-namespace group. Keep global and local directives in separate sections.
 
 ## Examples
 

--- a/documentation/rules/RH7207.md
+++ b/documentation/rules/RH7207.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-This rule requires `using` directives to be organized into separate sections for regular usings, `using static` directives, and alias directives. Within each section, directives are grouped by their root namespace (the first segment before the first dot, such as `System`, `Microsoft`, or `Reihitsu`), with each group separated by a single blank line.
+This rule requires all `global using` directives to form the first section and all local `using` directives to form the second. Within each section, directives are organized into regular, `using static`, and alias groups. Each using-type group is further grouped by its ordinal root namespace (the first segment before the first dot, such as `System`, `Microsoft`, or `Reihitsu`), with each boundary separated by a single blank line.
 
 ## Why is this a problem?
 
@@ -17,7 +17,7 @@ When regular usings, static imports, and aliases are mixed together, the import 
 
 ## How to fix it
 
-Place regular usings first, `using static` directives after them, and alias directives last. Within each section, keep the `System` group first, order the remaining root-namespace groups alphabetically, and separate each group with a single blank line. Apply the provided code fix to reorganize the directives automatically.
+Place every global directive before every local directive. Within each of those sections, place regular usings first, `using static` directives after them, and alias directives last. Only the exact-cased `System` root receives first-group priority. Order the remaining root-namespace groups case-insensitively with ordinal casing as the deterministic tie-breaker, keep each ordinal root contiguous, and separate every group boundary with a single blank line. Apply the provided code fix to reorganize the directives automatically.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

Make global usings the leading section, keep exact-cased `System` priority scoped to each global/local section, and keep ordinal namespace roots contiguous across analyzers, code fixes, and the formatter. Honor explicit `bin`/`obj` CLI targets while retaining recursive build-output exclusions, and document the dry-run exit contract consistently.

## Why

The original issue still reproduced analyzer/code-fix disagreement for case-variant namespace roots and selected the same CLI directory differently depending on path spelling. Reassessment also found that canonical ordering could move local usings ahead of global usings or fracture one ordinal root around another casing.

## Linked issues

Closes #470

## Review notes

Global/local status is the leading group dimension; only exact `System` receives special priority within its section. Explicit file and directory targets win, broader recursive scans still skip `bin`/`obj`, and path casing follows the host filesystem. Diagnostic metadata, public API signatures, dependencies, and runtime exit conditions are unchanged.

## Follow-up work

Deferred hygiene remains tracked separately in #626.