### PR TITLE
Enforce direct documentation tags and exact config filenames

### DIFF
--- a/Reihitsu.Analyzer.Test/Analyzer/RH0001ConfigurationFileMustBeValidAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Analyzer/RH0001ConfigurationFileMustBeValidAnalyzerTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.IO;
+using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -65,6 +66,80 @@ public class RH0001ConfigurationFileMustBeValidAnalyzerTests : AnalyzerTestsBase
                      {
                          test.TestState.AdditionalFiles.Add(("myreihitsu.json", "{}"));
                          test.TestState.AdditionalFiles.Add(("reihitsu.json", string.Empty));
+                     },
+                     InvalidConfiguration("The configuration file must not be empty or whitespace-only.", 1, 1));
+    }
+
+    /// <summary>
+    /// Verifies that configuration file matching is case-insensitive
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task UppercaseConfigurationFileNameIsLoaded()
+    {
+        const string configurationPath = "REIHITSU.JSON";
+
+        await Verify(TestCode,
+                     test => test.TestState.AdditionalFiles.Add((configurationPath, string.Empty)),
+                     InvalidConfiguration(configurationPath, "The configuration file must not be empty or whitespace-only.", 1, 1));
+    }
+
+    /// <summary>
+    /// Verifies that an exact configuration file in a subdirectory is loaded
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task ConfigurationFileInSubdirectoryIsLoaded()
+    {
+        var configurationPath = Path.Combine("settings", "reihitsu.json");
+
+        await Verify(TestCode,
+                     test => test.TestState.AdditionalFiles.Add((configurationPath, string.Empty)),
+                     InvalidConfiguration(configurationPath, "The configuration file must not be empty or whitespace-only.", 1, 1));
+    }
+
+    /// <summary>
+    /// Verifies that a prefixed configuration lookalike is ignored when no exact file exists
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task MyReihitsuConfigurationLookalikeIsIgnored()
+    {
+        await Verify(TestCode, test => test.TestState.AdditionalFiles.Add(("myreihitsu.json", string.Empty)));
+    }
+
+    /// <summary>
+    /// Verifies that a hyphen-prefixed configuration lookalike is ignored when no exact file exists
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task TeamReihitsuConfigurationLookalikeIsIgnored()
+    {
+        await Verify(TestCode, test => test.TestState.AdditionalFiles.Add(("team-reihitsu.json", string.Empty)));
+    }
+
+    /// <summary>
+    /// Verifies that a backup file is ignored when no exact configuration file exists
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task ConfigurationBackupFileIsIgnored()
+    {
+        await Verify(TestCode, test => test.TestState.AdditionalFiles.Add(("reihitsu.json.bak", string.Empty)));
+    }
+
+    /// <summary>
+    /// Verifies that the first exact configuration file wins over a later lookalike
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task ExactConfigurationFileBeforeLookalikeIsLoaded()
+    {
+        await Verify(TestCode,
+                     test =>
+                     {
+                         test.TestState.AdditionalFiles.Add(("reihitsu.json", string.Empty));
+                         test.TestState.AdditionalFiles.Add(("myreihitsu.json", "{}"));
                      },
                      InvalidConfiguration("The configuration file must not be empty or whitespace-only.", 1, 1));
     }
@@ -490,7 +565,20 @@ public class RH0001ConfigurationFileMustBeValidAnalyzerTests : AnalyzerTestsBase
     /// <returns>Diagnostic</returns>
     private static DiagnosticResult InvalidConfiguration(string message, int line, int column)
     {
-        return Diagnostic(RH0001ConfigurationFileMustBeValidAnalyzer.DiagnosticId).WithLocation("reihitsu.json", line, column)
+        return InvalidConfiguration("reihitsu.json", message, line, column);
+    }
+
+    /// <summary>
+    /// Invalid configuration diagnostic
+    /// </summary>
+    /// <param name="configurationPath">Configuration path</param>
+    /// <param name="message">Message</param>
+    /// <param name="line">Line</param>
+    /// <param name="column">Column</param>
+    /// <returns>Diagnostic</returns>
+    private static DiagnosticResult InvalidConfiguration(string configurationPath, string message, int line, int column)
+    {
+        return Diagnostic(RH0001ConfigurationFileMustBeValidAnalyzer.DiagnosticId).WithLocation(configurationPath, line, column)
                                                                                   .WithMessage(string.Format(AnalyzerResources.RH0001MessageFormat, message));
     }
 

--- a/Reihitsu.Analyzer.Test/Analyzer/RH0001ConfigurationFileMustBeValidAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Analyzer/RH0001ConfigurationFileMustBeValidAnalyzerTests.cs
@@ -54,6 +54,22 @@ public class RH0001ConfigurationFileMustBeValidAnalyzerTests : AnalyzerTestsBase
     }
 
     /// <summary>
+    /// Verifies that similarly named files are ignored and the exact configuration file is loaded
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task SimilarFileNameIsIgnoredAndExactConfigurationFileIsLoaded()
+    {
+        await Verify(TestCode,
+                     test =>
+                     {
+                         test.TestState.AdditionalFiles.Add(("myreihitsu.json", "{}"));
+                         test.TestState.AdditionalFiles.Add(("reihitsu.json", string.Empty));
+                     },
+                     InvalidConfiguration("The configuration file must not be empty or whitespace-only.", 1, 1));
+    }
+
+    /// <summary>
     /// Empty configuration
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer.Test/Core/DirectDocumentationSyntaxCheckerTests.cs
+++ b/Reihitsu.Analyzer.Test/Core/DirectDocumentationSyntaxCheckerTests.cs
@@ -5,8 +5,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Reihitsu.Analyzer.Core;
-using Reihitsu.Core;
-
 namespace Reihitsu.Analyzer.Test.Core;
 
 /// <summary>

--- a/Reihitsu.Analyzer.Test/Core/DirectDocumentationSyntaxCheckerTests.cs
+++ b/Reihitsu.Analyzer.Test/Core/DirectDocumentationSyntaxCheckerTests.cs
@@ -1,0 +1,63 @@
+using System.Linq;
+
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Analyzer.Core;
+using Reihitsu.Core;
+
+namespace Reihitsu.Analyzer.Test.Core;
+
+/// <summary>
+/// Unit tests for <see cref="DirectDocumentationSyntaxChecker"/>
+/// </summary>
+[TestClass]
+public class DirectDocumentationSyntaxCheckerTests
+{
+    #region Tests
+
+    /// <summary>
+    /// Verifies that direct matches are returned in source order without nested matches
+    /// </summary>
+    [TestMethod]
+    public void GetTagsIncludingNestedReturnsOnlyOrderedDirectMatchesWhenPresent()
+    {
+        const string source = """
+                              /// <remarks><param name="nested">Nested.</param></remarks>
+                              /// <param name="first">First.</param>
+                              /// <param name="second">Second.</param>
+                              class Sample
+                              {
+                              }
+                              """;
+
+        var documentationComment = GetDocumentationComment(source);
+        var matches = DirectDocumentationSyntaxChecker.GetTagsIncludingNested(documentationComment, "param");
+
+        CollectionAssert.AreEqual(new[] { "first", "second" },
+                                  matches.Select(DocumentationAnalysisUtilities.GetNameAttributeValue).ToArray());
+    }
+
+    #endregion // Tests
+
+    #region Methods
+
+    /// <summary>
+    /// Gets the documentation comment for the class in the provided source
+    /// </summary>
+    /// <param name="source">Source text</param>
+    /// <returns>The documentation comment</returns>
+    private static DocumentationCommentTriviaSyntax GetDocumentationComment(string source)
+    {
+        var declaration = CSharpSyntaxTree.ParseText(source)
+                                          .GetRoot()
+                                          .DescendantNodes()
+                                          .OfType<ClassDeclarationSyntax>()
+                                          .Single();
+
+        return DirectDocumentationSyntaxChecker.GetDocumentationComment(declaration);
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Analyzer.Test/Core/DirectDocumentationSyntaxCheckerTests.cs
+++ b/Reihitsu.Analyzer.Test/Core/DirectDocumentationSyntaxCheckerTests.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/Reihitsu.Analyzer.Test/Core/DirectDocumentationSyntaxCheckerTests.cs
+++ b/Reihitsu.Analyzer.Test/Core/DirectDocumentationSyntaxCheckerTests.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Reihitsu.Analyzer.Core;
+
 namespace Reihitsu.Analyzer.Test.Core;
 
 /// <summary>

--- a/Reihitsu.Analyzer.Test/Core/DocumentationAnalysisUtilitiesTests.cs
+++ b/Reihitsu.Analyzer.Test/Core/DocumentationAnalysisUtilitiesTests.cs
@@ -40,6 +40,28 @@ public class DocumentationAnalysisUtilitiesTests
     }
 
     /// <summary>
+    /// Verifies that a summary nested inside another documentation element does not document the member
+    /// </summary>
+    [TestMethod]
+    public void HasRequiredDocumentationReturnsFalseForMemberWithNestedSummaryWithoutSemanticModel()
+    {
+        const string source = """
+                              class Sample
+                              {
+                                  /// <remarks><summary>Nested summary</summary></remarks>
+                                  public void Execute()
+                                  {
+                                  }
+                              }
+                              """;
+
+        var declaration = GetSingleMethodDeclaration(source);
+        var hasRequiredDocumentation = DocumentationAnalysisUtilities.HasRequiredDocumentation(declaration, semanticModel: null, CancellationToken.None);
+
+        Assert.IsFalse(hasRequiredDocumentation);
+    }
+
+    /// <summary>
     /// Verifies that direct inheritdoc tags are accepted without expanded XML parsing for members
     /// </summary>
     [TestMethod]

--- a/Reihitsu.Analyzer.Test/Core/DocumentationAnalysisUtilitiesTests.cs
+++ b/Reihitsu.Analyzer.Test/Core/DocumentationAnalysisUtilitiesTests.cs
@@ -62,6 +62,28 @@ public class DocumentationAnalysisUtilitiesTests
     }
 
     /// <summary>
+    /// Verifies that inheritdoc nested inside another documentation element does not document a member
+    /// </summary>
+    [TestMethod]
+    public void HasRequiredDocumentationReturnsFalseForMemberWithNestedInheritdocWithoutSemanticModel()
+    {
+        const string source = """
+                              class Sample
+                              {
+                                  /// <remarks><inheritdoc/></remarks>
+                                  public void Execute()
+                                  {
+                                  }
+                              }
+                              """;
+
+        var declaration = GetSingleMethodDeclaration(source);
+        var hasRequiredDocumentation = DocumentationAnalysisUtilities.HasRequiredDocumentation(declaration, semanticModel: null, CancellationToken.None);
+
+        Assert.IsFalse(hasRequiredDocumentation);
+    }
+
+    /// <summary>
     /// Verifies that direct inheritdoc tags are accepted without expanded XML parsing for members
     /// </summary>
     [TestMethod]
@@ -121,6 +143,46 @@ public class DocumentationAnalysisUtilitiesTests
         var hasRequiredDocumentation = DocumentationAnalysisUtilities.HasRequiredDocumentation(declaration, semanticModel: null, CancellationToken.None);
 
         Assert.IsTrue(hasRequiredDocumentation);
+    }
+
+    /// <summary>
+    /// Verifies that a summary nested inside another documentation element does not document an enum member
+    /// </summary>
+    [TestMethod]
+    public void HasRequiredDocumentationReturnsFalseForEnumMemberWithNestedSummaryWithoutSemanticModel()
+    {
+        const string source = """
+                              enum Sample
+                              {
+                                  /// <remarks><summary>Nested summary</summary></remarks>
+                                  FirstValue
+                              }
+                              """;
+
+        var declaration = GetSingleEnumMemberDeclaration(source);
+        var hasRequiredDocumentation = DocumentationAnalysisUtilities.HasRequiredDocumentation(declaration, semanticModel: null, CancellationToken.None);
+
+        Assert.IsFalse(hasRequiredDocumentation);
+    }
+
+    /// <summary>
+    /// Verifies that inheritdoc nested inside another documentation element does not document an enum member
+    /// </summary>
+    [TestMethod]
+    public void HasRequiredDocumentationReturnsFalseForEnumMemberWithNestedInheritdocWithoutSemanticModel()
+    {
+        const string source = """
+                              enum Sample
+                              {
+                                  /// <remarks><inheritdoc/></remarks>
+                                  FirstValue
+                              }
+                              """;
+
+        var declaration = GetSingleEnumMemberDeclaration(source);
+        var hasRequiredDocumentation = DocumentationAnalysisUtilities.HasRequiredDocumentation(declaration, semanticModel: null, CancellationToken.None);
+
+        Assert.IsFalse(hasRequiredDocumentation);
     }
 
     #endregion // Tests

--- a/Reihitsu.Analyzer.Test/Core/XmlDocumentationExpanderTests.cs
+++ b/Reihitsu.Analyzer.Test/Core/XmlDocumentationExpanderTests.cs
@@ -1,0 +1,115 @@
+using System.Linq;
+using System.Xml.Linq;
+
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Analyzer.Core;
+
+namespace Reihitsu.Analyzer.Test.Core;
+
+/// <summary>
+/// Unit tests for <see cref="XmlDocumentationExpander"/>
+/// </summary>
+[TestClass]
+public class XmlDocumentationExpanderTests
+{
+    #region Tests
+
+    /// <summary>
+    /// Verifies that direct full elements are matched case-insensitively
+    /// </summary>
+    [TestMethod]
+    public void HasTagReturnsTrueForCaseInsensitiveDirectFullElement()
+    {
+        var documentationComment = GetDocumentationComment("<SuMmArY>Summary.</SuMmArY>");
+
+        Assert.IsTrue(XmlDocumentationExpander.HasTag(documentationComment, expandedDocumentation: null, tagName: "summary"));
+    }
+
+    /// <summary>
+    /// Verifies that direct empty elements are matched
+    /// </summary>
+    [TestMethod]
+    public void HasTagReturnsTrueForDirectEmptyElement()
+    {
+        var documentationComment = GetDocumentationComment("<inheritdoc/>");
+
+        Assert.IsTrue(XmlDocumentationExpander.HasTag(documentationComment, expandedDocumentation: null, tagName: "inheritdoc"));
+    }
+
+    /// <summary>
+    /// Verifies that nested full elements do not satisfy declaration-level tag queries
+    /// </summary>
+    [TestMethod]
+    public void HasTagReturnsFalseForNestedFullElement()
+    {
+        var documentationComment = GetDocumentationComment("<remarks><summary>Nested.</summary></remarks>");
+
+        Assert.IsFalse(XmlDocumentationExpander.HasTag(documentationComment, expandedDocumentation: null, tagName: "summary"));
+    }
+
+    /// <summary>
+    /// Verifies that nested empty elements do not satisfy declaration-level tag queries
+    /// </summary>
+    [TestMethod]
+    public void HasTagReturnsFalseForNestedEmptyElement()
+    {
+        var documentationComment = GetDocumentationComment("<remarks><inheritdoc/></remarks>");
+
+        Assert.IsFalse(XmlDocumentationExpander.HasTag(documentationComment, expandedDocumentation: null, tagName: "inheritdoc"));
+    }
+
+    /// <summary>
+    /// Verifies that expanded top-level elements remain eligible
+    /// </summary>
+    [TestMethod]
+    public void HasTagReturnsTrueForExpandedTopLevelElement()
+    {
+        var documentationComment = GetDocumentationComment("<remarks>Local remarks.</remarks>");
+        var expandedDocumentation = XElement.Parse("<member><summary>Expanded summary.</summary></member>");
+
+        Assert.IsTrue(XmlDocumentationExpander.HasTag(documentationComment, expandedDocumentation, "summary"));
+    }
+
+    /// <summary>
+    /// Verifies that expanded nested elements remain ineligible
+    /// </summary>
+    [TestMethod]
+    public void HasTagReturnsFalseForExpandedNestedElement()
+    {
+        var documentationComment = GetDocumentationComment("<remarks>Local remarks.</remarks>");
+        var expandedDocumentation = XElement.Parse("<member><remarks><summary>Nested.</summary></remarks></member>");
+
+        Assert.IsFalse(XmlDocumentationExpander.HasTag(documentationComment, expandedDocumentation, "summary"));
+    }
+
+    #endregion // Tests
+
+    #region Methods
+
+    /// <summary>
+    /// Gets a documentation comment containing the provided XML
+    /// </summary>
+    /// <param name="xml">XML content</param>
+    /// <returns>The documentation comment</returns>
+    private static DocumentationCommentTriviaSyntax GetDocumentationComment(string xml)
+    {
+        var source = $$"""
+                       /// {{xml}}
+                       class Sample
+                       {
+                       }
+                       """;
+        var declaration = CSharpSyntaxTree.ParseText(source)
+                                          .GetRoot()
+                                          .DescendantNodes()
+                                          .OfType<ClassDeclarationSyntax>()
+                                          .Single();
+
+        return DirectDocumentationSyntaxChecker.GetDocumentationComment(declaration);
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Analyzer.Test/Documentation/RH8030ElementDocumentationMustHaveSummaryTextAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH8030ElementDocumentationMustHaveSummaryTextAnalyzerTests.cs
@@ -74,6 +74,25 @@ public class RH8030ElementDocumentationMustHaveSummaryTextAnalyzerTests : Analyz
     }
 
     /// <summary>
+    /// Verifies that an empty summary nested in remarks is ignored
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticForEmptySummaryNestedInRemarks()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              /// <remarks><summary></summary></remarks>
+                              internal partial class TestClass
+                              {
+                              }
+                              """;
+
+        await Verify(source);
+    }
+
+    /// <summary>
     /// Verifies no diagnostics are reported when documentation mode is none
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer.Test/Documentation/RH8031ExtensionDeclarationsMustHaveSummaryTextAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH8031ExtensionDeclarationsMustHaveSummaryTextAnalyzerTests.cs
@@ -77,6 +77,26 @@ public class RH8031ExtensionDeclarationsMustHaveSummaryTextAnalyzerTests : Analy
     }
 
     /// <summary>
+    /// Verifies that a nested summary does not satisfy an extension declaration's documentation requirement
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticForSummaryNestedInRemarks()
+    {
+        const string source = """
+                              public static class Extensions
+                              {
+                                  /// <remarks><summary>Nested summary.</summary></remarks>
+                                  {|#0:extension|}(string value)
+                                  {
+                                  }
+                              }
+                              """;
+
+        await Verify(source, Diagnostics(RH8031ExtensionDeclarationsMustHaveSummaryTextAnalyzer.DiagnosticId, AnalyzerResources.RH8031MessageFormat));
+    }
+
+    /// <summary>
     /// Verifies no diagnostics are reported when documentation mode is none
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer.Test/Documentation/RH8102ElementParameterDocumentationMustMatchElementParametersAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH8102ElementParameterDocumentationMustMatchElementParametersAnalyzerTests.cs
@@ -40,6 +40,29 @@ public class RH8102ElementParameterDocumentationMustMatchElementParametersAnalyz
     }
 
     /// <summary>
+    /// Verifies that parameter tags nested in remarks are ignored
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticForParameterDocumentationNestedInRemarks()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              internal class TestClass
+                              {
+                                  /// <summary>Runs the method.</summary>
+                                  /// <remarks><param name="missingValue">Nested parameter.</param></remarks>
+                                  internal void TestMethod(int firstValue)
+                                  {
+                                  }
+                              }
+                              """;
+
+        await Verify(source);
+    }
+
+    /// <summary>
     /// Verifies no diagnostics are reported when documentation mode is none
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer.Test/Documentation/RH8103ElementParameterDocumentationMustDeclareParameterNameAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH8103ElementParameterDocumentationMustDeclareParameterNameAnalyzerTests.cs
@@ -39,6 +39,29 @@ public class RH8103ElementParameterDocumentationMustDeclareParameterNameAnalyzer
     }
 
     /// <summary>
+    /// Verifies that unnamed parameter tags nested in remarks are ignored
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticForUnnamedParameterNestedInRemarks()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              internal class TestClass
+                              {
+                                  /// <summary>Runs the method.</summary>
+                                  /// <remarks><param>Nested parameter.</param></remarks>
+                                  internal void TestMethod(int firstValue)
+                                  {
+                                  }
+                              }
+                              """;
+
+        await Verify(source);
+    }
+
+    /// <summary>
     /// Verifies no diagnostics are reported when documentation mode is none
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer.Test/Documentation/RH8104ElementParameterDocumentationMustHaveTextAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH8104ElementParameterDocumentationMustHaveTextAnalyzerTests.cs
@@ -39,6 +39,53 @@ public class RH8104ElementParameterDocumentationMustHaveTextAnalyzerTests : Anal
     }
 
     /// <summary>
+    /// Verifies that empty parameter tags nested in remarks are ignored
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticForEmptyParameterNestedInRemarks()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              internal class TestClass
+                              {
+                                  /// <summary>Runs the method.</summary>
+                                  /// <remarks><param name="firstValue"></param></remarks>
+                                  internal void TestMethod(int firstValue)
+                                  {
+                                  }
+                              }
+                              """;
+
+        await Verify(source);
+    }
+
+    /// <summary>
+    /// Verifies that direct parameter tags are analyzed without also analyzing nested matches
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyOnlyDirectEmptyParameterIsReportedBesideNestedMatch()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              internal class TestClass
+                              {
+                                  /// <summary>Runs the method.</summary>
+                                  /// <remarks><param name="nestedValue"></param></remarks>
+                                  /// {|#0:<param name="firstValue"></param>|}
+                                  internal void TestMethod(int firstValue)
+                                  {
+                                  }
+                              }
+                              """;
+
+        await Verify(source, Diagnostics(RH8104ElementParameterDocumentationMustHaveTextAnalyzer.DiagnosticId, AnalyzerResources.RH8104MessageFormat));
+    }
+
+    /// <summary>
     /// Verifies no diagnostics are reported when documentation mode is none
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer.Test/Documentation/RH8106ElementReturnValueDocumentationMustHaveTextAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH8106ElementReturnValueDocumentationMustHaveTextAnalyzerTests.cs
@@ -40,6 +40,30 @@ public class RH8106ElementReturnValueDocumentationMustHaveTextAnalyzerTests : An
     }
 
     /// <summary>
+    /// Verifies that an empty returns tag nested in remarks is ignored
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticForEmptyReturnsNestedInRemarks()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              internal class TestClass
+                              {
+                                  /// <summary>Gets the value.</summary>
+                                  /// <remarks><returns></returns></remarks>
+                                  internal int GetValue()
+                                  {
+                                      return 1;
+                                  }
+                              }
+                              """;
+
+        await Verify(source);
+    }
+
+    /// <summary>
     /// Verifies no diagnostics are reported when documentation mode is none
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer.Test/Documentation/RH8109GenericTypeParameterDocumentationMustMatchTypeParametersAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH8109GenericTypeParameterDocumentationMustMatchTypeParametersAnalyzerTests.cs
@@ -37,6 +37,26 @@ public class RH8109GenericTypeParameterDocumentationMustMatchTypeParametersAnaly
     }
 
     /// <summary>
+    /// Verifies that type parameter tags nested in remarks are ignored
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticForTypeParameterDocumentationNestedInRemarks()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              /// <summary>Represents a value.</summary>
+                              /// <remarks><typeparam name="TMissing">Nested parameter.</typeparam></remarks>
+                              internal class Repository<T>
+                              {
+                              }
+                              """;
+
+        await Verify(source);
+    }
+
+    /// <summary>
     /// Verifies no diagnostics are reported when documentation mode is none
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer.Test/Documentation/RH8110GenericTypeParameterDocumentationMustDeclareParameterNameAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH8110GenericTypeParameterDocumentationMustDeclareParameterNameAnalyzerTests.cs
@@ -36,6 +36,26 @@ public class RH8110GenericTypeParameterDocumentationMustDeclareParameterNameAnal
     }
 
     /// <summary>
+    /// Verifies that unnamed type parameter tags nested in remarks are ignored
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticForUnnamedTypeParameterNestedInRemarks()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              /// <summary>Represents a generic type.</summary>
+                              /// <remarks><typeparam>Nested parameter.</typeparam></remarks>
+                              internal class Repository<T>
+                              {
+                              }
+                              """;
+
+        await Verify(source);
+    }
+
+    /// <summary>
     /// Verifies no diagnostics are reported when documentation mode is none
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer.Test/Documentation/RH8111GenericTypeParameterDocumentationMustHaveTextAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH8111GenericTypeParameterDocumentationMustHaveTextAnalyzerTests.cs
@@ -36,6 +36,26 @@ public class RH8111GenericTypeParameterDocumentationMustHaveTextAnalyzerTests : 
     }
 
     /// <summary>
+    /// Verifies that empty type parameter tags nested in remarks are ignored
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticForEmptyTypeParameterNestedInRemarks()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              /// <summary>Represents a generic type.</summary>
+                              /// <remarks><typeparam name="T"></typeparam></remarks>
+                              internal class Repository<T>
+                              {
+                              }
+                              """;
+
+        await Verify(source);
+    }
+
+    /// <summary>
     /// Verifies no diagnostics are reported when documentation mode is none
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer.Test/Documentation/RH8203InheritdocMustBeUsedWithInheritingClassAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH8203InheritdocMustBeUsedWithInheritingClassAnalyzerTests.cs
@@ -65,6 +65,25 @@ public class RH8203InheritdocMustBeUsedWithInheritingClassAnalyzerTests : Analyz
     }
 
     /// <summary>
+    /// Verifies that inheritdoc nested in remarks is ignored
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticForInheritdocNestedInRemarks()
+    {
+        const string source = """
+                              namespace TestNamespace;
+
+                              /// <remarks><inheritdoc/></remarks>
+                              internal class TestClass
+                              {
+                              }
+                              """;
+
+        await Verify(source);
+    }
+
+    /// <summary>
     /// Verifies no diagnostics are reported when documentation mode is none
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer.Test/Documentation/RH8306PropertySummaryMustUseNounPhraseInsteadOfSentenceAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Documentation/RH8306PropertySummaryMustUseNounPhraseInsteadOfSentenceAnalyzerTests.cs
@@ -379,6 +379,27 @@ public class RH8306PropertySummaryMustUseNounPhraseInsteadOfSentenceAnalyzerTest
     }
 
     /// <summary>
+    /// Verifies that a sentence-like summary nested in remarks is ignored
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticForSentenceSummaryNestedInRemarks()
+    {
+        const string testData = """
+                                namespace TestNamespace
+                                {
+                                    internal class TestClass
+                                    {
+                                        /// <remarks><summary>Gets the value.</summary></remarks>
+                                        internal string TestProperty { get; }
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
     /// Verifies no diagnostics are reported when documentation mode is none
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer/Core/DirectDocumentationSyntaxChecker.cs
+++ b/Reihitsu.Analyzer/Core/DirectDocumentationSyntaxChecker.cs
@@ -42,15 +42,14 @@ internal static class DirectDocumentationSyntaxChecker
     }
 
     /// <summary>
-    /// Gets the first XML node with the specified tag name, falling back to nested nodes when the documentation
-    /// comment has no top-level match
+    /// Gets the first top-level XML node with the specified tag name
     /// </summary>
     /// <param name="documentationComment">Documentation comment</param>
     /// <param name="tagName">Tag name</param>
     /// <returns>The matching node, when present</returns>
-    internal static XmlNodeSyntax GetFirstTagIncludingNested(DocumentationCommentTriviaSyntax documentationComment, string tagName)
+    internal static XmlNodeSyntax GetFirstDirectTag(DocumentationCommentTriviaSyntax documentationComment, string tagName)
     {
-        return GetTagsIncludingNested(documentationComment, tagName).FirstOrDefault();
+        return GetDirectTags(documentationComment, tagName).FirstOrDefault();
     }
 
     /// <summary>
@@ -60,7 +59,7 @@ internal static class DirectDocumentationSyntaxChecker
     /// <param name="tagName">Tag name</param>
     /// <returns>The matching node, when present</returns>
     /// <remarks>
-    /// This searches the same nodes as <see cref="GetFirstTagIncludingNested"/> but skips anything inside a
+    /// This searches the nodes returned by <see cref="GetTagsIncludingNested"/> but skips anything inside a
     /// <c>&lt;code&gt;</c> or <c>&lt;example&gt;</c> sample, where a tag illustrates usage instead of documenting
     /// the member. Rules which remove the tag they find must use this overload, otherwise the fix deletes sample
     /// text. Tags nested in prose such as <c>&lt;summary&gt;</c> or <c>&lt;remarks&gt;</c> are still returned —
@@ -80,19 +79,16 @@ internal static class DirectDocumentationSyntaxChecker
     /// <returns>Matching nodes</returns>
     internal static ImmutableArray<XmlNodeSyntax> GetTagsIncludingNested(DocumentationCommentTriviaSyntax documentationComment, string tagName)
     {
-        if (documentationComment == null)
-        {
-            return [];
-        }
-
-        var directNodes = documentationComment.Content
-                                              .Where(obj => obj is XmlElementSyntax or XmlEmptyElementSyntax)
-                                              .Where(obj => string.Equals(XmlDocumentationElementOrderingUtilities.GetTagName(obj), tagName, StringComparison.OrdinalIgnoreCase))
-                                              .ToImmutableArray();
+        var directNodes = GetDirectTags(documentationComment, tagName);
 
         if (directNodes.Length > 0)
         {
             return directNodes;
+        }
+
+        if (documentationComment == null)
+        {
+            return [];
         }
 
         return documentationComment.DescendantNodes()
@@ -103,14 +99,33 @@ internal static class DirectDocumentationSyntaxChecker
     }
 
     /// <summary>
-    /// Determines whether the documentation contains the tag, at top level or nested
+    /// Gets the top-level XML nodes with the specified tag name in source order
     /// </summary>
     /// <param name="documentationComment">Documentation comment</param>
     /// <param name="tagName">Tag name</param>
-    /// <returns><see langword="true"/> if the tag exists</returns>
-    internal static bool HasTagIncludingNested(DocumentationCommentTriviaSyntax documentationComment, string tagName)
+    /// <returns>Matching top-level nodes</returns>
+    internal static ImmutableArray<XmlNodeSyntax> GetDirectTags(DocumentationCommentTriviaSyntax documentationComment, string tagName)
     {
-        return GetTagsIncludingNested(documentationComment, tagName).Length > 0;
+        if (documentationComment == null)
+        {
+            return [];
+        }
+
+        return documentationComment.Content
+                                   .Where(obj => obj is XmlElementSyntax or XmlEmptyElementSyntax)
+                                   .Where(obj => string.Equals(XmlDocumentationElementOrderingUtilities.GetTagName(obj), tagName, StringComparison.OrdinalIgnoreCase))
+                                   .ToImmutableArray();
+    }
+
+    /// <summary>
+    /// Determines whether the documentation contains a top-level tag
+    /// </summary>
+    /// <param name="documentationComment">Documentation comment</param>
+    /// <param name="tagName">Tag name</param>
+    /// <returns><see langword="true"/> if the top-level tag exists</returns>
+    internal static bool HasDirectTag(DocumentationCommentTriviaSyntax documentationComment, string tagName)
+    {
+        return GetDirectTags(documentationComment, tagName).Length > 0;
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer/Core/DocumentationAnalysisUtilities.cs
+++ b/Reihitsu.Analyzer/Core/DocumentationAnalysisUtilities.cs
@@ -307,6 +307,10 @@ internal static class DocumentationAnalysisUtilities
     /// <param name="semanticModel">Semantic model</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns><see langword="true"/> if the declaration is documented sufficiently</returns>
+    /// <remarks>
+    /// Top-level summary and inheritdoc tags qualify directly. Semantic expansion is considered when a model is
+    /// available
+    /// </remarks>
     internal static bool HasRequiredDocumentation(MemberDeclarationSyntax declaration, SemanticModel semanticModel, CancellationToken cancellationToken)
     {
         var documentationComment = DirectDocumentationSyntaxChecker.GetDocumentationComment(declaration);
@@ -316,14 +320,19 @@ internal static class DocumentationAnalysisUtilities
             return false;
         }
 
-        if (DirectDocumentationSyntaxChecker.HasTagIncludingNested(documentationComment, "inheritdoc"))
+        if (DirectDocumentationSyntaxChecker.HasDirectTag(documentationComment, "inheritdoc"))
         {
             return true;
         }
 
-        if (DirectDocumentationSyntaxChecker.HasTagIncludingNested(documentationComment, SummaryTagName))
+        if (DirectDocumentationSyntaxChecker.HasDirectTag(documentationComment, SummaryTagName))
         {
             return true;
+        }
+
+        if (semanticModel == null)
+        {
+            return false;
         }
 
         var expandedDocumentation = XmlDocumentationExpander.GetExpandedDocumentation(declaration, semanticModel, cancellationToken);
@@ -348,6 +357,10 @@ internal static class DocumentationAnalysisUtilities
     /// <param name="semanticModel">Semantic model</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns><see langword="true"/> if the declaration is documented sufficiently</returns>
+    /// <remarks>
+    /// Top-level summary and inheritdoc tags qualify directly. Semantic expansion is considered when a model is
+    /// available
+    /// </remarks>
     internal static bool HasRequiredDocumentation(EnumMemberDeclarationSyntax declaration, SemanticModel semanticModel, CancellationToken cancellationToken)
     {
         var documentationComment = DirectDocumentationSyntaxChecker.GetDocumentationComment(declaration);
@@ -357,14 +370,19 @@ internal static class DocumentationAnalysisUtilities
             return false;
         }
 
-        if (DirectDocumentationSyntaxChecker.HasTagIncludingNested(documentationComment, "inheritdoc"))
+        if (DirectDocumentationSyntaxChecker.HasDirectTag(documentationComment, "inheritdoc"))
         {
             return true;
         }
 
-        if (DirectDocumentationSyntaxChecker.HasTagIncludingNested(documentationComment, SummaryTagName))
+        if (DirectDocumentationSyntaxChecker.HasDirectTag(documentationComment, SummaryTagName))
         {
             return true;
+        }
+
+        if (semanticModel == null)
+        {
+            return false;
         }
 
         var expandedDocumentation = XmlDocumentationExpander.GetExpandedDocumentation(declaration, semanticModel, cancellationToken);

--- a/Reihitsu.Analyzer/Core/XmlDocumentationExpander.cs
+++ b/Reihitsu.Analyzer/Core/XmlDocumentationExpander.cs
@@ -44,7 +44,7 @@ internal static class XmlDocumentationExpander
     }
 
     /// <summary>
-    /// Determines whether the documentation contains a tag, considering expanded include XML
+    /// Determines whether the documentation contains a top-level tag, considering expanded include XML
     /// </summary>
     /// <param name="documentationComment">Documentation comment</param>
     /// <param name="expandedDocumentation">Expanded documentation</param>
@@ -52,7 +52,7 @@ internal static class XmlDocumentationExpander
     /// <returns><see langword="true"/> if the tag exists</returns>
     internal static bool HasTag(DocumentationCommentTriviaSyntax documentationComment, XElement expandedDocumentation, string tagName)
     {
-        if (DirectDocumentationSyntaxChecker.HasTagIncludingNested(documentationComment, tagName))
+        if (DirectDocumentationSyntaxChecker.HasDirectTag(documentationComment, tagName))
         {
             return true;
         }

--- a/Reihitsu.Analyzer/Data/ConfigurationManager.cs
+++ b/Reihitsu.Analyzer/Data/ConfigurationManager.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Text;
 using System.Text.Json;
 
@@ -44,9 +45,12 @@ internal static class ConfigurationManager
     /// </summary>
     /// <param name="additionalFiles">Additional files</param>
     /// <returns>Configuration load result</returns>
+    /// <remarks>
+    /// The first additional file whose final path segment equals <c>reihitsu.json</c>, case-insensitively, is loaded
+    /// </remarks>
     public static ConfigurationLoadResult GetConfiguration(ImmutableArray<AdditionalText> additionalFiles)
     {
-        var file = additionalFiles.FirstOrDefault(currentFile => currentFile.Path.EndsWith(ConfigurationFileName, StringComparison.OrdinalIgnoreCase));
+        var file = additionalFiles.FirstOrDefault(currentFile => string.Equals(Path.GetFileName(currentFile.Path), ConfigurationFileName, StringComparison.OrdinalIgnoreCase));
 
         if (file == null)
         {

--- a/Reihitsu.Analyzer/Rules/Documentation/RH8030ElementDocumentationMustHaveSummaryTextAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH8030ElementDocumentationMustHaveSummaryTextAnalyzer.cs
@@ -65,7 +65,7 @@ public class RH8030ElementDocumentationMustHaveSummaryTextAnalyzer : DiagnosticA
             return;
         }
 
-        var summaryNode = DirectDocumentationSyntaxChecker.GetFirstTagIncludingNested(documentationComment, "summary");
+        var summaryNode = DirectDocumentationSyntaxChecker.GetFirstDirectTag(documentationComment, "summary");
 
         if (summaryNode == null)
         {

--- a/Reihitsu.Analyzer/Rules/Documentation/RH8031ExtensionDeclarationsMustHaveSummaryTextAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH8031ExtensionDeclarationsMustHaveSummaryTextAnalyzer.cs
@@ -58,7 +58,7 @@ public class RH8031ExtensionDeclarationsMustHaveSummaryTextAnalyzer : Diagnostic
             return;
         }
 
-        var summaryNode = DirectDocumentationSyntaxChecker.GetFirstTagIncludingNested(documentationComment, "summary");
+        var summaryNode = DirectDocumentationSyntaxChecker.GetFirstDirectTag(documentationComment, "summary");
 
         if (summaryNode == null
             || DocumentationAnalysisUtilities.IsEmpty(summaryNode))

--- a/Reihitsu.Analyzer/Rules/Documentation/RH8102ElementParameterDocumentationMustMatchElementParametersAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH8102ElementParameterDocumentationMustMatchElementParametersAnalyzer.cs
@@ -59,7 +59,7 @@ public class RH8102ElementParameterDocumentationMustMatchElementParametersAnalyz
             return;
         }
 
-        var paramNodes = DirectDocumentationSyntaxChecker.GetTagsIncludingNested(documentationComment, "param");
+        var paramNodes = DirectDocumentationSyntaxChecker.GetDirectTags(documentationComment, "param");
 
         if (paramNodes.IsDefaultOrEmpty)
         {

--- a/Reihitsu.Analyzer/Rules/Documentation/RH8103ElementParameterDocumentationMustDeclareParameterNameAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH8103ElementParameterDocumentationMustDeclareParameterNameAnalyzer.cs
@@ -55,7 +55,7 @@ public class RH8103ElementParameterDocumentationMustDeclareParameterNameAnalyzer
             return;
         }
 
-        foreach (var paramNode in DirectDocumentationSyntaxChecker.GetTagsIncludingNested(documentationComment, "param")
+        foreach (var paramNode in DirectDocumentationSyntaxChecker.GetDirectTags(documentationComment, "param")
                                                                   .Where(paramNode => string.IsNullOrWhiteSpace(DocumentationAnalysisUtilities.GetNameAttributeValue(paramNode))))
         {
             context.ReportDiagnostic(CreateDiagnostic(paramNode.GetLocation()));

--- a/Reihitsu.Analyzer/Rules/Documentation/RH8104ElementParameterDocumentationMustHaveTextAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH8104ElementParameterDocumentationMustHaveTextAnalyzer.cs
@@ -55,7 +55,7 @@ public class RH8104ElementParameterDocumentationMustHaveTextAnalyzer : Diagnosti
             return;
         }
 
-        foreach (var paramNode in DirectDocumentationSyntaxChecker.GetTagsIncludingNested(documentationComment, "param")
+        foreach (var paramNode in DirectDocumentationSyntaxChecker.GetDirectTags(documentationComment, "param")
                                                                   .Where(paramNode => DocumentationAnalysisUtilities.IsEmpty(paramNode)))
         {
             context.ReportDiagnostic(CreateDiagnostic(paramNode.GetLocation()));

--- a/Reihitsu.Analyzer/Rules/Documentation/RH8106ElementReturnValueDocumentationMustHaveTextAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH8106ElementReturnValueDocumentationMustHaveTextAnalyzer.cs
@@ -55,7 +55,7 @@ public class RH8106ElementReturnValueDocumentationMustHaveTextAnalyzer : Diagnos
             return;
         }
 
-        var returnsNode = DirectDocumentationSyntaxChecker.GetFirstTagIncludingNested(documentationComment, "returns");
+        var returnsNode = DirectDocumentationSyntaxChecker.GetFirstDirectTag(documentationComment, "returns");
 
         if (returnsNode == null
             || DocumentationAnalysisUtilities.IsEmpty(returnsNode) == false)

--- a/Reihitsu.Analyzer/Rules/Documentation/RH8109GenericTypeParameterDocumentationMustMatchTypeParametersAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH8109GenericTypeParameterDocumentationMustMatchTypeParametersAnalyzer.cs
@@ -59,7 +59,7 @@ public class RH8109GenericTypeParameterDocumentationMustMatchTypeParametersAnaly
             return;
         }
 
-        var typeParameterNodes = DirectDocumentationSyntaxChecker.GetTagsIncludingNested(documentationComment, "typeparam");
+        var typeParameterNodes = DirectDocumentationSyntaxChecker.GetDirectTags(documentationComment, "typeparam");
 
         if (typeParameterNodes.IsDefaultOrEmpty)
         {

--- a/Reihitsu.Analyzer/Rules/Documentation/RH8110GenericTypeParameterDocumentationMustDeclareParameterNameAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH8110GenericTypeParameterDocumentationMustDeclareParameterNameAnalyzer.cs
@@ -55,7 +55,7 @@ public class RH8110GenericTypeParameterDocumentationMustDeclareParameterNameAnal
             return;
         }
 
-        var unnamedTypeParameterNodes = DirectDocumentationSyntaxChecker.GetTagsIncludingNested(documentationComment, "typeparam").Where(typeParameterNode => string.IsNullOrWhiteSpace(DocumentationAnalysisUtilities.GetNameAttributeValue(typeParameterNode)));
+        var unnamedTypeParameterNodes = DirectDocumentationSyntaxChecker.GetDirectTags(documentationComment, "typeparam").Where(typeParameterNode => string.IsNullOrWhiteSpace(DocumentationAnalysisUtilities.GetNameAttributeValue(typeParameterNode)));
 
         foreach (var typeParameterNode in unnamedTypeParameterNodes)
         {

--- a/Reihitsu.Analyzer/Rules/Documentation/RH8111GenericTypeParameterDocumentationMustHaveTextAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH8111GenericTypeParameterDocumentationMustHaveTextAnalyzer.cs
@@ -55,7 +55,7 @@ public class RH8111GenericTypeParameterDocumentationMustHaveTextAnalyzer : Diagn
             return;
         }
 
-        var emptyTypeParameterNodes = DirectDocumentationSyntaxChecker.GetTagsIncludingNested(documentationComment, "typeparam").Where(typeParameterNode => DocumentationAnalysisUtilities.IsEmpty(typeParameterNode));
+        var emptyTypeParameterNodes = DirectDocumentationSyntaxChecker.GetDirectTags(documentationComment, "typeparam").Where(typeParameterNode => DocumentationAnalysisUtilities.IsEmpty(typeParameterNode));
 
         foreach (var typeParameterNode in emptyTypeParameterNodes)
         {

--- a/Reihitsu.Analyzer/Rules/Documentation/RH8203InheritdocMustBeUsedWithInheritingClassAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH8203InheritdocMustBeUsedWithInheritingClassAnalyzer.cs
@@ -55,7 +55,7 @@ public class RH8203InheritdocMustBeUsedWithInheritingClassAnalyzer : DiagnosticA
             return;
         }
 
-        var inheritdocNode = DirectDocumentationSyntaxChecker.GetFirstTagIncludingNested(documentationComment, "inheritdoc");
+        var inheritdocNode = DirectDocumentationSyntaxChecker.GetFirstDirectTag(documentationComment, "inheritdoc");
         var expandedDocumentation = XmlDocumentationExpander.GetExpandedDocumentation(declaration, context.SemanticModel, context.CancellationToken);
         var expandedInheritdocElement = XmlDocumentationExpander.GetFirstExpandedElement(expandedDocumentation, "inheritdoc");
 

--- a/Reihitsu.Analyzer/Rules/Documentation/RH8306PropertySummaryMustUseNounPhraseInsteadOfSentenceAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Documentation/RH8306PropertySummaryMustUseNounPhraseInsteadOfSentenceAnalyzer.cs
@@ -182,7 +182,7 @@ public class RH8306PropertySummaryMustUseNounPhraseInsteadOfSentenceAnalyzer : D
         var documentationComment = DirectDocumentationSyntaxChecker.GetDocumentationComment(propertyDeclaration);
 
         if (documentationComment == null
-            || DirectDocumentationSyntaxChecker.GetFirstTagIncludingNested(documentationComment, "summary") is not XmlElementSyntax summaryElement)
+            || DirectDocumentationSyntaxChecker.GetFirstDirectTag(documentationComment, "summary") is not XmlElementSyntax summaryElement)
         {
             return;
         }


### PR DESCRIPTION
## Summary

Make declaration-level documentation analyzers inspect only top-level XML tags while preserving the intentional nested-prose behavior of RH8107 and RH8202. Restrict configuration discovery to an exact final `reihitsu.json` path segment and cover the affected consumers and predicate boundaries.

## Why

Nested documentation tags could silently satisfy or trigger direct-tag rules, while similarly named files could be loaded as repository configuration without indication.

## Linked issues

Closes #465

## Review notes

This changes shared analyzer predicates without changing diagnostic metadata, public API, dependencies, formatter behavior, or code-fix applicability. RH8107 and RH8202 remain on their sample-aware nested lookup. The local Release build passed; final validation is delegated to CI. One low-severity formatting finding remains in the new direct-helper test: there is no blank separator between its final using directive and file-scoped namespace.

## Follow-up work

Deferred analyzer-infrastructure hygiene remains tracked in #632.