### PR TITLE
Scope comment guards to the region each rewrite writes, and record code-fix coverage policy

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,10 +31,19 @@ dotnet run --project Reihitsu.Cli -- <changed-path-1> [<changed-path-2> ...]
 ```
 
 - Do not consider a change complete until all relevant unit tests pass.
-- For new analyzer rules, only implement a code fix when it can be delivered comprehensively. If only light or partial support is possible, omit the code fix.
 - For analyzer bug fixes, reproduce the bug in a unit test before changing production code.
 - For formatter bug fixes, add a regression test first before implementing the fix.
 - For analyzer tests, prefer many small, focused tests over one large test with many cases.
+
+## Code-fix coverage
+
+A code fix is never required to correct every case its diagnostic reports. Some inputs can only be corrected by hand, and reporting the diagnostic while offering no action is a complete, intended outcome for them — not a defect, and not by itself a reason to raise a report's severity.
+
+- A reported diagnostic with no available fix is a supported end state. "The diagnostic has no fix here" is an observation that still has to be argued on its merits; it is never a defect on its own.
+- For new analyzer rules, only implement a code fix when it can be delivered comprehensively. If only light or partial support is possible, omit the code fix.
+- Prefer no fix over an unsafe one. A rewrite that would drop, reorder, or relocate user-authored comments, directives, disabled text, or literals must withhold itself for that input.
+- None of this licenses an imprecise guard. A fix that refuses inputs it could rewrite safely is still worth narrowing, but the defect there is the guard's scope — how much safe ground it gives away — and not the bare fact that a diagnostic went unfixed.
+- When a rule's fix deliberately leaves a class of inputs to manual correction, record that in `documentation/rules/RH####.md` so the gap reads as a decision rather than an oversight.
 
 ## Custom agents
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,10 +39,19 @@ Focused runs:
 ```
 
 - Do not consider a change complete until all relevant unit tests pass.
-- For new analyzer rules, only implement a code fix when it can be delivered comprehensively. If only light or partial support is possible, omit the code fix.
 - For analyzer bug fixes, reproduce the bug in a unit test before changing production code.
 - For formatter bug fixes, add a regression test first before implementing the fix.
 - For analyzer tests, prefer many small, focused tests over one large test with many cases.
+
+## Code-fix coverage
+
+A code fix is never required to correct every case its diagnostic reports. Some inputs can only be corrected by hand, and reporting the diagnostic while offering no action is a complete, intended outcome for them — not a defect, and not by itself a reason to raise a report's severity.
+
+- A reported diagnostic with no available fix is a supported end state. "The diagnostic has no fix here" is an observation that still has to be argued on its merits; it is never a defect on its own.
+- For new analyzer rules, only implement a code fix when it can be delivered comprehensively. If only light or partial support is possible, omit the code fix.
+- Prefer no fix over an unsafe one. A rewrite that would drop, reorder, or relocate user-authored comments, directives, disabled text, or literals must withhold itself for that input.
+- None of this licenses an imprecise guard. A fix that refuses inputs it could rewrite safely is still worth narrowing, but the defect there is the guard's scope — how much safe ground it gives away — and not the bare fact that a diagnostic went unfixed.
+- When a rule's fix deliberately leaves a class of inputs to manual correction, record that in `documentation/rules/RH####.md` so the gap reads as a decision rather than an oversight.
 
 ## Codex command playbooks
 
@@ -65,6 +74,16 @@ The repository defines Codex-oriented command playbooks under `.codex/commands`:
 | `/gh-rereview` | Re-review a pull request after findings were addressed |
 
 Use the command playbook that matches the task so the repository-specific workflow and checklist are applied from the start.
+
+## Issue intake — question the report
+
+Issues here are filed under the maintainer's GitHub account, but many of them are generated — drafted by an agent from a source audit rather than observed by a person running the tool. The account name is not evidence that a human confirmed the behavior. Treat every issue as a hypothesis to be checked, never as a specification to be executed, and apply that regardless of who filed it:
+
+- Verify the premise before implementing it. The reproduction gate confirms a bug report's reported behavior; a report that says it was derived from reading code rather than from running it has confirmed nothing yet, however precise its file-and-line references look.
+- Check the reasoning, not only the example. A report can reproduce and still be wrong about why it matters, how far it generalizes, or how severe it is. Its severity argument is a claim like any other and gets tested like one.
+- Reject a framing the repository's own policy contradicts. A report that treats a diagnostic without a fix as a defect in itself is arguing against `Code-fix coverage` above, and that argument does not become correct by being written in an issue.
+- Fix the defect that exists, not the one the issue asserts. Where the analysis and the report disagree, implement the analysis and state plainly in the pull request how the shipped change differs from what was requested.
+- Say so when a report turns out to be wrong, overstated, or already-correct behavior. Downgrading, narrowing, or closing it is a legitimate result of a run — that is what the `NOT REPRODUCED` path is for.
 
 ## GitHub workflow stages
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,10 +30,19 @@ scripts/format.sh <changed-path-1> [<changed-path-2> ...]
 ```
 
 - Do not consider a change complete until all relevant unit tests pass.
-- For new analyzer rules, only implement a code fix when it can be delivered comprehensively. If only light or partial support is possible, omit the code fix.
 - For analyzer bug fixes, reproduce the bug in a unit test before changing production code.
 - For formatter bug fixes, add a regression test first before implementing the fix.
 - For analyzer tests, prefer many small, focused tests over one large test with many cases.
+
+## Code-fix coverage
+
+A code fix is never required to correct every case its diagnostic reports. Some inputs can only be corrected by hand, and reporting the diagnostic while offering no action is a complete, intended outcome for them — not a defect, and not by itself a reason to raise a report's severity.
+
+- A reported diagnostic with no available fix is a supported end state. "The diagnostic has no fix here" is an observation that still has to be argued on its merits; it is never a defect on its own.
+- For new analyzer rules, only implement a code fix when it can be delivered comprehensively. If only light or partial support is possible, omit the code fix.
+- Prefer no fix over an unsafe one. A rewrite that would drop, reorder, or relocate user-authored comments, directives, disabled text, or literals must withhold itself for that input.
+- None of this licenses an imprecise guard. A fix that refuses inputs it could rewrite safely is still worth narrowing, but the defect there is the guard's scope — how much safe ground it gives away — and not the bare fact that a diagnostic went unfixed.
+- When a rule's fix deliberately leaves a class of inputs to manual correction, record that in `documentation/rules/RH####.md` so the gap reads as a decision rather than an oversight.
 
 ## Custom slash commands
 
@@ -53,6 +62,16 @@ The repository defines custom Claude slash commands under `.claude/commands`:
 | `/gh-preflight` | Run the read-only quality gate before external review |
 
 Use the command that matches the task so the repository-specific workflow and checklist are applied from the start.
+
+## Issue intake — question the report
+
+Issues here are filed under the maintainer's GitHub account, but many of them are generated — drafted by an agent from a source audit rather than observed by a person running the tool. The account name is not evidence that a human confirmed the behavior. Treat every issue as a hypothesis to be checked, never as a specification to be executed, and apply that regardless of who filed it:
+
+- Verify the premise before implementing it. The reproduction gate confirms a bug report's reported behavior; a report that says it was derived from reading code rather than from running it has confirmed nothing yet, however precise its file-and-line references look.
+- Check the reasoning, not only the example. A report can reproduce and still be wrong about why it matters, how far it generalizes, or how severe it is. Its severity argument is a claim like any other and gets tested like one.
+- Reject a framing the repository's own policy contradicts. A report that treats a diagnostic without a fix as a defect in itself is arguing against `Code-fix coverage` above, and that argument does not become correct by being written in an issue.
+- Fix the defect that exists, not the one the issue asserts. Where the analysis and the report disagree, implement the analysis and state plainly in the pull request how the shipped change differs from what was requested.
+- Say so when a report turns out to be wrong, overstated, or already-correct behavior. Downgrading, narrowing, or closing it is a legitimate result of a run — that is what the `NOT REPRODUCED` path is for.
 
 ## GitHub workflow stages
 

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Clarity/RH3002StatementMustNotUseUnnecessaryParenthesesCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Clarity/RH3002StatementMustNotUseUnnecessaryParenthesesCodeFixProvider.cs
@@ -66,7 +66,7 @@ public class RH3002StatementMustNotUseUnnecessaryParenthesesCodeFixProvider : Co
             foreach (var diagnostic in context.Diagnostics)
             {
                 if (root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true) is ParenthesizedExpressionSyntax parenthesizedExpression
-                    && SyntaxNodeUtilities.ContainsCommentOrDirective(parenthesizedExpression) == false)
+                    && SyntaxNodeUtilities.InteriorContainsCommentOrDirective(parenthesizedExpression) == false)
                 {
                     context.RegisterCodeFix(CodeAction.Create(CodeFixResources.RH3002Title,
                                                               token => ApplyCodeFixAsync(context.Document, parenthesizedExpression, token),

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Clarity/RH3005UseReadableConditionsCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Clarity/RH3005UseReadableConditionsCodeFixProvider.cs
@@ -174,7 +174,7 @@ public class RH3005UseReadableConditionsCodeFixProvider : CodeFixProvider
                 var binaryExpression = root.FindToken(diagnostic.Location.SourceSpan.Start).Parent?.AncestorsAndSelf().OfType<BinaryExpressionSyntax>().FirstOrDefault();
 
                 if (binaryExpression != null
-                    && SyntaxNodeUtilities.ContainsCommentOrDirective(binaryExpression) == false
+                    && SyntaxNodeUtilities.InteriorContainsCommentOrDirective(binaryExpression) == false
                     && IsSwapSemanticsPreserving(semanticModel, binaryExpression, context.CancellationToken))
                 {
                     context.RegisterCodeFix(CodeAction.Create(CodeFixResources.RH3005Title,

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Layout/RH5101FirstArgumentShouldBeOnSameLineCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Layout/RH5101FirstArgumentShouldBeOnSameLineCodeFixProvider.cs
@@ -7,7 +7,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 
 using Reihitsu.Analyzer.Rules.Layout;
 using Reihitsu.Core;
@@ -36,22 +35,6 @@ public class RH5101FirstArgumentShouldBeOnSameLineCodeFixProvider : CodeFixProvi
         return await ReihitsuFormatter.FormatNodeInDocumentAsync(document, argumentList, cancellationToken).ConfigureAwait(false);
     }
 
-    /// <summary>
-    /// Determines whether a comment or a directive sits in the region the rewrite actually writes. That region runs
-    /// from the argument list's full span start to the end of its own span, which releases the trailing side and
-    /// keeps the leading one: <see cref="ReihitsuFormatter.FormatNodeInDocumentAsync"/> restores the last token's
-    /// trailing trivia unconditionally, so a comment written behind the closing parenthesis is never crossed and
-    /// must not withhold the fix, while it restores the first token's leading trivia only when that token does not
-    /// start a line, so a comment written before the opening parenthesis can still be rewritten and stays guarded
-    /// </summary>
-    /// <param name="root">Syntax root</param>
-    /// <param name="argumentList">Argument list to inspect</param>
-    /// <returns><see langword="true"/> if the rewritten region carries a comment or directive; otherwise <see langword="false"/></returns>
-    private static bool CarriesCommentOrDirectiveInRewrittenRegion(SyntaxNode root, ArgumentListSyntax argumentList)
-    {
-        return SyntaxNodeUtilities.SpanContainsCommentOrDirective(root, TextSpan.FromBounds(argumentList.FullSpan.Start, argumentList.Span.End));
-    }
-
     #endregion // Methods
 
     #region CodeFixProvider
@@ -77,7 +60,11 @@ public class RH5101FirstArgumentShouldBeOnSameLineCodeFixProvider : CodeFixProvi
                 var node = root.FindNode(diagnostic.Location.SourceSpan);
                 var argumentList = node.FirstAncestorOrSelf<ArgumentListSyntax>();
 
-                if (argumentList != null && CarriesCommentOrDirectiveInRewrittenRegion(root, argumentList) == false)
+                // The trailing side is released because the shared formatter restores the last token's trailing
+                // trivia unconditionally, so a comment behind the closing parenthesis is never crossed. The leading
+                // side stays guarded because that same entry point restores the first token's leading trivia only
+                // when the token does not start a line.
+                if (argumentList != null && SyntaxNodeUtilities.LeadingAndInteriorContainsCommentOrDirective(argumentList) == false)
                 {
                     context.RegisterCodeFix(CodeAction.Create(CodeFixResources.RH5101Title,
                                                               cancellationToken => ApplyCodeFixAsync(context.Document, argumentList, cancellationToken),

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Layout/RH5101FirstArgumentShouldBeOnSameLineCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Layout/RH5101FirstArgumentShouldBeOnSameLineCodeFixProvider.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
 
 using Reihitsu.Analyzer.Rules.Layout;
 using Reihitsu.Core;
@@ -35,6 +36,22 @@ public class RH5101FirstArgumentShouldBeOnSameLineCodeFixProvider : CodeFixProvi
         return await ReihitsuFormatter.FormatNodeInDocumentAsync(document, argumentList, cancellationToken).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Determines whether a comment or a directive sits in the region the rewrite actually writes. That region runs
+    /// from the argument list's full span start to the end of its own span, which releases the trailing side and
+    /// keeps the leading one: <see cref="ReihitsuFormatter.FormatNodeInDocumentAsync"/> restores the last token's
+    /// trailing trivia unconditionally, so a comment written behind the closing parenthesis is never crossed and
+    /// must not withhold the fix, while it restores the first token's leading trivia only when that token does not
+    /// start a line, so a comment written before the opening parenthesis can still be rewritten and stays guarded
+    /// </summary>
+    /// <param name="root">Syntax root</param>
+    /// <param name="argumentList">Argument list to inspect</param>
+    /// <returns><see langword="true"/> if the rewritten region carries a comment or directive; otherwise <see langword="false"/></returns>
+    private static bool CarriesCommentOrDirectiveInRewrittenRegion(SyntaxNode root, ArgumentListSyntax argumentList)
+    {
+        return SyntaxNodeUtilities.SpanContainsCommentOrDirective(root, TextSpan.FromBounds(argumentList.FullSpan.Start, argumentList.Span.End));
+    }
+
     #endregion // Methods
 
     #region CodeFixProvider
@@ -60,7 +77,7 @@ public class RH5101FirstArgumentShouldBeOnSameLineCodeFixProvider : CodeFixProvi
                 var node = root.FindNode(diagnostic.Location.SourceSpan);
                 var argumentList = node.FirstAncestorOrSelf<ArgumentListSyntax>();
 
-                if (argumentList != null && SyntaxNodeUtilities.ContainsCommentOrDirective(argumentList) == false)
+                if (argumentList != null && CarriesCommentOrDirectiveInRewrittenRegion(root, argumentList) == false)
                 {
                     context.RegisterCodeFix(CodeAction.Create(CodeFixResources.RH5101Title,
                                                               cancellationToken => ApplyCodeFixAsync(context.Document, argumentList, cancellationToken),

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Layout/RH5102ArgumentsShouldBeOnSingleOrSeparateLinesCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Layout/RH5102ArgumentsShouldBeOnSingleOrSeparateLinesCodeFixProvider.cs
@@ -7,7 +7,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 
 using Reihitsu.Analyzer.Rules.Layout;
 using Reihitsu.Core;
@@ -36,22 +35,6 @@ public class RH5102ArgumentsShouldBeOnSingleOrSeparateLinesCodeFixProvider : Cod
         return await ReihitsuFormatter.FormatNodeInDocumentAsync(document, argumentList, cancellationToken).ConfigureAwait(false);
     }
 
-    /// <summary>
-    /// Determines whether a comment or a directive sits in the region the rewrite actually writes. That region runs
-    /// from the argument list's full span start to the end of its own span, which releases the trailing side and
-    /// keeps the leading one: <see cref="ReihitsuFormatter.FormatNodeInDocumentAsync"/> restores the last token's
-    /// trailing trivia unconditionally, so a comment written behind the closing parenthesis is never crossed and
-    /// must not withhold the fix, while it restores the first token's leading trivia only when that token does not
-    /// start a line, so a comment written before the opening parenthesis can still be rewritten and stays guarded
-    /// </summary>
-    /// <param name="root">Syntax root</param>
-    /// <param name="argumentList">Argument list to inspect</param>
-    /// <returns><see langword="true"/> if the rewritten region carries a comment or directive; otherwise <see langword="false"/></returns>
-    private static bool CarriesCommentOrDirectiveInRewrittenRegion(SyntaxNode root, ArgumentListSyntax argumentList)
-    {
-        return SyntaxNodeUtilities.SpanContainsCommentOrDirective(root, TextSpan.FromBounds(argumentList.FullSpan.Start, argumentList.Span.End));
-    }
-
     #endregion // Methods
 
     #region CodeFixProvider
@@ -77,7 +60,11 @@ public class RH5102ArgumentsShouldBeOnSingleOrSeparateLinesCodeFixProvider : Cod
                 var node = root.FindNode(diagnostic.Location.SourceSpan);
                 var argumentList = node as ArgumentListSyntax ?? node.FirstAncestorOrSelf<ArgumentListSyntax>();
 
-                if (argumentList != null && CarriesCommentOrDirectiveInRewrittenRegion(root, argumentList) == false)
+                // The trailing side is released because the shared formatter restores the last token's trailing
+                // trivia unconditionally, so a comment behind the closing parenthesis is never crossed. The leading
+                // side stays guarded because that same entry point restores the first token's leading trivia only
+                // when the token does not start a line.
+                if (argumentList != null && SyntaxNodeUtilities.LeadingAndInteriorContainsCommentOrDirective(argumentList) == false)
                 {
                     context.RegisterCodeFix(CodeAction.Create(CodeFixResources.RH5102Title,
                                                               cancellationToken => ApplyCodeFixAsync(context.Document, argumentList, cancellationToken),

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Layout/RH5102ArgumentsShouldBeOnSingleOrSeparateLinesCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Layout/RH5102ArgumentsShouldBeOnSingleOrSeparateLinesCodeFixProvider.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
 
 using Reihitsu.Analyzer.Rules.Layout;
 using Reihitsu.Core;
@@ -35,6 +36,22 @@ public class RH5102ArgumentsShouldBeOnSingleOrSeparateLinesCodeFixProvider : Cod
         return await ReihitsuFormatter.FormatNodeInDocumentAsync(document, argumentList, cancellationToken).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Determines whether a comment or a directive sits in the region the rewrite actually writes. That region runs
+    /// from the argument list's full span start to the end of its own span, which releases the trailing side and
+    /// keeps the leading one: <see cref="ReihitsuFormatter.FormatNodeInDocumentAsync"/> restores the last token's
+    /// trailing trivia unconditionally, so a comment written behind the closing parenthesis is never crossed and
+    /// must not withhold the fix, while it restores the first token's leading trivia only when that token does not
+    /// start a line, so a comment written before the opening parenthesis can still be rewritten and stays guarded
+    /// </summary>
+    /// <param name="root">Syntax root</param>
+    /// <param name="argumentList">Argument list to inspect</param>
+    /// <returns><see langword="true"/> if the rewritten region carries a comment or directive; otherwise <see langword="false"/></returns>
+    private static bool CarriesCommentOrDirectiveInRewrittenRegion(SyntaxNode root, ArgumentListSyntax argumentList)
+    {
+        return SyntaxNodeUtilities.SpanContainsCommentOrDirective(root, TextSpan.FromBounds(argumentList.FullSpan.Start, argumentList.Span.End));
+    }
+
     #endregion // Methods
 
     #region CodeFixProvider
@@ -60,7 +77,7 @@ public class RH5102ArgumentsShouldBeOnSingleOrSeparateLinesCodeFixProvider : Cod
                 var node = root.FindNode(diagnostic.Location.SourceSpan);
                 var argumentList = node as ArgumentListSyntax ?? node.FirstAncestorOrSelf<ArgumentListSyntax>();
 
-                if (argumentList != null && SyntaxNodeUtilities.ContainsCommentOrDirective(argumentList) == false)
+                if (argumentList != null && CarriesCommentOrDirectiveInRewrittenRegion(root, argumentList) == false)
                 {
                     context.RegisterCodeFix(CodeAction.Create(CodeFixResources.RH5102Title,
                                                               cancellationToken => ApplyCodeFixAsync(context.Document, argumentList, cancellationToken),

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Layout/RH5109ParametersMustBeOnSameLineOrSeparateLinesCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Layout/RH5109ParametersMustBeOnSameLineOrSeparateLinesCodeFixProvider.cs
@@ -61,28 +61,14 @@ public class RH5109ParametersMustBeOnSameLineOrSeparateLinesCodeFixProvider : Co
         var replacement = $"({parameters.First()},{endOfLine}{alignment}{string.Join($",{endOfLine}{alignment}", parameters.Skip(1))})";
 
         // The rebuilt text already places every parameter on its own line, aligned under the first parameter, so it
-        // is the final layout for the guarded scope: the registration rejects every parameter list that carries a
-        // comment or a directive, including a documentation comment, because the parameter spans read above exclude
-        // the trivia around them and rebuilding from them would drop it. Return the text directly instead of running
-        // the formatter over the owning member:
+        // is the final layout for the guarded scope: the registration rejects every parameter list whose own span
+        // carries a comment or a directive, including a documentation comment, because the parameter spans read
+        // above exclude the trivia around them and rebuilding from them would drop it. Trivia trailing the closing
+        // parenthesis lies outside that span, is reproduced untouched by the replacement below, and does not
+        // withhold the fix. Return the text directly instead of running the formatter over the owning member:
         // that oversized scope reformatted the unrelated member body and inherited the body-scope formatter
         // defects, while formatting the isolated parameter list mis-aligns its continuation lines.
         return document.WithText(sourceText.Replace(parameterList.Span, replacement));
-    }
-
-    /// <summary>
-    /// Determines whether a comment or a directive sits in the region the rewrite actually writes. The replacement
-    /// above rebuilds exactly <see cref="ParameterListSyntax"/>'s own span, so trivia trailing the closing
-    /// parenthesis is never crossed and must not withhold the fix. The inspected region keeps the leading side
-    /// anyway, so this predicate covers the same region as its RH5101 and RH5102 counterparts and the three read
-    /// alike; the replacement could not reach a comment written before the opening parenthesis either way
-    /// </summary>
-    /// <param name="root">Syntax root</param>
-    /// <param name="parameterList">Parameter list to inspect</param>
-    /// <returns><see langword="true"/> if the rewritten region carries a comment or directive; otherwise <see langword="false"/></returns>
-    private static bool CarriesCommentOrDirectiveInRewrittenRegion(SyntaxNode root, ParameterListSyntax parameterList)
-    {
-        return SyntaxNodeUtilities.SpanContainsCommentOrDirective(root, TextSpan.FromBounds(parameterList.FullSpan.Start, parameterList.Span.End));
     }
 
     #endregion // Methods
@@ -112,8 +98,12 @@ public class RH5109ParametersMustBeOnSameLineOrSeparateLinesCodeFixProvider : Co
         {
             var parameterList = root.FindToken(diagnostic.Location.SourceSpan.Start).Parent?.FirstAncestorOrSelf<ParameterListSyntax>();
 
+            // The replacement below rebuilds exactly the parameter list's own span, so trivia trailing the closing
+            // parenthesis is never crossed and must not withhold the fix. The leading side is unreachable too, but
+            // it stays guarded so this predicate matches its RH5101 and RH5102 counterparts; the shape it gives up
+            // is recorded in the rule documentation.
             if (parameterList == null
-                || CarriesCommentOrDirectiveInRewrittenRegion(root, parameterList))
+                || SyntaxNodeUtilities.LeadingAndInteriorContainsCommentOrDirective(parameterList))
             {
                 continue;
             }

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Layout/RH5109ParametersMustBeOnSameLineOrSeparateLinesCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Layout/RH5109ParametersMustBeOnSameLineOrSeparateLinesCodeFixProvider.cs
@@ -70,6 +70,21 @@ public class RH5109ParametersMustBeOnSameLineOrSeparateLinesCodeFixProvider : Co
         return document.WithText(sourceText.Replace(parameterList.Span, replacement));
     }
 
+    /// <summary>
+    /// Determines whether a comment or a directive sits in the region the rewrite actually writes. The replacement
+    /// above rebuilds exactly <see cref="ParameterListSyntax"/>'s own span, so trivia trailing the closing
+    /// parenthesis is never crossed and must not withhold the fix. The inspected region keeps the leading side
+    /// anyway, so this predicate covers the same region as its RH5101 and RH5102 counterparts and the three read
+    /// alike; the replacement could not reach a comment written before the opening parenthesis either way
+    /// </summary>
+    /// <param name="root">Syntax root</param>
+    /// <param name="parameterList">Parameter list to inspect</param>
+    /// <returns><see langword="true"/> if the rewritten region carries a comment or directive; otherwise <see langword="false"/></returns>
+    private static bool CarriesCommentOrDirectiveInRewrittenRegion(SyntaxNode root, ParameterListSyntax parameterList)
+    {
+        return SyntaxNodeUtilities.SpanContainsCommentOrDirective(root, TextSpan.FromBounds(parameterList.FullSpan.Start, parameterList.Span.End));
+    }
+
     #endregion // Methods
 
     #region CodeFixProvider
@@ -98,7 +113,7 @@ public class RH5109ParametersMustBeOnSameLineOrSeparateLinesCodeFixProvider : Co
             var parameterList = root.FindToken(diagnostic.Location.SourceSpan.Start).Parent?.FirstAncestorOrSelf<ParameterListSyntax>();
 
             if (parameterList == null
-                || SyntaxNodeUtilities.ContainsCommentOrDirective(parameterList))
+                || CarriesCommentOrDirectiveInRewrittenRegion(root, parameterList))
             {
                 continue;
             }

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Layout/RH5408SimpleAutoPropertiesShouldBeSingleLinedCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Layout/RH5408SimpleAutoPropertiesShouldBeSingleLinedCodeFixProvider.cs
@@ -99,7 +99,10 @@ public class RH5408SimpleAutoPropertiesShouldBeSingleLinedCodeFixProvider : Code
 
         if (propertyDeclaration.Initializer != null)
         {
-            if (SyntaxNodeUtilities.ContainsCommentOrDirective(propertyDeclaration.Initializer))
+            // Only the initializer's own span is inspected, matching the analyzer's predicate exactly. The two must
+            // stay identical: a shape the analyzer reports and this predicate rejects is a diagnostic with no
+            // available action, which is the failure mode the gap guards below were introduced to avoid.
+            if (SyntaxNodeUtilities.InteriorContainsCommentOrDirective(propertyDeclaration.Initializer))
             {
                 return false;
             }

--- a/Reihitsu.Analyzer.Test/Clarity/RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Clarity/RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzerTests.cs
@@ -407,6 +407,11 @@ public class RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzerTests : Anal
                                                                .GetLocation());
 
         Assert.IsNotEmpty(actions);
+
+        var fixedCode = await ApplyCodeFixAsync(codeFixData);
+
+        Assert.Contains("/* note */ y;", fixedCode);
+        Assert.DoesNotContain("(y)", fixedCode);
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer.Test/Clarity/RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Clarity/RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzerTests.cs
@@ -379,5 +379,63 @@ public class RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzerTests : Anal
         Assert.IsEmpty(actions);
     }
 
+    /// <summary>
+    /// Verifying that a comment written before the parenthesized expression does not withhold the code fix. The
+    /// rewrite transplants the node's own outer trivia onto the replacement, so that comment is never crossed
+    /// (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCommentBeforeTheParenthesesIsOfferedACodeFix()
+    {
+        const string codeFixData = """
+                                   internal class TestClass
+                                   {
+                                       private static int Method(int y)
+                                       {
+                                           return
+                                               /* note */ (y);
+                                       }
+                                   }
+                                   """;
+
+        var actions = await GetCodeFixActionsAsync(codeFixData,
+                                                   RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<ParenthesizedExpressionSyntax>()
+                                                               .First()
+                                                               .GetLocation());
+
+        Assert.IsNotEmpty(actions);
+    }
+
+    /// <summary>
+    /// Verifying that a comment written inside the parentheses still withholds the code fix, because removing them
+    /// would discard it (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCommentInsideTheParenthesesWithholdsTheCodeFix()
+    {
+        const string codeFixData = """
+                                   internal class TestClass
+                                   {
+                                       private static int Method(int y)
+                                       {
+                                           return (/* note */ y);
+                                       }
+                                   }
+                                   """;
+
+        var actions = await GetCodeFixActionsAsync(codeFixData,
+                                                   RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<ParenthesizedExpressionSyntax>()
+                                                               .First()
+                                                               .GetLocation());
+
+        Assert.IsEmpty(actions);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Clarity/RH3005UseReadableConditionsAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Clarity/RH3005UseReadableConditionsAnalyzerTests.cs
@@ -627,6 +627,10 @@ public class RH3005UseReadableConditionsAnalyzerTests : AnalyzerTestsBase<RH3005
                                                    FirstComparisonOperatorLocation);
 
         Assert.IsNotEmpty(actions);
+
+        var fixedCode = await ApplyCodeFixAsync(codeFixData);
+
+        Assert.Contains("/* note */ count > 0;", fixedCode);
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer.Test/Clarity/RH3005UseReadableConditionsAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Clarity/RH3005UseReadableConditionsAnalyzerTests.cs
@@ -603,6 +603,57 @@ public class RH3005UseReadableConditionsAnalyzerTests : AnalyzerTestsBase<RH3005
         Assert.Contains("return count > 0;", fixedCode);
     }
 
+    /// <summary>
+    /// Verifying that a comment written before the comparison does not withhold the code fix. The swap transplants
+    /// the comparison's own outer trivia onto the replacement, so that comment is never crossed (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCommentBeforeTheComparisonIsOfferedACodeFix()
+    {
+        const string codeFixData = """
+                                   public class Test
+                                   {
+                                       public bool Run(int count)
+                                       {
+                                           return
+                                               /* note */ 0 < count;
+                                       }
+                                   }
+                                   """;
+
+        var actions = await GetCodeFixActionsAsync(codeFixData,
+                                                   RH3005UseReadableConditionsAnalyzer.DiagnosticId,
+                                                   FirstComparisonOperatorLocation);
+
+        Assert.IsNotEmpty(actions);
+    }
+
+    /// <summary>
+    /// Verifying that a comment written inside the comparison still withholds the code fix, because the swap would
+    /// relocate it relative to the operands (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCommentInsideTheComparisonWithholdsTheCodeFix()
+    {
+        const string codeFixData = """
+                                   public class Test
+                                   {
+                                       public bool Run(int count)
+                                       {
+                                           return 0 < /* note */ count;
+                                       }
+                                   }
+                                   """;
+
+        var actions = await GetCodeFixActionsAsync(codeFixData,
+                                                   RH3005UseReadableConditionsAnalyzer.DiagnosticId,
+                                                   FirstComparisonOperatorLocation);
+
+        Assert.IsEmpty(actions);
+    }
+
     #endregion // Tests
 
     #region Methods

--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5408SimpleAutoPropertiesShouldBeSingleLinedFormatterTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5408SimpleAutoPropertiesShouldBeSingleLinedFormatterTests.cs
@@ -248,5 +248,36 @@ public class RH5408SimpleAutoPropertiesShouldBeSingleLinedFormatterTests : Forma
                                                Diagnostics(RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer.DiagnosticId, AnalyzerResources.RH5408MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies that the formatter collapses an auto-property carrying a comment between the initializer value and a
+    /// semicolon on the same line, so the shape RH5408 newly reports is also corrected by the CLI, and that a second
+    /// pass over the result changes nothing under both line endings (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFormatterFixesAutoPropertyWithTrailingInitializerComment()
+    {
+        const string input = """
+                             internal class Example
+                             {
+                                 {|#0:internal int Value
+                                 {
+                                     get;
+                                     set;
+                                 } = 1 /* note */;|}
+                             }
+                             """;
+        const string fixedData = """
+                                 internal class Example
+                                 {
+                                     internal int Value { get; set; } = 1 /* note */;
+                                 }
+                                 """;
+
+        await VerifyFormatterFixAndIdempotency(input,
+                                               fixedData,
+                                               Diagnostics(RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer.DiagnosticId, AnalyzerResources.RH5408MessageFormat));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatting/RH5101FirstArgumentShouldBeOnSameLineAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH5101FirstArgumentShouldBeOnSameLineAnalyzerTests.cs
@@ -371,5 +371,113 @@ public class RH5101FirstArgumentShouldBeOnSameLineAnalyzerTests : AnalyzerTestsB
         Assert.IsNotEmpty(actions);
     }
 
+    /// <summary>
+    /// Verifying that a comment after the closing parenthesis is fixed and the comment stays where it was written
+    /// (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyTrailingCommentAfterClosingParenthesisIsFixed()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    private static int Add(int x, int y) => x + y;
+
+                                    private static int Use()
+                                    {
+                                        return Add(
+                                            {|#0:1|},
+                                            2) /* note */ + 3;
+                                    }
+                                }
+                                """;
+
+        const string resultData = """
+                                  internal class TestClass
+                                  {
+                                      private static int Add(int x, int y) => x + y;
+
+                                      private static int Use()
+                                      {
+                                          return Add(1,
+                                                     2) /* note */ + 3;
+                                      }
+                                  }
+                                  """;
+
+        await Verify(testData, resultData, Diagnostics(RH5101FirstArgumentShouldBeOnSameLineAnalyzer.DiagnosticId, AnalyzerResources.RH5101MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying that a comment written before the opening parenthesis still withholds the code fix. The rewrite is
+    /// delegated to the shared formatter, which restores the first token's leading trivia only when that token does
+    /// not start a line, so this region is not released together with the trailing one (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCommentBeforeTheOpeningParenthesisWithholdsTheCodeFix()
+    {
+        const string codeFixData = """
+                                   internal class TestClass
+                                   {
+                                       private static int Add(int x, int y) => x + y;
+
+                                       private static int Use()
+                                       {
+                                           return Add
+                                               /* note */ (
+                                               1,
+                                               2) + 3;
+                                       }
+                                   }
+                                   """;
+
+        var actions = await GetCodeFixActionsAsync(codeFixData,
+                                                   RH5101FirstArgumentShouldBeOnSameLineAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<ArgumentListSyntax>()
+                                                               .First()
+                                                               .Arguments
+                                                               .First()
+                                                               .GetLocation());
+
+        Assert.IsEmpty(actions);
+    }
+
+    /// <summary>
+    /// Verifying that a comment written directly against the closing parenthesis, without a separating space, is
+    /// offered a code fix like the space-separated shape (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCommentAdjacentToTheClosingParenthesisIsOfferedACodeFix()
+    {
+        const string codeFixData = """
+                                   internal class TestClass
+                                   {
+                                       private static int Add(int x, int y) => x + y;
+
+                                       private static int Use()
+                                       {
+                                           return Add(
+                                               1,
+                                               2)/* note */ + 3;
+                                       }
+                                   }
+                                   """;
+
+        var actions = await GetCodeFixActionsAsync(codeFixData,
+                                                   RH5101FirstArgumentShouldBeOnSameLineAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<ArgumentListSyntax>()
+                                                               .First()
+                                                               .Arguments
+                                                               .First()
+                                                               .GetLocation());
+
+        Assert.IsNotEmpty(actions);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatting/RH5101FirstArgumentShouldBeOnSameLineAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH5101FirstArgumentShouldBeOnSameLineAnalyzerTests.cs
@@ -253,5 +253,123 @@ public class RH5101FirstArgumentShouldBeOnSameLineAnalyzerTests : AnalyzerTestsB
         Assert.IsEmpty(actions);
     }
 
+    /// <summary>
+    /// Verifying that the argument list of the issue's literal example, which carries a comment after the closing
+    /// parenthesis, is reported (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyTrailingCommentAfterClosingParenthesisIsReported()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    private static int Add(int x, int y) => x + y;
+
+                                    private static int Use()
+                                    {
+                                        return Add(
+                                            {|#0:1|},
+                                            2) /* note */ + 3;
+                                    }
+                                }
+                                """;
+
+        await Verify(testData, Diagnostics(RH5101FirstArgumentShouldBeOnSameLineAnalyzer.DiagnosticId, AnalyzerResources.RH5101MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying that the argument list of the issue's literal example, which carries a comment after the closing
+    /// parenthesis, is offered a code fix (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyTrailingCommentAfterClosingParenthesisIsOfferedACodeFix()
+    {
+        const string codeFixData = """
+                                   internal class TestClass
+                                   {
+                                       private static int Add(int x, int y) => x + y;
+
+                                       private static int Use()
+                                       {
+                                           return Add(
+                                               1,
+                                               2) /* note */ + 3;
+                                       }
+                                   }
+                                   """;
+
+        var actions = await GetCodeFixActionsAsync(codeFixData,
+                                                   RH5101FirstArgumentShouldBeOnSameLineAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<ArgumentListSyntax>()
+                                                               .First()
+                                                               .Arguments
+                                                               .First()
+                                                               .GetLocation());
+
+        Assert.IsNotEmpty(actions);
+    }
+
+    /// <summary>
+    /// Verifying the control case of the issue's literal example: the identical input without the trailing comment is
+    /// reported (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyWithoutTrailingCommentIsReported()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    private static int Add(int x, int y) => x + y;
+
+                                    private static int Use()
+                                    {
+                                        return Add(
+                                            {|#0:1|},
+                                            2) + 3;
+                                    }
+                                }
+                                """;
+
+        await Verify(testData, Diagnostics(RH5101FirstArgumentShouldBeOnSameLineAnalyzer.DiagnosticId, AnalyzerResources.RH5101MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying the control case of the issue's literal example: the identical input without the trailing comment is
+    /// offered a code fix (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyWithoutTrailingCommentIsOfferedACodeFix()
+    {
+        const string codeFixData = """
+                                   internal class TestClass
+                                   {
+                                       private static int Add(int x, int y) => x + y;
+
+                                       private static int Use()
+                                       {
+                                           return Add(
+                                               1,
+                                               2) + 3;
+                                       }
+                                   }
+                                   """;
+
+        var actions = await GetCodeFixActionsAsync(codeFixData,
+                                                   RH5101FirstArgumentShouldBeOnSameLineAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<ArgumentListSyntax>()
+                                                               .First()
+                                                               .Arguments
+                                                               .First()
+                                                               .GetLocation());
+
+        Assert.IsNotEmpty(actions);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatting/RH5102ArgumentsShouldBeOnSingleOrSeparateLinesAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH5102ArgumentsShouldBeOnSingleOrSeparateLinesAnalyzerTests.cs
@@ -221,5 +221,111 @@ public class RH5102ArgumentsShouldBeOnSingleOrSeparateLinesAnalyzerTests : Analy
         Assert.IsEmpty(actions);
     }
 
+    /// <summary>
+    /// Verifying that an argument list carrying a comment after its closing parenthesis is reported (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyTrailingCommentAfterClosingParenthesisIsReported()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    private static int Add(int x, int y, int z) => x + y + z;
+
+                                    private static int Use()
+                                    {
+                                        return Add{|#0:(1, 2,
+                                                   3)|} /* note */ + 4;
+                                    }
+                                }
+                                """;
+
+        await Verify(testData, Diagnostics(RH5102ArgumentsShouldBeOnSingleOrSeparateLinesAnalyzer.DiagnosticId, AnalyzerResources.RH5102MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying that an argument list carrying a comment after its closing parenthesis is offered a code fix (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyTrailingCommentAfterClosingParenthesisIsOfferedACodeFix()
+    {
+        const string codeFixData = """
+                                   internal class TestClass
+                                   {
+                                       private static int Add(int x, int y, int z) => x + y + z;
+
+                                       private static int Use()
+                                       {
+                                           return Add(1, 2,
+                                                      3) /* note */ + 4;
+                                       }
+                                   }
+                                   """;
+
+        var actions = await GetCodeFixActionsAsync(codeFixData,
+                                                   RH5102ArgumentsShouldBeOnSingleOrSeparateLinesAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<ArgumentListSyntax>()
+                                                               .First()
+                                                               .GetLocation());
+
+        Assert.IsNotEmpty(actions);
+    }
+
+    /// <summary>
+    /// Verifying the control case: the identical input without the trailing comment is reported (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyWithoutTrailingCommentIsReported()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    private static int Add(int x, int y, int z) => x + y + z;
+
+                                    private static int Use()
+                                    {
+                                        return Add{|#0:(1, 2,
+                                                   3)|} + 4;
+                                    }
+                                }
+                                """;
+
+        await Verify(testData, Diagnostics(RH5102ArgumentsShouldBeOnSingleOrSeparateLinesAnalyzer.DiagnosticId, AnalyzerResources.RH5102MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying the control case: the identical input without the trailing comment is offered a code fix (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyWithoutTrailingCommentIsOfferedACodeFix()
+    {
+        const string codeFixData = """
+                                   internal class TestClass
+                                   {
+                                       private static int Add(int x, int y, int z) => x + y + z;
+
+                                       private static int Use()
+                                       {
+                                           return Add(1, 2,
+                                                      3) + 4;
+                                       }
+                                   }
+                                   """;
+
+        var actions = await GetCodeFixActionsAsync(codeFixData,
+                                                   RH5102ArgumentsShouldBeOnSingleOrSeparateLinesAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<ArgumentListSyntax>()
+                                                               .First()
+                                                               .GetLocation());
+
+        Assert.IsNotEmpty(actions);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatting/RH5102ArgumentsShouldBeOnSingleOrSeparateLinesAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH5102ArgumentsShouldBeOnSingleOrSeparateLinesAnalyzerTests.cs
@@ -327,5 +327,107 @@ public class RH5102ArgumentsShouldBeOnSingleOrSeparateLinesAnalyzerTests : Analy
         Assert.IsNotEmpty(actions);
     }
 
+    /// <summary>
+    /// Verifying that a comment after the closing parenthesis is fixed and the comment stays where it was written
+    /// (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyTrailingCommentAfterClosingParenthesisIsFixed()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    private static int Add(int x, int y, int z) => x + y + z;
+
+                                    private static int Use()
+                                    {
+                                        return Add{|#0:(1, 2,
+                                                   3)|} /* note */ + 4;
+                                    }
+                                }
+                                """;
+
+        const string resultData = """
+                                  internal class TestClass
+                                  {
+                                      private static int Add(int x, int y, int z) => x + y + z;
+
+                                      private static int Use()
+                                      {
+                                          return Add(1,
+                                                     2,
+                                                     3) /* note */ + 4;
+                                      }
+                                  }
+                                  """;
+
+        await Verify(testData, resultData, Diagnostics(RH5102ArgumentsShouldBeOnSingleOrSeparateLinesAnalyzer.DiagnosticId, AnalyzerResources.RH5102MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying that a comment written before the opening parenthesis still withholds the code fix. The rewrite is
+    /// delegated to the shared formatter, which restores the first token's leading trivia only when that token does
+    /// not start a line, so this region is not released together with the trailing one (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCommentBeforeTheOpeningParenthesisWithholdsTheCodeFix()
+    {
+        const string codeFixData = """
+                                   internal class TestClass
+                                   {
+                                       private static int Add(int x, int y, int z) => x + y + z;
+
+                                       private static int Use()
+                                       {
+                                           return Add
+                                               /* note */ (1, 2,
+                                               3) + 4;
+                                       }
+                                   }
+                                   """;
+
+        var actions = await GetCodeFixActionsAsync(codeFixData,
+                                                   RH5102ArgumentsShouldBeOnSingleOrSeparateLinesAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<ArgumentListSyntax>()
+                                                               .First()
+                                                               .GetLocation());
+
+        Assert.IsEmpty(actions);
+    }
+
+    /// <summary>
+    /// Verifying that a comment written directly against the closing parenthesis, without a separating space, is
+    /// offered a code fix like the space-separated shape (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCommentAdjacentToTheClosingParenthesisIsOfferedACodeFix()
+    {
+        const string codeFixData = """
+                                   internal class TestClass
+                                   {
+                                       private static int Add(int x, int y, int z) => x + y + z;
+
+                                       private static int Use()
+                                       {
+                                           return Add(1, 2,
+                                                      3)/* note */ + 4;
+                                       }
+                                   }
+                                   """;
+
+        var actions = await GetCodeFixActionsAsync(codeFixData,
+                                                   RH5102ArgumentsShouldBeOnSingleOrSeparateLinesAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<ArgumentListSyntax>()
+                                                               .First()
+                                                               .GetLocation());
+
+        Assert.IsNotEmpty(actions);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatting/RH5109ParametersMustBeOnSameLineOrSeparateLinesAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH5109ParametersMustBeOnSameLineOrSeparateLinesAnalyzerTests.cs
@@ -358,5 +358,99 @@ public class RH5109ParametersMustBeOnSameLineOrSeparateLinesAnalyzerTests : Anal
         Assert.IsNotEmpty(actions);
     }
 
+    /// <summary>
+    /// Verifying that a comment after the closing parenthesis is fixed and the comment stays where it was written
+    /// (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyTrailingCommentAfterClosingParenthesisIsFixed()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method{|#0:(|}int first, int second,
+                                                int third) /* note */
+                                    {
+                                    }
+                                }
+                                """;
+
+        const string resultData = """
+                                  internal class TestClass
+                                  {
+                                      void Method(int first,
+                                                  int second,
+                                                  int third) /* note */
+                                      {
+                                      }
+                                  }
+                                  """;
+
+        await Verify(testData, resultData, Diagnostics(RH5109ParametersMustBeOnSameLineOrSeparateLinesAnalyzer.DiagnosticId, AnalyzerResources.RH5109MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying that a comment written before the opening parenthesis still withholds the code fix. The replacement
+    /// could not reach that region, but the guard covers it so the predicate reads identically across RH5101, RH5102
+    /// and RH5109 (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCommentBeforeTheOpeningParenthesisWithholdsTheCodeFix()
+    {
+        const string codeFixData = """
+                                   internal class TestClass
+                                   {
+                                       void Method
+                                           /* note */ (int first, int second,
+                                                       int third)
+                                       {
+                                       }
+                                   }
+                                   """;
+
+        var actions = await GetCodeFixActionsAsync(codeFixData,
+                                                   RH5109ParametersMustBeOnSameLineOrSeparateLinesAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<MethodDeclarationSyntax>()
+                                                               .Single()
+                                                               .ParameterList
+                                                               .OpenParenToken
+                                                               .GetLocation());
+
+        Assert.IsEmpty(actions);
+    }
+
+    /// <summary>
+    /// Verifying that a comment written directly against the closing parenthesis, without a separating space, is
+    /// offered a code fix like the space-separated shape (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCommentAdjacentToTheClosingParenthesisIsOfferedACodeFix()
+    {
+        const string codeFixData = """
+                                   internal class TestClass
+                                   {
+                                       void Method(int first, int second,
+                                                   int third)/* note */
+                                       {
+                                       }
+                                   }
+                                   """;
+
+        var actions = await GetCodeFixActionsAsync(codeFixData,
+                                                   RH5109ParametersMustBeOnSameLineOrSeparateLinesAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<MethodDeclarationSyntax>()
+                                                               .Single()
+                                                               .ParameterList
+                                                               .OpenParenToken
+                                                               .GetLocation());
+
+        Assert.IsNotEmpty(actions);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatting/RH5109ParametersMustBeOnSameLineOrSeparateLinesAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH5109ParametersMustBeOnSameLineOrSeparateLinesAnalyzerTests.cs
@@ -260,5 +260,103 @@ public class RH5109ParametersMustBeOnSameLineOrSeparateLinesAnalyzerTests : Anal
         Assert.AreNotEqual(codeFixData, fixedCode);
     }
 
+    /// <summary>
+    /// Verifying that a parameter list carrying a comment after its closing parenthesis is reported (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyTrailingCommentAfterClosingParenthesisIsReported()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method{|#0:(|}int first, int second,
+                                                int third) /* note */
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(testData, Diagnostics(RH5109ParametersMustBeOnSameLineOrSeparateLinesAnalyzer.DiagnosticId, AnalyzerResources.RH5109MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying that a parameter list carrying a comment after its closing parenthesis is offered a code fix (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyTrailingCommentAfterClosingParenthesisIsOfferedACodeFix()
+    {
+        const string codeFixData = """
+                                   internal class TestClass
+                                   {
+                                       void Method(int first, int second,
+                                                   int third) /* note */
+                                       {
+                                       }
+                                   }
+                                   """;
+
+        var actions = await GetCodeFixActionsAsync(codeFixData,
+                                                   RH5109ParametersMustBeOnSameLineOrSeparateLinesAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<MethodDeclarationSyntax>()
+                                                               .Single()
+                                                               .ParameterList
+                                                               .OpenParenToken
+                                                               .GetLocation());
+
+        Assert.IsNotEmpty(actions);
+    }
+
+    /// <summary>
+    /// Verifying the control case: the identical input without the trailing comment is reported (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyWithoutTrailingCommentIsReported()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method{|#0:(|}int first, int second,
+                                                int third)
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(testData, Diagnostics(RH5109ParametersMustBeOnSameLineOrSeparateLinesAnalyzer.DiagnosticId, AnalyzerResources.RH5109MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying the control case: the identical input without the trailing comment is offered a code fix (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyWithoutTrailingCommentIsOfferedACodeFix()
+    {
+        const string codeFixData = """
+                                   internal class TestClass
+                                   {
+                                       void Method(int first, int second,
+                                                   int third)
+                                       {
+                                       }
+                                   }
+                                   """;
+
+        var actions = await GetCodeFixActionsAsync(codeFixData,
+                                                   RH5109ParametersMustBeOnSameLineOrSeparateLinesAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<MethodDeclarationSyntax>()
+                                                               .Single()
+                                                               .ParameterList
+                                                               .OpenParenToken
+                                                               .GetLocation());
+
+        Assert.IsNotEmpty(actions);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatting/RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzerTests.cs
@@ -1313,6 +1313,30 @@ public class RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzerTests : Analyz
     }
 
     /// <summary>
+    /// Verifying that a block comment between the initializer value and a semicolon on a later line still exempts the
+    /// property. This is the negative side of the same boundary and the same trivia kind as the reported shape, so it
+    /// pins the line-span condition rather than the comment kind (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyBlockCommentBeforeSemicolonOnItsOwnLineIsNotReported()
+    {
+        const string testData = """
+                                internal class RH5408
+                                {
+                                    public int Value
+                                    {
+                                        get;
+                                        set;
+                                    } = 1 /* note */
+                                        ;
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
     /// Verifying that a comment between the equals token and the initializer value still exempts the property. The
     /// collapse would be safe there, but the interior guard is the only owner of that gap, so the shape is left to
     /// manual correction (issue #650)

--- a/Reihitsu.Analyzer.Test/Formatting/RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzerTests.cs
@@ -1050,5 +1050,312 @@ public class RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzerTests : Analyz
         Assert.IsEmpty(actions);
     }
 
+    /// <summary>
+    /// Verifying that a comment between the initializer value and a semicolon on the same line no longer exempts the
+    /// property. The collapse never joins across that gap, and the formatter already reformats the shape (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCommentBetweenInitializerValueAndSemicolonIsDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class RH5408
+                                {
+                                    {|#0:public int Value
+                                    {
+                                        get;
+                                        set;
+                                    } = 1 /* note */;|}
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class RH5408
+                                 {
+                                     public int Value { get; set; } = 1 /* note */;
+                                 }
+                                 """;
+
+        await Verify(testData,
+                     fixedData,
+                     Diagnostics(RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer.DiagnosticId, AnalyzerResources.RH5408MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying that the documentation comment of a property carrying a trailing initializer comment survives the
+    /// collapse (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDocumentedPropertyWithTrailingInitializerCommentIsDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class RH5408
+                                {
+                                    /// <summary>The value.</summary>
+                                    {|#0:public int Value
+                                    {
+                                        get;
+                                        set;
+                                    } = 1 /* note */;|}
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class RH5408
+                                 {
+                                     /// <summary>
+                                     /// The value.
+                                     /// </summary>
+                                     public int Value { get; set; } = 1 /* note */;
+                                 }
+                                 """;
+
+        await Verify(testData,
+                     fixedData,
+                     Diagnostics(RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer.DiagnosticId, AnalyzerResources.RH5408MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying that the documentation comment of a property without a trailing initializer comment is expanded the
+    /// same way. This control pins the expansion as pre-existing behavior of the documentation phase rather than a
+    /// side effect of the guard narrowing in issue #650
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDocumentedPropertyWithoutTrailingInitializerCommentIsDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class RH5408
+                                {
+                                    /// <summary>The value.</summary>
+                                    {|#0:public int Value
+                                    {
+                                        get;
+                                        set;
+                                    } = 1;|}
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class RH5408
+                                 {
+                                     /// <summary>
+                                     /// The value.
+                                     /// </summary>
+                                     public int Value { get; set; } = 1;
+                                 }
+                                 """;
+
+        await Verify(testData,
+                     fixedData,
+                     Diagnostics(RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer.DiagnosticId, AnalyzerResources.RH5408MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying that an init accessor with a trailing initializer comment is collapsed (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyInitPropertyWithTrailingInitializerCommentIsDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class RH5408
+                                {
+                                    {|#0:public int Value
+                                    {
+                                        get;
+                                        init;
+                                    } = 1 /* note */;|}
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class RH5408
+                                 {
+                                     public int Value { get; init; } = 1 /* note */;
+                                 }
+                                 """;
+
+        await Verify(testData,
+                     fixedData,
+                     Diagnostics(RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer.DiagnosticId, AnalyzerResources.RH5408MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying that an accessor modifier is preserved when a property with a trailing initializer comment is
+    /// collapsed (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyAccessorModifierWithTrailingInitializerCommentIsDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class RH5408
+                                {
+                                    {|#0:public int Value
+                                    {
+                                        get;
+                                        private set;
+                                    } = 1 /* note */;|}
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class RH5408
+                                 {
+                                     public int Value { get; private set; } = 1 /* note */;
+                                 }
+                                 """;
+
+        await Verify(testData,
+                     fixedData,
+                     Diagnostics(RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer.DiagnosticId, AnalyzerResources.RH5408MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying that a single-line generic initializer value with a trailing comment is collapsed (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyGenericInitializerWithTrailingCommentIsDetectedAndFixed()
+    {
+        const string testData = """
+                                using System.Collections.Generic;
+
+                                internal class RH5408
+                                {
+                                    {|#0:public Dictionary<int, string> Value
+                                    {
+                                        get;
+                                        set;
+                                    } = new Dictionary<int, string>() /* note */;|}
+                                }
+                                """;
+        const string fixedData = """
+                                 using System.Collections.Generic;
+
+                                 internal class RH5408
+                                 {
+                                     public Dictionary<int, string> Value { get; set; } = new Dictionary<int, string>() /* note */;
+                                 }
+                                 """;
+
+        await Verify(testData,
+                     fixedData,
+                     Diagnostics(RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer.DiagnosticId, AnalyzerResources.RH5408MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying that a comment before the initializer equals token still exempts the property. The gap guard between
+    /// the accessor list and the initializer is, after issue #650, the only owner of that region
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCommentBeforeInitializerEqualsIsNotReported()
+    {
+        const string testData = """
+                                internal class RH5408
+                                {
+                                    public int Value
+                                    {
+                                        get;
+                                        set;
+                                    }
+                                        /* note */ = 1;
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifying that a directive before the initializer equals token still exempts the property. The gap guard
+    /// between the accessor list and the initializer is, after issue #650, the only owner of that region
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDirectiveBeforeInitializerEqualsIsNotReported()
+    {
+        const string testData = """
+                                internal class RH5408
+                                {
+                                    public int Value
+                                    {
+                                        get;
+                                        set;
+                                    }
+                                #if FEATURE
+                                #endif
+                                        = 1;
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifying that a line comment between the initializer value and the semicolon still exempts the property. Such
+    /// a comment runs to the end of the line, so the gap spans lines and its own guard owns it (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyLineCommentBetweenInitializerValueAndSemicolonIsNotReported()
+    {
+        const string testData = """
+                                internal class RH5408
+                                {
+                                    public int Value
+                                    {
+                                        get;
+                                        set;
+                                    } = 1 // note
+                                        ;
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifying that a comment between the equals token and the initializer value still exempts the property. The
+    /// collapse would be safe there, but the interior guard is the only owner of that gap, so the shape is left to
+    /// manual correction (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCommentBetweenEqualsAndInitializerValueIsNotReported()
+    {
+        const string testData = """
+                                internal class RH5408
+                                {
+                                    public int Value
+                                    {
+                                        get;
+                                        set;
+                                    } = /* note */ 1;
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifying that a multi-line initializer value with a trailing comment still exempts the property (issue #650)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyMultiLineInitializerValueWithTrailingCommentIsNotReported()
+    {
+        const string testData = """
+                                internal class RH5408
+                                {
+                                    public int Value
+                                    {
+                                        get;
+                                        set;
+                                    } = 1
+                                        + 2 /* note */;
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer/Rules/Layout/RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Layout/RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer.cs
@@ -145,13 +145,13 @@ public class RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer : DiagnosticA
                 return false;
             }
 
-            // The reported span runs to the end of the declaration, so it covers the initializer as well. A comment
-            // in the gap between the accessor list and the initializer lives in the closing brace's trailing trivia,
-            // which the check above does not inspect; a directive cannot occupy trailing trivia, so it always lands
-            // in the initializer's leading trivia and is already covered. The formatter only has to join that gap
-            // when the initializer starts on a later line, and it refuses to join across such trivia, so the
-            // analyzer must guard the same gap to avoid a permanent diagnostic. Trivia in a gap that already sits
-            // on one line is never crossed and must not suppress the diagnostic.
+            // The reported span runs to the end of the declaration, so it covers the initializer as well. This guard
+            // is the only owner of the gap between the accessor list and the initializer: a comment there lives in
+            // the closing brace's trailing trivia and a directive in the equals token's leading trivia, and the
+            // interior check above inspects neither. The formatter only has to join that gap when the initializer
+            // starts on a later line, and it refuses to join across such trivia, so the analyzer must guard the same
+            // gap to avoid a permanent diagnostic. Trivia in a gap that already sits on one line is never crossed
+            // and must not suppress the diagnostic.
             var initializerGapSpan = TextSpan.FromBounds(propertyDeclaration.AccessorList.CloseBraceToken.Span.End, propertyDeclaration.Initializer.EqualsToken.SpanStart);
 
             if (SyntaxNodeUtilities.IsSingleLineSpan(propertyDeclaration.SyntaxTree, initializerGapSpan) == false

--- a/Reihitsu.Analyzer/Rules/Layout/RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Layout/RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer.cs
@@ -134,7 +134,13 @@ public class RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer : DiagnosticA
 
         if (propertyDeclaration.Initializer != null)
         {
-            if (SyntaxNodeUtilities.ContainsCommentOrDirective(propertyDeclaration.Initializer))
+            // Only the initializer's own span is inspected. Its full span additionally covers the leading trivia of
+            // the equals token and the trailing trivia of the value's last token, and neither region is crossed in
+            // every case: the two gap guards below own them wherever the collapse actually has to join across them,
+            // and where they do not fire nothing is joined at all. Both of those guards carry a line-span
+            // precondition and are, after this narrowing, the only owners of their region — weakening either one
+            // silently uncovers it.
+            if (SyntaxNodeUtilities.InteriorContainsCommentOrDirective(propertyDeclaration.Initializer))
             {
                 return false;
             }
@@ -163,8 +169,9 @@ public class RH5408SimpleAutoPropertiesShouldBeSingleLinedAnalyzer : DiagnosticA
             // declaration multi-line. DeclarationSemicolonLineBreakRewriter joins that gap, but it refuses to join
             // across a comment or directive, so the analyzer must guard the same gap to avoid a permanent diagnostic.
             // The line check keeps the guard aligned with the rewriter, which only acts on a semicolon that carries a
-            // leading line break: trivia in a gap that already sits on one line is never crossed, and such a comment
-            // is trailing trivia of the initializer value, which the initializer guard above already owns.
+            // leading line break: trivia in a gap that already sits on one line is never crossed. Such a comment is
+            // trailing trivia of the initializer value, which the interior guard above deliberately no longer owns,
+            // so this guard is its only owner once the gap spans lines.
             var tokenBeforeSemicolon = propertyDeclaration.SemicolonToken.GetPreviousToken();
 
             if (propertyDeclaration.SemicolonToken.IsMissing == false

--- a/Reihitsu.Core.Test/SyntaxNodeUtilitiesTests.cs
+++ b/Reihitsu.Core.Test/SyntaxNodeUtilitiesTests.cs
@@ -211,6 +211,45 @@ public class SyntaxNodeUtilitiesTests
     }
 
     /// <summary>
+    /// Verifies that the leading-and-interior predicate ignores a comment trailing the node, so a rewrite that
+    /// reproduces everything after the node verbatim is not withheld by it
+    /// </summary>
+    [TestMethod]
+    public void LeadingAndInteriorContainsCommentOrDirectiveIgnoresTrailingComment()
+    {
+        Assert.IsFalse(SyntaxNodeUtilities.LeadingAndInteriorContainsCommentOrDirective(GetArgumentList("""
+                                                                                                            Method("first",
+                                                                                                                   "second") /* note */;
+                                                                                                        """)));
+    }
+
+    /// <summary>
+    /// Verifies that the leading-and-interior predicate still reports a comment in the node's leading trivia, which
+    /// is the region such a rewrite can still reach
+    /// </summary>
+    [TestMethod]
+    public void LeadingAndInteriorContainsCommentOrDirectiveReportsLeadingComment()
+    {
+        Assert.IsTrue(SyntaxNodeUtilities.LeadingAndInteriorContainsCommentOrDirective(GetArgumentList("""
+                                                                                                           Method
+                                                                                                               /* note */ ("first",
+                                                                                                                           "second");
+                                                                                                       """)));
+    }
+
+    /// <summary>
+    /// Verifies that the leading-and-interior predicate still reports a comment inside the node's own span
+    /// </summary>
+    [TestMethod]
+    public void LeadingAndInteriorContainsCommentOrDirectiveReportsInteriorComment()
+    {
+        Assert.IsTrue(SyntaxNodeUtilities.LeadingAndInteriorContainsCommentOrDirective(GetArgumentList("""
+                                                                                                           Method("first", /* note */
+                                                                                                                  "second");
+                                                                                                       """)));
+    }
+
+    /// <summary>
     /// Verifies that the group predicate ignores a comment in front of the first sibling, so a documented
     /// member is not treated differently from an undocumented one
     /// </summary>

--- a/Reihitsu.Core/SyntaxNodeUtilities.cs
+++ b/Reihitsu.Core/SyntaxNodeUtilities.cs
@@ -119,6 +119,22 @@ public static class SyntaxNodeUtilities
     }
 
     /// <summary>
+    /// Determines whether a node's own span or its leading trivia contains a comment or a preprocessor directive,
+    /// ignoring only the trailing trivia. This is the predicate for a rewrite that reproduces everything after the
+    /// node verbatim but can still rewrite what precedes it — delegating the layout of a parenthesized list to
+    /// <c>ReihitsuFormatter.FormatNodeInDocumentAsync</c> is the case that needs it, because that entry point
+    /// restores the last token's trailing trivia unconditionally but the first token's leading trivia only when
+    /// that token does not start a line. <see cref="InteriorContainsCommentOrDirective"/> is the symmetric form,
+    /// for a rewrite that transplants the trivia on both sides
+    /// </summary>
+    /// <param name="node">Node</param>
+    /// <returns><see langword="true"/> if the node's span or leading trivia contains a comment or directive; otherwise <see langword="false"/></returns>
+    public static bool LeadingAndInteriorContainsCommentOrDirective(SyntaxNode node)
+    {
+        return SpanContainsCommentOrDirective(node, TextSpan.FromBounds(node.FullSpan.Start, node.Span.End));
+    }
+
+    /// <summary>
     /// Determines whether the region covered by a group of sibling nodes — including the gaps between them —
     /// contains a comment or a preprocessor directive. A rewrite that folds the siblings into one must refuse
     /// when trivia sits between them, because the fold would consume it, while the leading documentation

--- a/documentation/rules/RH3002.md
+++ b/documentation/rules/RH3002.md
@@ -19,6 +19,10 @@ Unnecessary parentheses create visual clutter. They can make simple expressions 
 
 Remove the parentheses when they do not affect the behavior of the expression.
 
+A comment written before or after the parenthesized expression does not withhold the code fix, because the rewrite transplants the expression's own outer trivia onto the replacement and leaves that comment untouched.
+
+A comment or directive written between the parentheses does withhold it, because removing them would discard that trivia. The diagnostic is still reported for that shape, and it has to be corrected by hand.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH3005.md
+++ b/documentation/rules/RH3005.md
@@ -19,6 +19,10 @@ Conditions are easier to read when the changing value appears first. Writing the
 
 Swap the operands so the variable or expression is on the left side.
 
+A comment written before or after the comparison does not withhold the code fix, because the rewrite transplants the comparison's own outer trivia onto the replacement and leaves that comment untouched.
+
+A comment or directive written inside the comparison does withhold it, because swapping the operands would relocate that trivia relative to the code it describes. The diagnostic is still reported for that shape, and it has to be corrected by hand.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH5101.md
+++ b/documentation/rules/RH5101.md
@@ -21,6 +21,10 @@ Move the first argument to the same line as the opening parenthesis. The code fi
 
 When a comment or directive sits in the gap between the opening parenthesis and the first argument, the shape is not reported, because the formatter refuses to collapse across that trivia.
 
+A comment that follows the closing parenthesis is not crossed by the rewrite, so it does not withhold the code fix. A call whose arguments are split across lines and whose closing parenthesis is followed by `/* note */` is reported and fixed, with the comment left exactly where it was written.
+
+A comment written before the opening parenthesis is a different case: the rewrite can still reach that region, because the formatter restores the first token's leading trivia only when that token does not start a line. The diagnostic is still reported there, but no code fix is offered and the layout has to be corrected by hand.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH5101.md
+++ b/documentation/rules/RH5101.md
@@ -23,7 +23,7 @@ When a comment or directive sits in the gap between the opening parenthesis and 
 
 A comment that follows the closing parenthesis is not crossed by the rewrite, so it does not withhold the code fix. A call whose arguments are split across lines and whose closing parenthesis is followed by `/* note */` is reported and fixed, with the comment left exactly where it was written.
 
-A comment written before the opening parenthesis is a different case: the rewrite can still reach that region, because the formatter restores the first token's leading trivia only when that token does not start a line. The diagnostic is still reported there, but no code fix is offered and the layout has to be corrected by hand.
+A comment written on its own line between the callee and the opening parenthesis is a different case: the rewrite can still reach that region, because the formatter restores the first token's leading trivia only when that token does not start a line. The diagnostic is still reported there, but no code fix is offered and the layout has to be corrected by hand. A comment on the same line as the callee — `Add /* note */ (` — belongs to the callee instead and does not withhold the fix.
 
 ## Examples
 

--- a/documentation/rules/RH5102.md
+++ b/documentation/rules/RH5102.md
@@ -21,6 +21,10 @@ Inconsistent argument placement makes it harder to scan and understand method ca
 
 Either place all arguments on a single line, or place each argument on its own line. The code fix will automatically place each argument on its own line.
 
+A comment that follows the closing parenthesis is not crossed by the rewrite, so it does not withhold the code fix. A call whose arguments are split inconsistently and whose closing parenthesis is followed by `/* note */` is reported and fixed, with the comment left exactly where it was written.
+
+A comment or directive sitting between the parentheses does withhold it, because redistributing the arguments would relocate that trivia. A comment written before the opening parenthesis withholds it too, because the formatter restores the first token's leading trivia only when that token does not start a line. Both shapes are still reported and have to be corrected by hand.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH5102.md
+++ b/documentation/rules/RH5102.md
@@ -23,7 +23,7 @@ Either place all arguments on a single line, or place each argument on its own l
 
 A comment that follows the closing parenthesis is not crossed by the rewrite, so it does not withhold the code fix. A call whose arguments are split inconsistently and whose closing parenthesis is followed by `/* note */` is reported and fixed, with the comment left exactly where it was written.
 
-A comment or directive sitting between the parentheses does withhold it, because redistributing the arguments would relocate that trivia. A comment written before the opening parenthesis withholds it too, because the formatter restores the first token's leading trivia only when that token does not start a line. Both shapes are still reported and have to be corrected by hand.
+A comment or directive sitting between the parentheses does withhold it, because redistributing the arguments would relocate that trivia. A comment written on its own line between the callee and the opening parenthesis withholds it too, because the formatter restores the first token's leading trivia only when that token does not start a line. Both shapes are still reported and have to be corrected by hand. A comment on the same line as the callee — `Add /* note */ (` — belongs to the callee instead and does not withhold the fix.
 
 ## Examples
 

--- a/documentation/rules/RH5109.md
+++ b/documentation/rules/RH5109.md
@@ -21,7 +21,7 @@ Either keep all parameters on one line or put each parameter on its own line. Th
 
 A comment that follows the closing parenthesis is not crossed by the rewrite, so it does not withhold the code fix. A parameter list that is split inconsistently and whose closing parenthesis is followed by `/* note */` is reported and fixed, with the comment left exactly where it was written.
 
-A comment or directive sitting between the parentheses does withhold it, because the fix rebuilds the list from the parameter spans and would drop that trivia. A comment written before the opening parenthesis withholds it as well: the replacement could not reach that region, but the guard covers it anyway so that this rule, RH5101 and RH5102 read alike. Both shapes are still reported and have to be corrected by hand.
+A comment or directive sitting between the parentheses does withhold it, because the fix rebuilds the list from the parameter spans and would drop that trivia. A comment written on its own line between the method name and the opening parenthesis withholds it as well: the replacement could not reach that region, but the guard covers it anyway so that this rule, RH5101 and RH5102 read alike. Both shapes are still reported and have to be corrected by hand. A comment on the same line as the method name — `void Method /* note */ (` — belongs to the name instead and does not withhold the fix.
 
 ## Examples
 

--- a/documentation/rules/RH5109.md
+++ b/documentation/rules/RH5109.md
@@ -19,6 +19,10 @@ Partially split parameter lists are harder to scan because the reader cannot qui
 
 Either keep all parameters on one line or put each parameter on its own line. The code fix will apply the separate-line form automatically.
 
+A comment that follows the closing parenthesis is not crossed by the rewrite, so it does not withhold the code fix. A parameter list that is split inconsistently and whose closing parenthesis is followed by `/* note */` is reported and fixed, with the comment left exactly where it was written.
+
+A comment or directive sitting between the parentheses does withhold it, because the fix rebuilds the list from the parameter spans and would drop that trivia. A comment written before the opening parenthesis withholds it as well: the replacement could not reach that region, but the guard covers it anyway so that this rule, RH5101 and RH5102 read alike. Both shapes are still reported and have to be corrected by hand.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH5408.md
+++ b/documentation/rules/RH5408.md
@@ -40,7 +40,11 @@ Auto-properties are not reported when a comment or directive would be crossed by
 
 A comment that follows the accessor list is not crossed by the collapse, so it does not exempt the property. `public int Value { get; set; } // explanation` stays on one line, and the multi-line form of the same declaration is reported and collapsed with the comment kept in place.
 
-The terminating semicolon is part of the reported declaration too, so a semicolon broken onto its own line is reported and collapsed back onto the declaration line. A comment or directive between the initializer value and that semicolon exempts the property instead, because the formatter refuses to join across that trivia.
+The terminating semicolon is part of the reported declaration too, so a semicolon broken onto its own line is reported and collapsed back onto the declaration line. A comment between the initializer value and a semicolon that sits on a later line exempts the property instead, because the formatter refuses to join across that trivia. A line comment always has that effect, since it runs to the end of its line.
+
+A comment between the initializer value and a semicolon on the *same* line is never crossed, so it does not exempt the property. `public int Value { get; set; } = 1 /* note */;` keeps the comment where it was written, and the multi-line form of the same declaration is reported and collapsed.
+
+A comment between the equals token and the initializer value still exempts the property. That shape could be collapsed safely, but the guard covering the initializer's interior is the only owner of that gap, so the rule leaves it to manual correction rather than widening the guard.
 
 A property initializer is part of the reported declaration, so a comment or directive between the accessor list and an initializer that starts on a later line does exempt the property. The formatter cannot pull the initializer up across that trivia, and the rule stays silent rather than reporting a declaration that cannot be collapsed. Trivia in a gap that already sits on one line — for example `public int Value { get; set; } /* note */ = 1;` — is never crossed and does not exempt the property.
 


### PR DESCRIPTION
## Summary

Six guards asked whether a node's **full span** carried a comment or directive, while the rewrite they guard never writes outside the node's own span. Each is now scoped to the region its rewrite actually writes, derived per rule from the rewrite vehicle rather than copied:

| Rule | New region | Why that region |
|---|---|---|
| RH5101, RH5102, RH5109 code fixes | node's leading trivia + own span | `FormatNodeInDocumentAsync` restores the last token's trailing trivia unconditionally, but the first token's leading trivia only when it does not start a line |
| RH3002, RH3005 code fixes | node interior | Both rewrites transplant the node's outer trivia verbatim via `WithTriviaFrom` |
| RH5408 analyzer **and** code fix | initializer interior | The `}`→`=` and value→`;` gap guards already own the released regions wherever the collapse must join across them |

The shared span predicate lives in `SyntaxNodeUtilities.LeadingAndInteriorContainsCommentOrDirective`, a fourth member of that existing family, with each rule's justification kept at its call site.

`CLAUDE.md`, `AGENTS.md` and `.github/copilot-instructions.md` gain a **Code-fix coverage** policy; the first two also gain **Issue intake — question the report**.

## Why

Closes #650.

A comment behind a closing parenthesis withheld a fix that applies correctly, so the analyzer and the code fix disagreed about the same input. The new policy makes explicit that this is a guard-precision defect — not the absence of a fix — and that a diagnostic with no available fix is a supported end state.

## Review notes

**RH5408 widens a report surface.** A block comment between an initializer value and a same-line semicolon now reports where the analyzer was previously silent (9 measured variants, 0 regressions across 31 fixtures). This goes beyond issue #650 and was taken on an explicit maintainer decision. The justification is not the issue's severity claim but that the analyzer was silent about a shape `reihitsu-format` already reformats. The analyzer and code-fix predicates are identical and move together, so a reported property always has an action.

**The shipped change rejects parts of the issue.** The issue argues this is "more severe than" #604 and #610 because a reported diagnostic gets no fix; per the `Code-fix coverage` policy added here, that is not a defect in itself, so the severity escalation does not hold. The issue's stated reason for per-rule guards ("the three rules do not cross the same gap") is also wrong — the interior is identical for all three; the dimension that differs is the rewrite vehicle. Its reported-span warning was checked and is negative: no reported span extends past the closing parenthesis, so #604's extra gap guard has no counterpart here.

**Scope beyond the issue's three call sites** came from sweeping all ten production call sites of `ContainsCommentOrDirective`. `RH3102`, `RH3004` and `RH5111` were swept and correctly left alone — `RH3102` rewrites with `SyntaxRemoveOptions.KeepNoTrivia`, so its full-span guard is required.

**Deliberate residuals**, each recorded in the matching rule doc: a comment inside a list or between `=` and an initializer value still withholds the fix, and RH5109 keeps its unreachable leading-side guard so the three predicates read alike.

## Follow-up work

None.
