### PR TITLE
Scope the indexer argument collapse guard to the bracket interior

### DIFF
--- a/Reihitsu.Analyzer.CodeFixes/Rules/Layout/RH5307IndexerBracketedArgumentsShouldBeSingleLinedCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Layout/RH5307IndexerBracketedArgumentsShouldBeSingleLinedCodeFixProvider.cs
@@ -50,9 +50,14 @@ public class RH5307IndexerBracketedArgumentsShouldBeSingleLinedCodeFixProvider :
     /// </summary>
     /// <param name="bracketedArgumentList">Bracketed argument list</param>
     /// <returns><see langword="true"/> if collapsing is safe; otherwise, <see langword="false"/></returns>
+    /// <remarks>
+    /// The interior-scoped check mirrors the analyzer, so the fix stays offered for exactly the
+    /// diagnostics the analyzer reports. The rewrite only joins the gaps between the brackets, which
+    /// leaves a comment behind the closing bracket untouched (see issue #610)
+    /// </remarks>
     private static bool CanSafelyCollapseToSingleLine(BracketedArgumentListSyntax bracketedArgumentList)
     {
-        return SyntaxNodeUtilities.ContainsCommentOrDirective(bracketedArgumentList) == false
+        return SyntaxNodeUtilities.InteriorContainsCommentOrDirective(bracketedArgumentList) == false
                && SyntaxNodeUtilities.AreAllSingleLine(bracketedArgumentList.Arguments);
     }
 

--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5307IndexerBracketedArgumentsShouldBeSingleLinedFormatterTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5307IndexerBracketedArgumentsShouldBeSingleLinedFormatterTests.cs
@@ -48,5 +48,61 @@ public class RH5307IndexerBracketedArgumentsShouldBeSingleLinedFormatterTests : 
                                  Diagnostics(RH5307IndexerBracketedArgumentsShouldBeSingleLinedAnalyzer.DiagnosticId, AnalyzerResources.RH5307MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies that the formatter collapses multiline indexer arguments that carry a comment behind
+    /// the closing bracket, and that analyzer and formatter agree on that decision under both line
+    /// endings (issue #610)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFormatterFixesMultilineIndexerArgumentsWithTrailingComment()
+    {
+        const string input = """
+                             internal class Example
+                             {
+                                 private static int Method(int[] values)
+                                 {
+                                     return {|#0:values[
+                                         0]|} /* note */ + 2;
+                                 }
+                             }
+                             """;
+        const string fixedData = """
+                                 internal class Example
+                                 {
+                                     private static int Method(int[] values)
+                                     {
+                                         return values[0] /* note */ + 2;
+                                     }
+                                 }
+                                 """;
+
+        await VerifyFormatterFixAndIdempotency(input,
+                                               fixedData,
+                                               Diagnostics(RH5307IndexerBracketedArgumentsShouldBeSingleLinedAnalyzer.DiagnosticId, AnalyzerResources.RH5307MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that the formatter leaves an indexer argument list alone when a comment sits between
+    /// the brackets, because that gap is crossed by the collapse (issue #610)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFormatterKeepsIndexerArgumentsWithInteriorComment()
+    {
+        const string input = """
+                             internal class Example
+                             {
+                                 private static int Method(int[] values)
+                                 {
+                                     return values[ /* note */
+                                                   0] + 2;
+                                 }
+                             }
+                             """;
+
+        await VerifyFormatterStability(input);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatting/RH5307IndexerBracketedArgumentsShouldBeSingleLinedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH5307IndexerBracketedArgumentsShouldBeSingleLinedAnalyzerTests.cs
@@ -50,6 +50,62 @@ public class RH5307IndexerBracketedArgumentsShouldBeSingleLinedAnalyzerTests : A
     }
 
     /// <summary>
+    /// Verifies that a comment written behind the closing bracket does not suppress the diagnostic or
+    /// the code fix. The comment sits outside the interior the fix rewrites, so it is not a join
+    /// barrier (issue #610)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticAndCodeFixForMultilineIndexerArgumentsWithTrailingComment()
+    {
+        const string testData = """
+                                internal class Example
+                                {
+                                    private static int Method(int[] values)
+                                    {
+                                        return {|#0:values[
+                                            0]|} /* note */ + 2;
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class Example
+                                 {
+                                     private static int Method(int[] values)
+                                     {
+                                         return values[0] /* note */ + 2;
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData,
+                     fixedData,
+                     Diagnostics(RH5307IndexerBracketedArgumentsShouldBeSingleLinedAnalyzer.DiagnosticId, AnalyzerResources.RH5307MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that a comment written between the brackets still suppresses the diagnostic, because
+    /// the collapse would have to cross it (issue #610)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticForIndexerArgumentsWithInteriorComment()
+    {
+        const string testData = """
+                                internal class Example
+                                {
+                                    private static int Method(int[] values)
+                                    {
+                                        return values[ /* note */
+                                                      0] + 2;
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
     /// Verifies that single-line indexer bracketed arguments remain valid
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer/Rules/Layout/RH5307IndexerBracketedArgumentsShouldBeSingleLinedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Layout/RH5307IndexerBracketedArgumentsShouldBeSingleLinedAnalyzer.cs
@@ -53,9 +53,16 @@ public class RH5307IndexerBracketedArgumentsShouldBeSingleLinedAnalyzer : Diagno
     /// </summary>
     /// <param name="bracketedArgumentList">Bracketed argument list</param>
     /// <returns><see langword="true"/> if collapsing is safe; otherwise, <see langword="false"/></returns>
+    /// <remarks>
+    /// The interior-scoped check matches the region the code fix and the formatter actually rewrite,
+    /// which runs from the opening to the closing bracket. A comment behind the closing bracket lies
+    /// outside it and must not suppress the diagnostic (see issue #610). The reported location ends at
+    /// the closing bracket as well, so narrowing the guard cannot produce a diagnostic the fix is
+    /// unable to clear
+    /// </remarks>
     private static bool CanSafelyCollapseToSingleLine(BracketedArgumentListSyntax bracketedArgumentList)
     {
-        return SyntaxNodeUtilities.ContainsCommentOrDirective(bracketedArgumentList) == false
+        return SyntaxNodeUtilities.InteriorContainsCommentOrDirective(bracketedArgumentList) == false
                && SyntaxNodeUtilities.AreAllSingleLine(bracketedArgumentList.Arguments);
     }
 

--- a/Reihitsu.Formatter.Test/Regression/LineBreaks/BracketedArgumentTrailingCommentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/LineBreaks/BracketedArgumentTrailingCommentTests.cs
@@ -1,0 +1,50 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Formatter.Test.Helpers;
+
+namespace Reihitsu.Formatter.Test.Regression.LineBreaks;
+
+/// <summary>
+/// Regression tests for issue #610: a comment that trails the closing bracket of an indexer argument
+/// list sits outside the interior the single-line collapse rewrites, so it must not block that
+/// collapse. Trivia the collapse actually crosses - between the brackets - remains a join barrier
+/// </summary>
+[TestClass]
+public class BracketedArgumentTrailingCommentTests : FormatterTestsBase
+{
+    #region Methods
+
+    /// <summary>
+    /// Verifies that a block comment trailing the closing bracket does not block the collapse of a
+    /// multiline indexer argument list
+    /// </summary>
+    [TestMethod]
+    public void BlockCommentAfterClosingBracketDoesNotBlockTheCollapse()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 private int Get(int[] a)
+                                 {
+                                     return a[
+                                         0] /* note */ + 2;
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    private int Get(int[] a)
+                                    {
+                                        return a[0] /* note */ + 2;
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Formatter.Test/Regression/LineBreaks/BracketedArgumentTrailingCommentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/LineBreaks/BracketedArgumentTrailingCommentTests.cs
@@ -46,5 +46,183 @@ public class BracketedArgumentTrailingCommentTests : FormatterTestsBase
         AssertRuleResult(input, expected);
     }
 
+    /// <summary>
+    /// Verifies that a single-line comment trailing the closing bracket does not block the collapse.
+    /// The comment runs to the end of the line, so it is the shape most easily mistaken for interior
+    /// trivia
+    /// </summary>
+    [TestMethod]
+    public void LineCommentAfterClosingBracketDoesNotBlockTheCollapse()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 private int Get(int[] a)
+                                 {
+                                     return a[
+                                         0] // note
+                                            + 2;
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    private int Get(int[] a)
+                                    {
+                                        return a[0] // note
+                                               + 2;
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a comment trailing the closing bracket does not block the collapse of a
+    /// multi-argument indexer list, where the collapse additionally crosses the separator gaps
+    /// </summary>
+    [TestMethod]
+    public void CommentAfterClosingBracketDoesNotBlockTheMultiArgumentCollapse()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 private int Get(int[,] a)
+                                 {
+                                     return a[
+                                         1,
+                                         2] /* note */ + 2;
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    private int Get(int[,] a)
+                                    {
+                                        return a[1, 2] /* note */ + 2;
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a comment written between the brackets still blocks the collapse. This gap is
+    /// crossed by the rewrite, so it remains a join barrier and marks the other side of the boundary.
+    /// The continuation indentation in the expected text is owned by the indentation phase and is not
+    /// what this test pins - the argument staying on its own line is
+    /// </summary>
+    [TestMethod]
+    public void CommentBetweenTheBracketsStillBlocksTheCollapse()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 private int Get(int[] a)
+                                 {
+                                     return a[ /* note */
+                                         0] + 2;
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    private int Get(int[] a)
+                                    {
+                                        return a[ /* note */
+                                                 0] + 2;
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a comment written before the closing bracket still blocks the collapse. The
+    /// closing bracket is pulled up by the rewrite, so trivia in front of it is crossed
+    /// </summary>
+    [TestMethod]
+    public void CommentBeforeTheClosingBracketStillBlocksTheCollapse()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 private int Get(int[] a)
+                                 {
+                                     return a[
+                                         0 /* note */] + 2;
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    private int Get(int[] a)
+                                    {
+                                        return a[
+                                                 0 /* note */] + 2;
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a directive written between the brackets still blocks the collapse
+    /// </summary>
+    [TestMethod]
+    public void DirectiveBetweenTheBracketsStillBlocksTheCollapse()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 private int Get(int[] a)
+                                 {
+                                     return a[
+                             #if DEBUG
+                                         0
+                             #else
+                                         1
+                             #endif
+                                         ] + 2;
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    private int Get(int[] a)
+                                    {
+                                        return a[
+                                #if DEBUG
+                                            0
+                                #else
+                                                 1
+                                #endif
+                                                 ] + 2;
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
     #endregion // Methods
 }

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/Rewriter/LineBreakListRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/Rewriter/LineBreakListRewriter.cs
@@ -198,6 +198,14 @@ internal sealed class LineBreakListRewriter : CSharpSyntaxRewriter
     /// </summary>
     /// <param name="node">The bracketed argument list node</param>
     /// <returns><see langword="true"/> if collapsing is safe; otherwise, <see langword="false"/></returns>
+    /// <remarks>
+    /// The interior-scoped check is deliberate. The collapse only rewrites the gaps between the
+    /// brackets - opening bracket to first argument, the separators, and last argument to closing
+    /// bracket - so a comment trailing the closing bracket is never crossed and must not force the
+    /// list apart. RH5307 applies the same interior-scoped guard in its analyzer and its code fix, so
+    /// all three surfaces agree on the decision (see issue #610, and issue #604 for the auto-property
+    /// counterpart)
+    /// </remarks>
     private static bool CanSafelyCollapseBracketedArguments(BracketedArgumentListSyntax node)
     {
         if (node.Parent is not ElementAccessExpressionSyntax and not ImplicitElementAccessSyntax)
@@ -205,7 +213,7 @@ internal sealed class LineBreakListRewriter : CSharpSyntaxRewriter
             return false;
         }
 
-        if (SyntaxNodeUtilities.ContainsCommentOrDirective(node))
+        if (SyntaxNodeUtilities.InteriorContainsCommentOrDirective(node))
         {
             return false;
         }

--- a/documentation/rules/RH5307.md
+++ b/documentation/rules/RH5307.md
@@ -21,6 +21,10 @@ Collapse indexer arguments so that `[` and `]` and all arguments are on the same
 
 The code fix reformats the surrounding code automatically using the formatter.
 
+Indexer argument lists are not reported when a comment or directive sits between the brackets, because the collapse would have to join across that trivia. The formatter refuses that rewrite, so the rule stays silent rather than reporting a list that cannot be collapsed.
+
+A comment that follows the closing bracket is not crossed by the collapse, so it does not exempt the list. `values[0] /* note */ + 2` keeps the comment where it was written, and the multi-line form of the same expression is reported and collapsed with the comment left in place.
+
 ## Examples
 
 ### Violation


### PR DESCRIPTION
## Summary

Narrow the comment/directive guard that decides the single-line collapse of an indexer argument list from the node's full span to its interior, in all three surfaces that share it: the formatter's `LineBreakListRewriter`, the RH5307 analyzer, and the RH5307 code fix.

## Why

All three called `SyntaxNodeUtilities.ContainsCommentOrDirective`, which walks the node's full trivia and therefore counts a comment trailing the closing `]`. The collapse only rewrites gaps between the brackets — opening bracket to first argument, the separators, and last argument to closing bracket — so that trailing trivia is never crossed and must not block the collapse. This is the bracketed-argument counterpart of the auto-property accessor-list defect fixed in #604.

## Linked issues

Closes #610

## Review notes

The guard moves, so the region it no longer covers is the reviewable part. Two regions drop out of scope, and neither is crossed by the rewrite: the leading trivia of `[` (the opening bracket is never moved) and the trailing trivia of `]` (the closing bracket is pulled up by rewriting its *leading* trivia). Every gap the collapse actually joins lies inside `node.Span`, which is what the interior predicate checks.

The issue asked whether narrowing could strand a permanent diagnostic, as it did in #604. It cannot here: RH5307 reports at `elementAccessExpression.GetLocation()` / `bracketedArgumentList.GetLocation()`, and `GetLocation()` returns `Span`, which ends at the closing `]` — the trailing comment lies outside the reported span. Analyzer and formatter also agree on the multi-line test itself, since `AreAllSingleLine` and `LineBreakDetection.IsMultiLine` are both `Span`-based. No extra gap guard was needed.

Tests cover both sides of the moved boundary: a comment after `]` (block and line form, single- and multi-argument) now collapses, while a comment or `#if` directive between the brackets still blocks it. The analyzer/formatter parity case runs through `VerifyFormatterFixAndIdempotency`, so it is checked under LF and CRLF and over a second pass.

The three "still blocks" fixtures pin the continuation indentation produced by the indentation phase, which is a different phase's policy and unchanged by this diff.

## Follow-up work

#650 — `RH5101`, `RH5102` and `RH5109` guard argument and parameter lists with the same full-span predicate for rewrites that are likewise interior-only. Filed separately because the guard there lives only in the code fix while the analyzers do not share it, so the symptom is a diagnostic with no offered fix rather than a missed collapse. Pre-existing and deliberately out of scope here.
