### PR TITLE
Preserve a comment written before the first declarator when splitting a field

### DIFF
--- a/Reihitsu.Analyzer.Test/Formatting/RH7101DoNotCombineFieldsAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH7101DoNotCombineFieldsAnalyzerTests.cs
@@ -332,24 +332,63 @@ public class RH7101DoNotCombineFieldsAnalyzerTests : AnalyzerTestsBase<RH7101DoN
     }
 
     /// <summary>
-    /// Verifies that a comment written before the first declarator survives the fix. Only the survival of the comment
-    /// text is asserted, because the position it should end up in is still open (issue #636)
+    /// Verifies that a comment written before the first declarator is preserved by the fix. The fix runs the split
+    /// transform without the formatting pipeline behind it, so this is the surface where the comment's own whitespace
+    /// reaches the user unchanged (issue #636)
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
     [TestMethod]
-    public async Task VerifyCommentBeforeFirstDeclaratorSurvivesTheFix()
+    public async Task VerifyCommentBeforeFirstDeclaratorIsPreservedByTheFix()
     {
         const string testData = """
                                 internal class TestClass
                                 {
                                     private int
-                                    /* c */ firstField, secondField;
+                                    /* c */ firstField, {|#0:secondField|};
                                 }
                                 """;
 
-        var actual = await ApplyCodeFixAsync(testData);
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     private int
+                                     /* c */ firstField;
+                                     private int
+                                 secondField;
+                                 }
+                                 """;
 
-        Assert.Contains("/* c */", actual, "The comment before the first declarator must survive the fix.");
+        await Verify(testData, fixedData, Diagnostics(RH7101DoNotCombineFieldsAnalyzer.DiagnosticId, AnalyzerResources.RH7101MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that the fix emits the comment's own indentation verbatim. No later phase runs on this surface, so
+    /// the column the author wrote the comment at is the column the user sees, unlike the formatter surface where the
+    /// indentation phase re-anchors it (issue #636)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFixKeepsTheOwnIndentationOfTheCommentBeforeFirstDeclarator()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    private int
+                                /* c */ firstField, {|#0:secondField|};
+                                }
+                                """;
+
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     private int
+                                 /* c */ firstField;
+                                     private int
+                                 secondField;
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH7101DoNotCombineFieldsAnalyzer.DiagnosticId, AnalyzerResources.RH7101MessageFormat));
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer.Test/Formatting/RH7101DoNotCombineFieldsAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH7101DoNotCombineFieldsAnalyzerTests.cs
@@ -392,6 +392,36 @@ public class RH7101DoNotCombineFieldsAnalyzerTests : AnalyzerTestsBase<RH7101DoN
     }
 
     /// <summary>
+    /// Verifies that the fix keeps the first declarator's indentation when its slot holds no comment at all. This is
+    /// the other side of the boundary from a preserved comment, and the code fix is the only surface that can tell
+    /// the two apart, because no later phase re-anchors the declarator here (issue #636)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFixKeepsTheIndentationOfAFirstDeclaratorWithoutAComment()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    private int
+                                    firstField, {|#0:secondField|};
+                                }
+                                """;
+
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     private int
+                                     firstField;
+                                     private int
+                                 secondField;
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH7101DoNotCombineFieldsAnalyzer.DiagnosticId, AnalyzerResources.RH7101MessageFormat));
+    }
+
+    /// <summary>
     /// Verifies that the fix is not offered when the combined field carries a preprocessor directive, because the
     /// split transform leaves directive-bearing fields intact and the fix would otherwise be a no-op (issue #456)
     /// </summary>

--- a/Reihitsu.Analyzer.Test/Formatting/RH7101DoNotCombineFieldsAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH7101DoNotCombineFieldsAnalyzerTests.cs
@@ -332,6 +332,27 @@ public class RH7101DoNotCombineFieldsAnalyzerTests : AnalyzerTestsBase<RH7101DoN
     }
 
     /// <summary>
+    /// Verifies that a comment written before the first declarator survives the fix. Only the survival of the comment
+    /// text is asserted, because the position it should end up in is still open (issue #636)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCommentBeforeFirstDeclaratorSurvivesTheFix()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    private int
+                                    /* c */ firstField, secondField;
+                                }
+                                """;
+
+        var actual = await ApplyCodeFixAsync(testData);
+
+        Assert.Contains("/* c */", actual, "The comment before the first declarator must survive the fix.");
+    }
+
+    /// <summary>
     /// Verifies that the fix is not offered when the combined field carries a preprocessor directive, because the
     /// split transform leaves directive-bearing fields intact and the fix would otherwise be a no-op (issue #456)
     /// </summary>

--- a/Reihitsu.Formatter.Test/Regression/Structural/FieldDeclarationSplitTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Structural/FieldDeclarationSplitTests.cs
@@ -1025,6 +1025,32 @@ public class FieldDeclarationSplitTests : FormatterTestsBase
     }
 
     /// <summary>
+    /// Verifies that a comment written before the first declarator survives the split. Only the survival of the
+    /// comment text is asserted, because the position it should end up in is still open (issue #636)
+    /// </summary>
+    [TestMethod]
+    public void CommentBeforeFirstDeclaratorSurvivesTheSplit()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 private int
+                                 /* c */ _first, _second;
+                             }
+                             """;
+
+        foreach (var endOfLine in _lineEndings)
+        {
+            // Act
+            var actual = ApplyRule(NormalizeLineEndings(input, endOfLine), endOfLine);
+
+            // Assert
+            Assert.Contains("/* c */", actual, $"The comment before the first declarator must survive the split under {DescribeLineEnding(endOfLine)} line endings.");
+        }
+    }
+
+    /// <summary>
     /// Verifies that static fields declared in an interface are split
     /// </summary>
     [TestMethod]

--- a/Reihitsu.Formatter.Test/Regression/Structural/FieldDeclarationSplitTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Structural/FieldDeclarationSplitTests.cs
@@ -995,12 +995,12 @@ public class FieldDeclarationSplitTests : FormatterTestsBase
     }
 
     /// <summary>
-    /// Verifies that a comment written before the first declarator is still dropped. It sits in the first
-    /// declarator's leading trivia, which has no terminator in front of it, so the terminator rule does not reach
-    /// it. This records the remaining gap deliberately rather than widening the split silently
+    /// Verifies that a comment written before the first declarator is preserved where the author wrote it. It sits
+    /// in the first declarator's leading trivia, which the split used to strip without any call site reading it
+    /// (issue #636)
     /// </summary>
     [TestMethod]
-    public void CommentBeforeFirstDeclaratorIsStillDropped()
+    public void CommentBeforeFirstDeclaratorIsPreserved()
     {
         // Arrange
         const string input = """
@@ -1008,6 +1008,480 @@ public class FieldDeclarationSplitTests : FormatterTestsBase
                              {
                                  private int
                                  /* c */ _first, _second;
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    private int
+
+                                    /* c */ _first;
+                                    private int
+                                    _second;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a line comment written before the first declarator is preserved. It ends its own line, so the
+    /// declarator stays on the following line rather than being commented out (issue #636)
+    /// </summary>
+    [TestMethod]
+    public void LineCommentBeforeFirstDeclaratorIsPreserved()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 private int
+                                 // c
+                                 _first, _second;
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    private int
+
+                                    // c
+                                    _first;
+                                    private int
+                                    _second;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a single line documentation comment written before the first declarator is preserved and
+    /// normalized to its multi line form (issue #636)
+    /// </summary>
+    [TestMethod]
+    public void SingleLineDocumentationCommentBeforeFirstDeclaratorIsPreserved()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 private int
+                                 /// <summary>First.</summary>
+                                 _first, _second;
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    private int
+
+                                    /// <summary>
+                                    /// First.
+                                    /// </summary>
+                                    _first;
+                                    private int
+                                    _second;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a delimited documentation comment written before the first declarator is preserved. It carries
+    /// no line break of its own, so the declarator stays on its line (issue #636)
+    /// </summary>
+    [TestMethod]
+    public void DelimitedDocumentationCommentBeforeFirstDeclaratorIsPreserved()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 private int
+                                 /** c */ _first, _second;
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    private int
+
+                                    /** c */ _first;
+                                    private int
+                                    _second;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that two comments written before the first declarator are both preserved in their source order
+    /// (issue #636)
+    /// </summary>
+    [TestMethod]
+    public void TwoCommentsBeforeFirstDeclaratorArePreserved()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 private int
+                                 /* a */ /* b */ _first, _second;
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    private int
+
+                                    /* a */ /* b */ _first;
+                                    private int
+                                    _second;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a comment written before the first of three declarators lands on the first generated field only
+    /// (issue #636)
+    /// </summary>
+    [TestMethod]
+    public void CommentBeforeFirstOfThreeDeclaratorsLandsOnTheFirstFieldOnly()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 private int
+                                 /* c */ _first, _second, _third;
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    private int
+
+                                    /* c */ _first;
+                                    private int
+                                    _second;
+                                    private int
+                                    _third;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that the field's own documentation comment and a comment written before the first declarator are
+    /// both preserved, in their own slots, and that neither is duplicated (issue #636)
+    /// </summary>
+    [TestMethod]
+    public void FieldDocumentationAndCommentBeforeFirstDeclaratorAreBothPreserved()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 /// <summary>
+                                 /// Fields.
+                                 /// </summary>
+                                 private int
+                                 /* c */ _first, _second;
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    /// <summary>
+                                    /// Fields.
+                                    /// </summary>
+                                    private int
+
+                                    /* c */ _first;
+                                    private int
+                                    _second;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that the attribute list is still duplicated onto every generated field while a comment written
+    /// before the first declarator lands on the first field only (issue #636)
+    /// </summary>
+    [TestMethod]
+    public void AttributeListAndCommentBeforeFirstDeclaratorAreBothPreserved()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 [System.Obsolete]
+                                 private int
+                                 /* c */ _first, _second;
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    [System.Obsolete]
+                                    private int
+
+                                    /* c */ _first;
+                                    [System.Obsolete]
+                                    private int
+                                    _second;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a comment written before the first declarator is preserved when the declarators carry
+    /// initializers (issue #636)
+    /// </summary>
+    [TestMethod]
+    public void CommentBeforeFirstDeclaratorWithInitializersIsPreserved()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 private int
+                                 /* c */ _first = 1, _second = 2;
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    private int
+
+                                    /* c */ _first = 1;
+                                    private int
+                                    _second = 2;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a comment written before the first declarator and a comment written after its separator are
+    /// both preserved on the first generated field, on either side of the generated semicolon (issue #636)
+    /// </summary>
+    [TestMethod]
+    public void CommentsBeforeAndAfterTheFirstDeclaratorAreBothPreserved()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 private int
+                                 /* a */ _first, // b
+                                         _second;
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    private int
+
+                                    /* a */ _first; // b
+                                    private int
+                                    _second;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a comment written before the first declarator of a struct field is preserved (issue #636)
+    /// </summary>
+    [TestMethod]
+    public void CommentBeforeFirstDeclaratorInStructIsPreserved()
+    {
+        // Arrange
+        const string input = """
+                             internal struct TestStruct
+                             {
+                                 private int
+                                 /* c */ _first, _second;
+                             }
+                             """;
+        const string expected = """
+                                internal struct TestStruct
+                                {
+                                    private int
+
+                                    /* c */ _first;
+                                    private int
+                                    _second;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a comment written before the first declarator of a record struct field is preserved (issue #636)
+    /// </summary>
+    [TestMethod]
+    public void CommentBeforeFirstDeclaratorInRecordStructIsPreserved()
+    {
+        // Arrange
+        const string input = """
+                             internal record struct TestRecord
+                             {
+                                 private int
+                                 /* c */ _first, _second;
+                             }
+                             """;
+        const string expected = """
+                                internal record struct TestRecord
+                                {
+                                    private int
+
+                                    /* c */ _first;
+                                    private int
+                                    _second;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a comment written before the first declarator of a static interface field is preserved
+    /// (issue #636)
+    /// </summary>
+    [TestMethod]
+    public void CommentBeforeFirstDeclaratorInInterfaceIsPreserved()
+    {
+        // Arrange
+        const string input = """
+                             internal interface ITestInterface
+                             {
+                                 static int
+                                 /* c */ _first, _second;
+                             }
+                             """;
+        const string expected = """
+                                internal interface ITestInterface
+                                {
+                                    static int
+
+                                    /* c */ _first;
+                                    static int
+                                    _second;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a comment written before the first declarator of a nested type's field is preserved at the
+    /// nested indentation (issue #636)
+    /// </summary>
+    [TestMethod]
+    public void CommentBeforeFirstDeclaratorInNestedTypeIsPreserved()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 private class Inner
+                                 {
+                                     private int
+                                     /* c */ _first, _second;
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    private class Inner
+                                    {
+                                        private int
+
+                                        /* c */ _first;
+                                        private int
+                                        _second;
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a misindented comment before the first declarator is re-anchored to the member indentation.
+    /// The split preserves the author's whitespace and the indentation phase owns the column, so the output does not
+    /// depend on the column the comment was written at (issue #636)
+    /// </summary>
+    [TestMethod]
+    public void MisindentedCommentBeforeFirstDeclaratorIsNormalizedToMemberIndentation()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 private int
+                             /* c */ _first, _second;
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    private int
+
+                                    /* c */ _first;
+                                    private int
+                                    _second;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that whitespace-only trivia before the first declarator is unchanged by the split. This is the other
+    /// side of the boundary from a comment in the same slot: without a comment there is nothing to preserve, so the
+    /// output must stay what it was before the slot was read at all (issue #636)
+    /// </summary>
+    [TestMethod]
+    public void WhitespaceOnlyTriviaBeforeFirstDeclaratorIsUnchanged()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 private int
+                                 _first, _second;
                              }
                              """;
         const string expected = """
@@ -1025,29 +1499,97 @@ public class FieldDeclarationSplitTests : FormatterTestsBase
     }
 
     /// <summary>
-    /// Verifies that a comment written before the first declarator survives the split. Only the survival of the
-    /// comment text is asserted, because the position it should end up in is still open (issue #636)
+    /// Verifies that a comment written on the type's own line is still duplicated onto every generated field. It is
+    /// trailing trivia of the type token rather than leading trivia of the declarator, so it is a different slot and
+    /// this fix must not reach it (issue #636)
     /// </summary>
     [TestMethod]
-    public void CommentBeforeFirstDeclaratorSurvivesTheSplit()
+    public void CommentOnTheTypeLineIsStillDuplicatedOntoEveryField()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 private int /* c */ _first, _second;
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    private int /* c */ _first;
+                                    private int /* c */ _second;
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a directive written before the first declarator still leaves the field declaration intact. The
+    /// directive guard inspects the whole declaration, so it covers the newly read slot as well (issue #636)
+    /// </summary>
+    [TestMethod]
+    public void DirectiveBeforeFirstDeclaratorLeavesTheFieldIntact()
     {
         // Arrange
         const string input = """
                              internal class TestClass
                              {
                                  private int
-                                 /* c */ _first, _second;
+                             #if DEBUG
+                                 /* c */
+                             #endif
+                                 _first, _second;
                              }
                              """;
 
-        foreach (var endOfLine in _lineEndings)
-        {
-            // Act
-            var actual = ApplyRule(NormalizeLineEndings(input, endOfLine), endOfLine);
+        // Act & Assert
+        AssertRuleResult(input);
+    }
 
-            // Assert
-            Assert.Contains("/* c */", actual, $"The comment before the first declarator must survive the split under {DescribeLineEnding(endOfLine)} line endings.");
-        }
+    /// <summary>
+    /// Verifies that disabled text written before the first declarator still leaves the field declaration intact
+    /// (issue #636)
+    /// </summary>
+    [TestMethod]
+    public void DisabledTextBeforeFirstDeclaratorLeavesTheFieldIntact()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 private int
+                             #if false
+                                 /* c */
+                             #endif
+                                 _first, _second;
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a comment before the declarator of a single declarator field is untouched. The split does not
+    /// run at all, so the slot is never rebuilt (issue #636)
+    /// </summary>
+    [TestMethod]
+    public void CommentBeforeDeclaratorOfSingleDeclaratorFieldIsUnchanged()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 private int
+
+                                 /* c */ _first;
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
     }
 
     /// <summary>

--- a/Reihitsu.Formatter.Test/Regression/Structural/FieldDeclarationSplitTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Structural/FieldDeclarationSplitTests.cs
@@ -1469,9 +1469,10 @@ public class FieldDeclarationSplitTests : FormatterTestsBase
     }
 
     /// <summary>
-    /// Verifies that whitespace-only trivia before the first declarator is unchanged by the split. This is the other
-    /// side of the boundary from a comment in the same slot: without a comment there is nothing to preserve, so the
-    /// output must stay what it was before the slot was read at all (issue #636)
+    /// Verifies that the pipeline output for a first declarator whose slot holds no comment is unchanged by the
+    /// split. The indentation phase re-anchors the declarator either way, so this asserts that reading the slot
+    /// caused no regression here rather than pinning the boundary itself - that side is only observable on the code
+    /// fix surface, where no later phase runs (issue #636)
     /// </summary>
     [TestMethod]
     public void WhitespaceOnlyTriviaBeforeFirstDeclaratorIsUnchanged()

--- a/Reihitsu.Formatter/Pipeline/StructuralTransforms/Rewriter/FieldDeclarationSplitTransform.cs
+++ b/Reihitsu.Formatter/Pipeline/StructuralTransforms/Rewriter/FieldDeclarationSplitTransform.cs
@@ -259,12 +259,21 @@ internal sealed class FieldDeclarationSplitTransform : CSharpSyntaxRewriter
             {
                 var variable = variables[variableIndex];
 
-                // Only the declarator's leading trivia is dropped, because the generated field rebuilds it below.
-                // Its trailing trivia is what the author wrote between the declarator and its terminator, so it
-                // stays on the declarator - carrying it over to the semicolon instead would move an ordinary
+                // Only a later declarator's leading trivia is dropped, because BuildLeadingTrivia rebuilds it below.
+                // The first declarator is carried over unchanged: the generated field's own leading trivia comes from
+                // the declaration rather than from BuildLeadingTrivia, so nothing would read the first declarator's
+                // leading trivia and a comment written between the type and the declarator would be deleted outright
+                // (issue #636). Keeping the declarator node itself, rather than stripping it and re-attaching the
+                // trivia, is also what keeps its trailing trivia from being attached twice.
+                // A declarator's trailing trivia is what the author wrote between the declarator and its terminator,
+                // so it stays on the declarator - carrying it over to the semicolon instead would move an ordinary
                 // comment into a leading position the blank-line phase separates onto its own line (issue #625).
-                var updatedField = fieldDeclaration.WithDeclaration(fieldDeclaration.Declaration.WithVariables(SyntaxFactory.SingletonSeparatedList(variable.WithoutTrivia()
-                                                                                                                                                            .WithTrailingTrivia(variable.GetTrailingTrivia()))));
+                var declarator = variableIndex == 0
+                                     ? variable
+                                     : variable.WithoutTrivia()
+                                               .WithTrailingTrivia(variable.GetTrailingTrivia());
+
+                var updatedField = fieldDeclaration.WithDeclaration(fieldDeclaration.Declaration.WithVariables(SyntaxFactory.SingletonSeparatedList(declarator)));
 
                 if (variableIndex == 0)
                 {

--- a/Reihitsu.Formatter/Pipeline/StructuralTransforms/Rewriter/FieldDeclarationSplitTransform.cs
+++ b/Reihitsu.Formatter/Pipeline/StructuralTransforms/Rewriter/FieldDeclarationSplitTransform.cs
@@ -263,8 +263,9 @@ internal sealed class FieldDeclarationSplitTransform : CSharpSyntaxRewriter
                 // The first declarator is carried over unchanged: the generated field's own leading trivia comes from
                 // the declaration rather than from BuildLeadingTrivia, so nothing would read the first declarator's
                 // leading trivia and a comment written between the type and the declarator would be deleted outright
-                // (issue #636). Keeping the declarator node itself, rather than stripping it and re-attaching the
-                // trivia, is also what keeps its trailing trivia from being attached twice.
+                // (issue #636). Keeping the declarator node itself is the narrowest way to preserve that slot: the
+                // alternative of stripping it and re-attaching the trivia to the generated field would collide with
+                // the field's own leading trivia, which the branch below sets.
                 // A declarator's trailing trivia is what the author wrote between the declarator and its terminator,
                 // so it stays on the declarator - carrying it over to the semicolon instead would move an ordinary
                 // comment into a leading position the blank-line phase separates onto its own line (issue #625).


### PR DESCRIPTION
## Summary

`FieldDeclarationSplitTransform.SplitFields` now carries the first declarator over unchanged instead of rebuilding it without its trivia, so a comment written between the type and the first declarator survives the split where the author wrote it. Later declarators keep their existing `BuildLeadingTrivia` treatment.

## Why

The generated field's leading trivia comes from the field declaration, not from `BuildLeadingTrivia`, so no call site ever read the first declarator's own leading trivia and a comment in that slot was deleted outright. Both the formatter pipeline and the RH7101 code fix were affected; on the code-fix surface no later phase runs, so the deletion was the final document the user saw.

## Linked issues

Closes #636

## Review notes

The issue left the placement undecided; option (a) was chosen, so the comment stays between the type and the declarator rather than being relocated above the field. Collapsing it onto the type's line was considered and rejected: it is impossible for `//` and `///` (the declarator would be commented out) and not a fixed point for `/** … */`, so it would require exactly the per-comment-kind special casing this change avoids.

The blank line between `private int` and the preserved comment in the expected outputs is existing `BlankLinePhase` policy for an own-line comment inside a declaration — the same shape already asserted for #624 — not something this change introduces.

The declarator's whitespace is now preserved as well as its comments. On the pipeline surface `IndentationPhase` re-anchors it, so nothing changes there; on the code-fix surface it is user-visible, and the first generated field of a comment-free multi-line declaration now keeps the author's indentation instead of being emitted at column 0. Both sides of that boundary are asserted on the code-fix surface, since it is the only one that can observe them.

The directive guard needed no widening: `CarriesDirective` inspects the whole declaration, which strictly contains the newly read slot, so a directive or disabled text there still leaves the field unsplit.

## Follow-up work

On the code-fix surface later generated fields are still emitted at column 0 while the first now keeps the author's indentation. That asymmetry is the pre-existing later-declarator path, outside this issue's mechanism, and is left for a separate change.