### PR TITLE
Correct analyzer ownership and spacing boundaries

### DIFF
--- a/Reihitsu.Analyzer.CodeFixes/Rules/Clarity/RH3202ExpressionStyleMethodsShouldNotBeUsedCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Clarity/RH3202ExpressionStyleMethodsShouldNotBeUsedCodeFixProvider.cs
@@ -56,7 +56,10 @@ public class RH3202ExpressionStyleMethodsShouldNotBeUsedCodeFixProvider : CodeFi
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (root.FindNode(diagnostic.Location.SourceSpan) is MethodDeclarationSyntax methodDeclaration)
+                var methodDeclaration = root.FindNode(diagnostic.Location.SourceSpan)
+                                            .FirstAncestorOrSelf<MethodDeclarationSyntax>();
+
+                if (methodDeclaration != null)
                 {
                     context.RegisterCodeFix(CodeAction.Create(CodeFixResources.RH3202Title,
                                                               cancellationToken => ApplyCodeFixAsync(context.Document, methodDeclaration, cancellationToken),

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Clarity/RH3203ExpressionStyleConstructorsShouldNotBeUsedCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Clarity/RH3203ExpressionStyleConstructorsShouldNotBeUsedCodeFixProvider.cs
@@ -59,7 +59,10 @@ public class RH3203ExpressionStyleConstructorsShouldNotBeUsedCodeFixProvider : C
 
         foreach (var diagnostic in context.Diagnostics)
         {
-            if (root.FindNode(diagnostic.Location.SourceSpan) is ConstructorDeclarationSyntax constructorDeclaration)
+            var constructorDeclaration = root.FindNode(diagnostic.Location.SourceSpan)
+                                             .FirstAncestorOrSelf<ConstructorDeclarationSyntax>();
+
+            if (constructorDeclaration != null)
             {
                 context.RegisterCodeFix(CodeAction.Create(CodeFixResources.RH3203Title,
                                                           token => ApplyCodeFixAsync(context.Document, constructorDeclaration, token),

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Design/RH2004AccessModifierMustBeDeclaredCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Design/RH2004AccessModifierMustBeDeclaredCodeFixProvider.cs
@@ -39,7 +39,7 @@ public class RH2004AccessModifierMustBeDeclaredCodeFixProvider : CodeFixProvider
             return document;
         }
 
-        var updatedDeclaration = await CreateUpdatedDeclarationAsync(document, memberDeclaration, cancellationToken).ConfigureAwait(false);
+        var updatedDeclaration = CreateUpdatedDeclaration(memberDeclaration);
         var updatedRoot = root.ReplaceNode(memberDeclaration, updatedDeclaration);
 
         return document.WithSyntaxRoot(updatedRoot);
@@ -48,35 +48,16 @@ public class RH2004AccessModifierMustBeDeclaredCodeFixProvider : CodeFixProvider
     /// <summary>
     /// Creates the declaration with the missing accessibility modifier added
     /// </summary>
-    /// <param name="document">Document</param>
     /// <param name="memberDeclaration">Declaration</param>
-    /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>The updated declaration</returns>
-    private static async Task<MemberDeclarationSyntax> CreateUpdatedDeclarationAsync(Document document, MemberDeclarationSyntax memberDeclaration, CancellationToken cancellationToken)
+    private static MemberDeclarationSyntax CreateUpdatedDeclaration(MemberDeclarationSyntax memberDeclaration)
     {
-        // A partial type may declare its accessibility on another part. Selecting the modifier syntactically would
-        // insert a conflicting one next to that part (CS0262), so the already declared accessibility is read from
-        // the merged declared symbol instead.
-        if (memberDeclaration is TypeDeclarationSyntax typeDeclaration
-            && typeDeclaration.Modifiers.Any(SyntaxKind.PartialKeyword))
-        {
-            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-
-            if (semanticModel?.GetDeclaredSymbol(typeDeclaration, cancellationToken) is { } declaredSymbol)
-            {
-                var accessibilityModifiers = DeclarationModifierUtilities.GetAccessibilityModifierKinds(declaredSymbol.DeclaredAccessibility);
-
-                if (accessibilityModifiers.Count > 0)
-                {
-                    return DeclarationModifierUtilities.AddAccessibilityModifiers(typeDeclaration, accessibilityModifiers);
-                }
-            }
-        }
-
-        var defaultModifier = memberDeclaration.Parent is CompilationUnitSyntax
-                                                       or BaseNamespaceDeclarationSyntax
-                                  ? SyntaxKind.InternalKeyword
-                                  : SyntaxKind.PrivateKeyword;
+        var defaultModifier = memberDeclaration.Parent switch
+                              {
+                                  CompilationUnitSyntax or BaseNamespaceDeclarationSyntax => SyntaxKind.InternalKeyword,
+                                  InterfaceDeclarationSyntax => SyntaxKind.PublicKeyword,
+                                  _ => SyntaxKind.PrivateKeyword
+                              };
 
         return DeclarationModifierUtilities.AddAccessibilityModifier(memberDeclaration, defaultModifier);
     }

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Naming/RH4102CustomEventNameCasingCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Naming/RH4102CustomEventNameCasingCodeFixProvider.cs
@@ -1,4 +1,4 @@
-﻿using System.Composition;
+using System.Composition;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -11,18 +11,18 @@ using Reihitsu.Core;
 namespace Reihitsu.Analyzer.CodeFixes.Rules.Naming;
 
 /// <summary>
-/// Providing fixes for <see cref="RH4102EventNameCasingAnalyzer"/>
+/// Providing fixes for custom event declarations reported by <see cref="RH4102EventNameCasingAnalyzer"/>
 /// </summary>
 [Shared]
-[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(RH4102EventNameCasingCodeFixProvider))]
-public class RH4102EventNameCasingCodeFixProvider : CasingCodeFixProviderBase<VariableDeclaratorSyntax>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(RH4102CustomEventNameCasingCodeFixProvider))]
+internal sealed class RH4102CustomEventNameCasingCodeFixProvider : CasingCodeFixProviderBase<EventDeclarationSyntax>
 {
     #region Constructor
 
     /// <summary>
     /// Constructor
     /// </summary>
-    public RH4102EventNameCasingCodeFixProvider()
+    public RH4102CustomEventNameCasingCodeFixProvider()
         : base(RH4102EventNameCasingAnalyzer.DiagnosticId, CodeFixResources.RH4102Title, CasingUtilities.ToPascalCase)
     {
     }
@@ -32,7 +32,7 @@ public class RH4102EventNameCasingCodeFixProvider : CasingCodeFixProviderBase<Va
     #region CasingCodeFixProviderBase
 
     /// <inheritdoc/>
-    protected override string GetIdentifier(VariableDeclaratorSyntax node)
+    protected override string GetIdentifier(EventDeclarationSyntax node)
     {
         return node.Identifier.ValueText;
     }

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Naming/RH4102EventNameCasingCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Naming/RH4102EventNameCasingCodeFixProvider.cs
@@ -15,7 +15,7 @@ namespace Reihitsu.Analyzer.CodeFixes.Rules.Naming;
 /// </summary>
 [Shared]
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(RH4102EventNameCasingCodeFixProvider))]
-public class RH4102EventNameCasingCodeFixProvider : CasingCodeFixProviderBase<VariableDeclaratorSyntax>
+public class RH4102EventNameCasingCodeFixProvider : CasingCodeFixProviderBase<SyntaxNode>
 {
     #region Constructor
 
@@ -32,9 +32,14 @@ public class RH4102EventNameCasingCodeFixProvider : CasingCodeFixProviderBase<Va
     #region CasingCodeFixProviderBase
 
     /// <inheritdoc/>
-    protected override string GetIdentifier(VariableDeclaratorSyntax node)
+    protected override string GetIdentifier(SyntaxNode node)
     {
-        return node.Identifier.ValueText;
+        return node switch
+               {
+                   VariableDeclaratorSyntax variableDeclarator => variableDeclarator.Identifier.ValueText,
+                   EventDeclarationSyntax eventDeclaration => eventDeclaration.Identifier.ValueText,
+                   _ => string.Empty
+               };
     }
 
     #endregion // CasingCodeFixProviderBase

--- a/Reihitsu.Analyzer.Test/Design/RH2003NotImplementedExceptionShouldNotBeUsedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Design/RH2003NotImplementedExceptionShouldNotBeUsedAnalyzerTests.cs
@@ -66,5 +66,47 @@ public class RH2003NotImplementedExceptionShouldNotBeUsedAnalyzerTests : Analyze
         await Verify(testData, Diagnostics(RH2003NotImplementedExceptionShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH2003MessageFormat, 3));
     }
 
+    /// <summary>
+    /// Verifying that implicit creation of <see cref="System.NotImplementedException"/> triggers a diagnostic
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyImplicitNotImplementedExceptionDiagnostic()
+    {
+        const string testData = """
+                                using System;
+
+                                namespace Reihitsu.Analyzer.Test.Design.Resources;
+
+                                internal class Sample
+                                {
+                                    private readonly NotImplementedException exception = {|#0:new|}();
+                                }
+                                """;
+
+        await Verify(testData, Diagnostics(RH2003NotImplementedExceptionShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH2003MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifying that implicit creation of another exception type does not trigger a diagnostic
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyImplicitOtherExceptionDoesNotTriggerDiagnostic()
+    {
+        const string testData = """
+                                using System;
+
+                                namespace Reihitsu.Analyzer.Test.Design.Resources;
+
+                                internal class Sample
+                                {
+                                    private readonly InvalidOperationException exception = new();
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Design/RH2004AccessModifierMustBeDeclaredAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Design/RH2004AccessModifierMustBeDeclaredAnalyzerTests.cs
@@ -48,13 +48,6 @@ public class RH2004AccessModifierMustBeDeclaredAnalyzerTests : AnalyzerTestsBase
                                 internal interface IContract
                                 {
                                     void InterfaceMethod();
-
-                                    class NestedInterfaceType
-                                    {
-                                        void NestedInterfaceMethod()
-                                        {
-                                        }
-                                    }
                                 }
                                 """;
 
@@ -83,17 +76,58 @@ public class RH2004AccessModifierMustBeDeclaredAnalyzerTests : AnalyzerTestsBase
                                   internal interface IContract
                                   {
                                       void InterfaceMethod();
-
-                                      class NestedInterfaceType
-                                      {
-                                          void NestedInterfaceMethod()
-                                          {
-                                          }
-                                      }
                                   }
                                   """;
 
         await Verify(testData, resultData, Diagnostics(RH2004AccessModifierMustBeDeclaredAnalyzer.DiagnosticId, AnalyzerResources.RH2004MessageFormat, 4));
+    }
+
+    /// <summary>
+    /// Verifying that direct interface members are exempt while a nested type and its members are analyzed
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyOnlyDirectInterfaceMembersAreExempt()
+    {
+        const string testData = """
+                                namespace Reihitsu.Analyzer.Test.Design.Resources;
+
+                                internal interface IContract
+                                {
+                                    void InterfaceMethod();
+
+                                    class {|#0:NestedType|}
+                                    {
+                                        void {|#1:NestedMethod|}()
+                                        {
+                                        }
+                                    }
+                                }
+                                """;
+
+        await Verify(testData, Diagnostics(RH2004AccessModifierMustBeDeclaredAnalyzer.DiagnosticId, AnalyzerResources.RH2004MessageFormat, 2));
+    }
+
+    /// <summary>
+    /// Verifying that a non-partial record struct without explicit accessibility is reported
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNonPartialRecordStructIsReportedAndFixed()
+    {
+        const string testData = """
+                                namespace Reihitsu.Analyzer.Test.Design.Resources;
+
+                                record struct {|#0:Sample|};
+                                """;
+
+        const string resultData = """
+                                  namespace Reihitsu.Analyzer.Test.Design.Resources;
+
+                                  internal record struct Sample;
+                                  """;
+
+        await Verify(testData, resultData, Diagnostics(RH2004AccessModifierMustBeDeclaredAnalyzer.DiagnosticId, AnalyzerResources.RH2004MessageFormat));
     }
 
     /// <summary>
@@ -173,13 +207,11 @@ public class RH2004AccessModifierMustBeDeclaredAnalyzerTests : AnalyzerTestsBase
     }
 
     /// <summary>
-    /// Verifying that a partial type without an explicit accessibility adopts the accessibility declared on
-    /// another part instead of the syntactic default, so the fixed code does not introduce a conflicting
-    /// modifier (CS0262)
+    /// Verifying that partial types with accessibility declared on another part are owned by RH7104
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
     [TestMethod]
-    public async Task VerifyPartialTypeAdoptsPublicAccessibilityDeclaredOnAnotherPart()
+    public async Task VerifyPartialTypeWithAccessibilityOnAnotherPartDoesNotTriggerDiagnostic()
     {
         const string testData = """
                                 namespace Reihitsu.Analyzer.Test.Design.Resources;
@@ -188,33 +220,20 @@ public class RH2004AccessModifierMustBeDeclaredAnalyzerTests : AnalyzerTestsBase
                                 {
                                 }
 
-                                partial class {|#0:Sample|}
+                                partial class Sample
                                 {
                                 }
                                 """;
 
-        const string resultData = """
-                                  namespace Reihitsu.Analyzer.Test.Design.Resources;
-
-                                  public partial class Sample
-                                  {
-                                  }
-
-                                  public partial class Sample
-                                  {
-                                  }
-                                  """;
-
-        await Verify(testData, resultData, Diagnostics(RH2004AccessModifierMustBeDeclaredAnalyzer.DiagnosticId, AnalyzerResources.RH2004MessageFormat, 1));
+        await Verify(testData);
     }
 
     /// <summary>
-    /// Verifying that a nested partial type adopts a compound accessibility (<see langword="protected"/>
-    /// <see langword="internal"/>) declared on another part
+    /// Verifying that nested partial types are owned by RH7104
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
     [TestMethod]
-    public async Task VerifyNestedPartialTypeAdoptsProtectedInternalAccessibilityDeclaredOnAnotherPart()
+    public async Task VerifyNestedPartialTypeDoesNotTriggerDiagnostic()
     {
         const string testData = """
                                 namespace Reihitsu.Analyzer.Test.Design.Resources;
@@ -228,90 +247,47 @@ public class RH2004AccessModifierMustBeDeclaredAnalyzerTests : AnalyzerTestsBase
 
                                 internal partial class Outer
                                 {
-                                    partial class {|#0:Inner|}
+                                    partial class Inner
                                     {
                                     }
                                 }
                                 """;
 
-        const string resultData = """
-                                  namespace Reihitsu.Analyzer.Test.Design.Resources;
-
-                                  internal partial class Outer
-                                  {
-                                      protected internal partial class Inner
-                                      {
-                                      }
-                                  }
-
-                                  internal partial class Outer
-                                  {
-                                      protected internal partial class Inner
-                                      {
-                                      }
-                                  }
-                                  """;
-
-        await Verify(testData, resultData, Diagnostics(RH2004AccessModifierMustBeDeclaredAnalyzer.DiagnosticId, AnalyzerResources.RH2004MessageFormat, 1));
+        await Verify(testData);
     }
 
     /// <summary>
-    /// Verifying that a single-part partial type at namespace level keeps the existing <see langword="internal"/>
-    /// default
+    /// Verifying that all partial type kinds are owned by RH7104
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
     [TestMethod]
-    public async Task VerifySinglePartPartialTypeAtNamespaceLevelReceivesInternal()
+    public async Task VerifyPartialTypesDoNotTriggerDiagnostics()
     {
         const string testData = """
                                 namespace Reihitsu.Analyzer.Test.Design.Resources;
 
-                                partial class {|#0:Sample|}
+                                partial class SampleClass
+                                {
+                                }
+
+                                partial struct SampleStruct
+                                {
+                                }
+
+                                partial interface ISample
+                                {
+                                }
+
+                                partial record SampleRecord
+                                {
+                                }
+
+                                partial record struct SampleRecordStruct
                                 {
                                 }
                                 """;
 
-        const string resultData = """
-                                  namespace Reihitsu.Analyzer.Test.Design.Resources;
-
-                                  internal partial class Sample
-                                  {
-                                  }
-                                  """;
-
-        await Verify(testData, resultData, Diagnostics(RH2004AccessModifierMustBeDeclaredAnalyzer.DiagnosticId, AnalyzerResources.RH2004MessageFormat, 1));
-    }
-
-    /// <summary>
-    /// Verifying that a nested single-part partial type keeps the existing <see langword="private"/> default
-    /// </summary>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
-    [TestMethod]
-    public async Task VerifyNestedSinglePartPartialTypeReceivesPrivate()
-    {
-        const string testData = """
-                                namespace Reihitsu.Analyzer.Test.Design.Resources;
-
-                                internal class Outer
-                                {
-                                    partial class {|#0:Inner|}
-                                    {
-                                    }
-                                }
-                                """;
-
-        const string resultData = """
-                                  namespace Reihitsu.Analyzer.Test.Design.Resources;
-
-                                  internal class Outer
-                                  {
-                                      private partial class Inner
-                                      {
-                                      }
-                                  }
-                                  """;
-
-        await Verify(testData, resultData, Diagnostics(RH2004AccessModifierMustBeDeclaredAnalyzer.DiagnosticId, AnalyzerResources.RH2004MessageFormat, 1));
+        await Verify(testData);
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer.Test/Design/RH2004AccessModifierMustBeDeclaredAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Design/RH2004AccessModifierMustBeDeclaredAnalyzerTests.cs
@@ -105,7 +105,23 @@ public class RH2004AccessModifierMustBeDeclaredAnalyzerTests : AnalyzerTestsBase
                                 }
                                 """;
 
-        await Verify(testData, Diagnostics(RH2004AccessModifierMustBeDeclaredAnalyzer.DiagnosticId, AnalyzerResources.RH2004MessageFormat, 2));
+        const string resultData = """
+                                  namespace Reihitsu.Analyzer.Test.Design.Resources;
+
+                                  internal interface IContract
+                                  {
+                                      void InterfaceMethod();
+
+                                      public class NestedType
+                                      {
+                                          private void NestedMethod()
+                                          {
+                                          }
+                                      }
+                                  }
+                                  """;
+
+        await Verify(testData, resultData.ReplaceLineEndings("\r\n"), Diagnostics(RH2004AccessModifierMustBeDeclaredAnalyzer.DiagnosticId, AnalyzerResources.RH2004MessageFormat, 2));
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer.Test/Design/RH2004AccessModifierMustBeDeclaredAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Design/RH2004AccessModifierMustBeDeclaredAnalyzerTests.cs
@@ -121,7 +121,7 @@ public class RH2004AccessModifierMustBeDeclaredAnalyzerTests : AnalyzerTestsBase
                                   }
                                   """;
 
-        await Verify(testData, resultData.ReplaceLineEndings("\r\n"), Diagnostics(RH2004AccessModifierMustBeDeclaredAnalyzer.DiagnosticId, AnalyzerResources.RH2004MessageFormat, 2));
+        await Verify(testData, resultData.ReplaceLineEndings(System.Environment.NewLine), Diagnostics(RH2004AccessModifierMustBeDeclaredAnalyzer.DiagnosticId, AnalyzerResources.RH2004MessageFormat, 2));
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer.Test/Design/RH2005FieldsMustBePrivateAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Design/RH2005FieldsMustBePrivateAnalyzerTests.cs
@@ -17,7 +17,7 @@ public class RH2005FieldsMustBePrivateAnalyzerTests : AnalyzerTestsBase<RH2005Fi
     #region Tests
 
     /// <summary>
-    /// Verifying that exposed fields trigger diagnostics and are fixed
+    /// Verifying that public fields in classes and record classes trigger diagnostics and are fixed
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
     [TestMethod]
@@ -30,9 +30,13 @@ public class RH2005FieldsMustBePrivateAnalyzerTests : AnalyzerTestsBase<RH2005Fi
                                 {
                                     public string {|#0:publicField|};
 
-                                    protected int {|#1:protectedField|};
+                                    protected int protectedField;
 
-                                    internal bool {|#2:internalField|};
+                                    internal bool internalField;
+
+                                    protected internal int protectedInternalField;
+
+                                    private protected int privateProtectedField;
 
                                     private string privateField;
 
@@ -50,7 +54,12 @@ public class RH2005FieldsMustBePrivateAnalyzerTests : AnalyzerTestsBase<RH2005Fi
 
                                 public record SampleRecord
                                 {
-                                    public int {|#3:recordField|};
+                                    public int {|#1:recordField|};
+                                }
+
+                                public record struct SampleRecordStruct
+                                {
+                                    public int PublicField;
                                 }
                                 """;
 
@@ -61,9 +70,13 @@ public class RH2005FieldsMustBePrivateAnalyzerTests : AnalyzerTestsBase<RH2005Fi
                                   {
                                       private string publicField;
 
-                                      private int protectedField;
+                                      protected int protectedField;
 
-                                      private bool internalField;
+                                      internal bool internalField;
+
+                                      protected internal int protectedInternalField;
+
+                                      private protected int privateProtectedField;
 
                                       private string privateField;
 
@@ -83,9 +96,46 @@ public class RH2005FieldsMustBePrivateAnalyzerTests : AnalyzerTestsBase<RH2005Fi
                                   {
                                       private int recordField;
                                   }
+
+                                  public record struct SampleRecordStruct
+                                  {
+                                      public int PublicField;
+                                  }
                                   """;
 
-        await Verify(testData, resultData, Diagnostics(RH2005FieldsMustBePrivateAnalyzer.DiagnosticId, AnalyzerResources.RH2005MessageFormat, 4));
+        await Verify(testData, resultData, Diagnostics(RH2005FieldsMustBePrivateAnalyzer.DiagnosticId, AnalyzerResources.RH2005MessageFormat, 2));
+    }
+
+    /// <summary>
+    /// Verifying that non-public fields in classes and record classes do not trigger diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNonPublicFieldsDoNotTriggerDiagnostics()
+    {
+        const string testData = """
+                                namespace Reihitsu.Analyzer.Test.Design.Resources;
+
+                                internal class SampleClass
+                                {
+                                    internal int InternalField;
+                                    protected int ProtectedField;
+                                    protected internal int ProtectedInternalField;
+                                    private protected int PrivateProtectedField;
+                                    private int PrivateField;
+                                }
+
+                                internal record SampleRecord
+                                {
+                                    internal int InternalField;
+                                    protected int ProtectedField;
+                                    protected internal int ProtectedInternalField;
+                                    private protected int PrivateProtectedField;
+                                    private int PrivateField;
+                                }
+                                """;
+
+        await Verify(testData);
     }
 
     #endregion // Tests

--- a/Reihitsu.Analyzer.Test/Design/RH2006DebugAssertMustProvideMessageTextAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Design/RH2006DebugAssertMustProvideMessageTextAnalyzerTests.cs
@@ -79,6 +79,31 @@ public class RH2006DebugAssertMustProvideMessageTextAnalyzerTests : AnalyzerTest
     }
 
     /// <summary>
+    /// Verifying that named arguments are associated with the message parameter rather than their source order
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyReversedNamedArgumentsUseMessageParameter()
+    {
+        const string testData = """
+                                using System.Diagnostics;
+
+                                namespace Reihitsu.Analyzer.Test.Design.Resources;
+
+                                internal static class Sample
+                                {
+                                    internal static void Verify()
+                                    {
+                                        {|#0:Debug.Assert(message: "", condition: true)|};
+                                        Debug.Assert(message: "Condition must hold.", condition: true);
+                                    }
+                                }
+                                """;
+
+        await Verify(testData, Diagnostics(RH2006DebugAssertMustProvideMessageTextAnalyzer.DiagnosticId, AnalyzerResources.RH2006MessageFormat));
+    }
+
+    /// <summary>
     /// Verifying that descriptive and nonconstant messages do not trigger diagnostics
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer.Test/Design/RH2006DebugAssertMustProvideMessageTextAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Design/RH2006DebugAssertMustProvideMessageTextAnalyzerTests.cs
@@ -52,5 +52,56 @@ public class RH2006DebugAssertMustProvideMessageTextAnalyzerTests : AnalyzerTest
         await Verify(testData, Diagnostics(RH2006DebugAssertMustProvideMessageTextAnalyzer.DiagnosticId, AnalyzerResources.RH2006MessageFormat, 2));
     }
 
+    /// <summary>
+    /// Verifying that constant messages without text trigger diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNullEmptyAndWhitespaceMessagesTriggerDiagnostics()
+    {
+        const string testData = """
+                                using System.Diagnostics;
+
+                                namespace Reihitsu.Analyzer.Test.Design.Resources;
+
+                                internal static class Sample
+                                {
+                                    internal static void Verify(bool condition)
+                                    {
+                                        {|#0:Debug.Assert(condition, null)|};
+                                        {|#1:Debug.Assert(condition, "")|};
+                                        {|#2:Debug.Assert(condition, "  \t")|};
+                                    }
+                                }
+                                """;
+
+        await Verify(testData, Diagnostics(RH2006DebugAssertMustProvideMessageTextAnalyzer.DiagnosticId, AnalyzerResources.RH2006MessageFormat, 3));
+    }
+
+    /// <summary>
+    /// Verifying that descriptive and nonconstant messages do not trigger diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNonemptyAndNonconstantMessagesDoNotTriggerDiagnostics()
+    {
+        const string testData = """
+                                using System.Diagnostics;
+
+                                namespace Reihitsu.Analyzer.Test.Design.Resources;
+
+                                internal static class Sample
+                                {
+                                    internal static void Verify(bool condition, string message)
+                                    {
+                                        Debug.Assert(condition, "Condition must hold.");
+                                        Debug.Assert(condition, message);
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Design/RH2007DebugFailMustProvideMessageTextAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Design/RH2007DebugFailMustProvideMessageTextAnalyzerTests.cs
@@ -54,5 +54,28 @@ public class RH2007DebugFailMustProvideMessageTextAnalyzerTests : AnalyzerTestsB
         await Verify(testData, Diagnostics(RH2007DebugFailMustProvideMessageTextAnalyzer.DiagnosticId, AnalyzerResources.RH2007MessageFormat, 3));
     }
 
+    /// <summary>
+    /// Verifies that the message parameter is analyzed when named arguments are in reverse source order
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyReorderedNamedMessageArgumentIsAnalyzed()
+    {
+        const string testData = """
+                                using System.Diagnostics;
+
+                                internal static class Sample
+                                {
+                                    internal static void Verify()
+                                    {
+                                        {|#0:Debug.Fail(detailMessage: "detail", message: "")|};
+                                        Debug.Fail(detailMessage: "detail", message: "Do not get here.");
+                                    }
+                                }
+                                """;
+
+        await Verify(testData, Diagnostics(RH2007DebugFailMustProvideMessageTextAnalyzer.DiagnosticId, AnalyzerResources.RH2007MessageFormat));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH3202ExpressionStyleMethodsShouldNotBeUsedFormatterTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH3202ExpressionStyleMethodsShouldNotBeUsedFormatterTests.cs
@@ -40,7 +40,7 @@ public class RH3202ExpressionStyleMethodsShouldNotBeUsedFormatterTests : Formatt
 
         await VerifyFormatterFix(input,
                                  fixedData,
-                                 ExpectedDiagnostic(RH3202ExpressionStyleMethodsShouldNotBeUsedAnalyzer.DiagnosticId, 3, 5, 3, 35, AnalyzerResources.RH3202MessageFormat));
+                                 ExpectedDiagnostic(RH3202ExpressionStyleMethodsShouldNotBeUsedAnalyzer.DiagnosticId, 3, 29, 3, 34, AnalyzerResources.RH3202MessageFormat));
     }
 
     #endregion // Tests

--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH3203ExpressionStyleConstructorsShouldNotBeUsedFormatterTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH3203ExpressionStyleConstructorsShouldNotBeUsedFormatterTests.cs
@@ -44,7 +44,7 @@ public class RH3203ExpressionStyleConstructorsShouldNotBeUsedFormatterTests : Fo
 
         await VerifyFormatterFix(input,
                                  fixedData,
-                                 ExpectedDiagnostic(RH3203ExpressionStyleConstructorsShouldNotBeUsedAnalyzer.DiagnosticId, 3, 5, 3, 38, AnalyzerResources.RH3203MessageFormat));
+                                 ExpectedDiagnostic(RH3203ExpressionStyleConstructorsShouldNotBeUsedAnalyzer.DiagnosticId, 3, 24, 3, 37, AnalyzerResources.RH3203MessageFormat));
     }
 
     #endregion // Tests

--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH6003SemicolonsMustBeSpacedCorrectlyFormatterTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH6003SemicolonsMustBeSpacedCorrectlyFormatterTests.cs
@@ -47,6 +47,27 @@ public class RH6003SemicolonsMustBeSpacedCorrectlyFormatterTests : FormatterTest
     }
 
     /// <summary>
+    /// Verifies that continuation-line indentation is stable and analyzer-clean with LF and CRLF line endings
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyContinuationLineSemicolonStaysAnalyzerClean()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method()
+                                    {
+                                        int value = 1
+                                        ;
+                                    }
+                                }
+                                """;
+
+        await VerifyFormatterStability(testData);
+    }
+
+    /// <summary>
     /// Verifies that a documentation comment in front of the terminating semicolon leaves the formatter output analyzer-clean. The
     /// horizontal spacing rewriter exempts the gap in front of such a comment from normalization, so the exemption
     /// must not be wide enough to leave a space this analyzer reports (issues #591, #625)

--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH6011OpeningGenericBracketsMustBeSpacedCorrectlyFormatterTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH6011OpeningGenericBracketsMustBeSpacedCorrectlyFormatterTests.cs
@@ -48,5 +48,27 @@ public class RH6011OpeningGenericBracketsMustBeSpacedCorrectlyFormatterTests : F
                                  Diagnostics(RH6011OpeningGenericBracketsMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6011MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies that a continuation-line opening generic bracket remains analyzer-clean with LF and CRLF line endings
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyContinuationLineOpeningGenericBracketStaysAnalyzerClean()
+    {
+        const string testData = """
+                                using System.Collections.Generic;
+                                internal class TestClass
+                                {
+                                    List
+                                    <int> Method()
+                                    {
+                                        return new();
+                                    }
+                                }
+                                """;
+
+        await VerifyFormatterStability(testData);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH6012ClosingGenericBracketsMustBeSpacedCorrectlyFormatterTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH6012ClosingGenericBracketsMustBeSpacedCorrectlyFormatterTests.cs
@@ -48,5 +48,27 @@ public class RH6012ClosingGenericBracketsMustBeSpacedCorrectlyFormatterTests : F
                                  Diagnostics(RH6012ClosingGenericBracketsMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6012MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies that a continuation-line closing generic bracket remains analyzer-clean with LF and CRLF line endings
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyContinuationLineClosingGenericBracketStaysAnalyzerClean()
+    {
+        const string testData = """
+                                using System.Collections.Generic;
+                                internal class TestClass
+                                {
+                                    List<int
+                                    > Method()
+                                    {
+                                        return new();
+                                    }
+                                }
+                                """;
+
+        await VerifyFormatterStability(testData);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH6014ClosingAttributeBracketsMustBeSpacedCorrectlyFormatterTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH6014ClosingAttributeBracketsMustBeSpacedCorrectlyFormatterTests.cs
@@ -70,5 +70,22 @@ public class RH6014ClosingAttributeBracketsMustBeSpacedCorrectlyFormatterTests :
                                  Diagnostics(RH6014ClosingAttributeBracketsMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6014MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies that a continuation-line closing attribute bracket remains analyzer-clean with LF and CRLF line endings
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyContinuationLineClosingAttributeBracketStaysAnalyzerClean()
+    {
+        const string testData = """
+                                [
+                                System.Obsolete
+                                ]
+                                internal class TestClass;
+                                """;
+
+        await VerifyFormatterStability(testData);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH6015NullableTypeSymbolsMustNotBePrecededBySpaceFormatterTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH6015NullableTypeSymbolsMustNotBePrecededBySpaceFormatterTests.cs
@@ -44,5 +44,25 @@ public class RH6015NullableTypeSymbolsMustNotBePrecededBySpaceFormatterTests : F
                                  Diagnostics(RH6015NullableTypeSymbolsMustNotBePrecededBySpaceAnalyzer.DiagnosticId, AnalyzerResources.RH6015MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies that a continuation-line nullable type symbol remains analyzer-clean with LF and CRLF line endings
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyContinuationLineNullableTypeSymbolStaysAnalyzerClean()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method(int
+                                    ? value)
+                                    {
+                                    }
+                                }
+                                """;
+
+        await VerifyFormatterStability(testData);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH6024BinaryOperatorsMustBeSpacedCorrectlyFormatterTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH6024BinaryOperatorsMustBeSpacedCorrectlyFormatterTests.cs
@@ -46,5 +46,36 @@ public class RH6024BinaryOperatorsMustBeSpacedCorrectlyFormatterTests : Formatte
                                  Diagnostics(RH6024BinaryOperatorsMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6024MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies that the formatter fixes keyword-operator spacing and remains stable with LF and CRLF line endings
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFormatterFixesKeywordOperatorsAndIsIdempotent()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    bool Method(object value)
+                                    {
+                                        return value  {|#0:is|}  string && value  {|#1:as|}  string != null;
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     bool Method(object value)
+                                     {
+                                         return value is string && value as string != null;
+                                     }
+                                 }
+                                 """;
+
+        await VerifyFormatterFixAndIdempotency(testData,
+                                               fixedData,
+                                               Diagnostics(RH6024BinaryOperatorsMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6024MessageFormat, 2));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatting/RH3202ExpressionStyleMethodsShouldNotBeUsedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH3202ExpressionStyleMethodsShouldNotBeUsedAnalyzerTests.cs
@@ -172,5 +172,41 @@ public class RH3202ExpressionStyleMethodsShouldNotBeUsedAnalyzerTests : Analyzer
                      Diagnostics(RH3202ExpressionStyleMethodsShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH3202MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies two expression-bodied methods are fixed in one Fix All iteration
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyTwoMethodsAreFixedInOneFixAllIteration()
+    {
+        const string testData = """
+                                internal class RH3202
+                                {
+                                    public int First() {|#0:=> 1|};
+
+                                    public int Second() {|#1:=> 2|};
+                                }
+                                """;
+
+        const string resultData = """
+                                  internal class RH3202
+                                  {
+                                      public int First()
+                                      {
+                                          return 1;
+                                      }
+                                      public int Second()
+                                      {
+                                          return 2;
+                                      }
+                                  }
+                                  """;
+
+        await Verify(testData.Replace("\r\n", "\n"),
+                     resultData.Replace("\r\n", "\n"),
+                     static config => config.NumberOfFixAllIterations = 1,
+                     Diagnostics(RH3202ExpressionStyleMethodsShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH3202MessageFormat, 2));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatting/RH3202ExpressionStyleMethodsShouldNotBeUsedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH3202ExpressionStyleMethodsShouldNotBeUsedAnalyzerTests.cs
@@ -26,7 +26,7 @@ public class RH3202ExpressionStyleMethodsShouldNotBeUsedAnalyzerTests : Analyzer
         const string testData = """
                                 internal class RH3202
                                 {
-                                    {|#0:public int GetValueExpression() => 42;|}
+                                    public int GetValueExpression() {|#0:=> 42|};
                                     
                                     public int GetValueBlock()
                                     {
@@ -50,7 +50,9 @@ public class RH3202ExpressionStyleMethodsShouldNotBeUsedAnalyzerTests : Analyzer
                                   }
                                   """;
 
-        await Verify(testData, resultData, Diagnostics(RH3202ExpressionStyleMethodsShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH3202MessageFormat));
+        await Verify(testData.Replace("\r\n", "\n"),
+                     resultData.Replace("\r\n", "\n"),
+                     Diagnostics(RH3202ExpressionStyleMethodsShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH3202MessageFormat));
     }
 
     /// <summary>
@@ -63,7 +65,7 @@ public class RH3202ExpressionStyleMethodsShouldNotBeUsedAnalyzerTests : Analyzer
         const string testData = """
                                 internal class RH3202
                                 {
-                                    {|#0:public int GetValue() => throw new System.Exception();|}
+                                    public int GetValue() {|#0:=> throw new System.Exception()|};
                                 }
                                 """;
 
@@ -77,7 +79,9 @@ public class RH3202ExpressionStyleMethodsShouldNotBeUsedAnalyzerTests : Analyzer
                                   }
                                   """;
 
-        await Verify(testData, resultData, Diagnostics(RH3202ExpressionStyleMethodsShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH3202MessageFormat));
+        await Verify(testData.Replace("\r\n", "\n"),
+                     resultData.Replace("\r\n", "\n"),
+                     Diagnostics(RH3202ExpressionStyleMethodsShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH3202MessageFormat));
     }
 
     /// <summary>
@@ -92,7 +96,7 @@ public class RH3202ExpressionStyleMethodsShouldNotBeUsedAnalyzerTests : Analyzer
 
                                 internal class RH3202
                                 {
-                                    {|#0:public async ValueTask DoWorkAsync() => await Task.CompletedTask;|}
+                                    public async ValueTask DoWorkAsync() {|#0:=> await Task.CompletedTask|};
                                 }
                                 """;
 
@@ -108,7 +112,9 @@ public class RH3202ExpressionStyleMethodsShouldNotBeUsedAnalyzerTests : Analyzer
                                   }
                                   """;
 
-        await Verify(testData, resultData, Diagnostics(RH3202ExpressionStyleMethodsShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH3202MessageFormat));
+        await Verify(testData.Replace("\r\n", "\n"),
+                     resultData.Replace("\r\n", "\n"),
+                     Diagnostics(RH3202ExpressionStyleMethodsShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH3202MessageFormat));
     }
 
     /// <summary>
@@ -143,9 +149,9 @@ public class RH3202ExpressionStyleMethodsShouldNotBeUsedAnalyzerTests : Analyzer
         const string testData = """
                                 internal class RH3202
                                 {
-                                    {|#0:public int GetValue() => 1
+                                    public int GetValue() {|#0:=> 1|}
                                 #pragma warning disable CS0618
-                                        ;|}
+                                        ;
                                 }
                                 """;
 
@@ -161,7 +167,9 @@ public class RH3202ExpressionStyleMethodsShouldNotBeUsedAnalyzerTests : Analyzer
                                   }
                                   """;
 
-        await Verify(testData, resultData, Diagnostics(RH3202ExpressionStyleMethodsShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH3202MessageFormat));
+        await Verify(testData.Replace("\r\n", "\n"),
+                     resultData.Replace("\r\n", "\n"),
+                     Diagnostics(RH3202ExpressionStyleMethodsShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH3202MessageFormat));
     }
 
     #endregion // Tests

--- a/Reihitsu.Analyzer.Test/Formatting/RH3203ExpressionStyleConstructorsShouldNotBeUsedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH3203ExpressionStyleConstructorsShouldNotBeUsedAnalyzerTests.cs
@@ -26,7 +26,7 @@ public class RH3203ExpressionStyleConstructorsShouldNotBeUsedAnalyzerTests : Ana
         const string testData = """
                                 internal class RH3203
                                 {
-                                    {|#0:public RH3203() => System.Console.WriteLine();|}
+                                    public RH3203() {|#0:=> System.Console.WriteLine()|};
                                 }
                                 """;
         const string fixedData = """
@@ -39,8 +39,8 @@ public class RH3203ExpressionStyleConstructorsShouldNotBeUsedAnalyzerTests : Ana
                                  }
                                  """;
 
-        await Verify(testData,
-                     fixedData,
+        await Verify(testData.Replace("\r\n", "\n"),
+                     fixedData.Replace("\r\n", "\n"),
                      Diagnostics(RH3203ExpressionStyleConstructorsShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH3203MessageFormat));
     }
 
@@ -54,8 +54,8 @@ public class RH3203ExpressionStyleConstructorsShouldNotBeUsedAnalyzerTests : Ana
         const string testData = """
                                 internal class RH3203
                                 {
-                                    {|#0:public RH3203() => System.Console.WriteLine();|}
-                                    {|#1:public RH3203(int i) => System.Console.WriteLine(i);|}
+                                    public RH3203() {|#0:=> System.Console.WriteLine()|};
+                                    public RH3203(int i) {|#1:=> System.Console.WriteLine(i)|};
                                 }
 
                                 internal class RH3203Expression
@@ -111,9 +111,9 @@ public class RH3203ExpressionStyleConstructorsShouldNotBeUsedAnalyzerTests : Ana
                                 {
                                     private int _value;
 
-                                    {|#0:public RH3203() => _value = 1
+                                    public RH3203() {|#0:=> _value = 1|}
                                 #pragma warning disable CS0168
-                                        ;|}
+                                        ;
                                 }
                                 """;
 
@@ -130,7 +130,9 @@ public class RH3203ExpressionStyleConstructorsShouldNotBeUsedAnalyzerTests : Ana
                                   }
                                   """;
 
-        await Verify(testData, resultData, Diagnostics(RH3203ExpressionStyleConstructorsShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH3203MessageFormat));
+        await Verify(testData.Replace("\r\n", "\n"),
+                     resultData.Replace("\r\n", "\n"),
+                     Diagnostics(RH3203ExpressionStyleConstructorsShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH3203MessageFormat));
     }
 
     #endregion // Tests

--- a/Reihitsu.Analyzer.Test/Formatting/RH3203ExpressionStyleConstructorsShouldNotBeUsedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH3203ExpressionStyleConstructorsShouldNotBeUsedAnalyzerTests.cs
@@ -135,5 +135,44 @@ public class RH3203ExpressionStyleConstructorsShouldNotBeUsedAnalyzerTests : Ana
                      Diagnostics(RH3203ExpressionStyleConstructorsShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH3203MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies two expression-bodied constructors are fixed in one Fix All iteration
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyTwoConstructorsAreFixedInOneFixAllIteration()
+    {
+        const string testData = """
+                                internal class RH3203
+                                {
+                                    private int _value;
+
+                                    public RH3203() {|#0:=> _value = 1|};
+
+                                    public RH3203(int value) {|#1:=> _value = value|};
+                                }
+                                """;
+
+        const string resultData = """
+                                  internal class RH3203
+                                  {
+                                      private int _value;
+                                      public RH3203()
+                                      {
+                                          _value = 1;
+                                      }
+                                      public RH3203(int value)
+                                      {
+                                          _value = value;
+                                      }
+                                  }
+                                  """;
+
+        await Verify(testData.Replace("\r\n", "\n"),
+                     resultData.Replace("\r\n", "\n"),
+                     static config => config.NumberOfFixAllIterations = 1,
+                     Diagnostics(RH3203ExpressionStyleConstructorsShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH3203MessageFormat, 2));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatting/RH6003SemicolonsMustBeSpacedCorrectlyAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH6003SemicolonsMustBeSpacedCorrectlyAnalyzerTests.cs
@@ -68,6 +68,35 @@ public class RH6003SemicolonsMustBeSpacedCorrectlyAnalyzerTests : AnalyzerTestsB
     }
 
     /// <summary>
+    /// Verifies that a tab immediately before a semicolon is detected and fixed
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyTabBeforeSemicolonIsDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method()
+                                    {
+                                        var value = 0{|#0:	|};
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     void Method()
+                                     {
+                                         var value = 0;
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH6003SemicolonsMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6003MessageFormat));
+    }
+
+    /// <summary>
     /// Verifies that continuation-line indentation before a semicolon does not produce a diagnostic
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
@@ -86,6 +115,90 @@ public class RH6003SemicolonsMustBeSpacedCorrectlyAnalyzerTests : AnalyzerTestsB
                                 """;
 
         await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that continuation-line indentation before a semicolon does not produce a diagnostic with CRLF line endings
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyContinuationLineIndentationDoesNotProduceDiagnosticWithCarriageReturnLineFeed()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method()
+                                    {
+                                        int value = 1
+                                            ;
+                                    }
+                                }
+                                """;
+
+        await Verify(NormalizeToCarriageReturnLineFeed(testData));
+    }
+
+    /// <summary>
+    /// Verifies that a comment before a semicolon is preserved while only the adjacent whitespace run is removed
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCommentBeforeSemicolonIsPreservedByCodeFix()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method()
+                                    {
+                                        int value = 1 /* Keep. */{|#0: |};
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     void Method()
+                                     {
+                                         int value = 1 /* Keep. */;
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH6003SemicolonsMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6003MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that Fix All removes multiple same-line whitespace runs in one iteration
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyMultipleSameLineDiagnosticsAreFixedInOneFixAllIteration()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method()
+                                    {
+                                        int first = 1{|#0: |};
+                                        int second = 2{|#1:	|};
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     void Method()
+                                     {
+                                         int first = 1;
+                                         int second = 2;
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData,
+                     fixedData,
+                     static config => config.NumberOfFixAllIterations = 1,
+                     Diagnostics(RH6003SemicolonsMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6003MessageFormat, 2));
     }
 
     #endregion // Tests

--- a/Reihitsu.Analyzer.Test/Formatting/RH6003SemicolonsMustBeSpacedCorrectlyAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH6003SemicolonsMustBeSpacedCorrectlyAnalyzerTests.cs
@@ -67,5 +67,26 @@ public class RH6003SemicolonsMustBeSpacedCorrectlyAnalyzerTests : AnalyzerTestsB
         await Verify(testData, fixedData, Diagnostics(RH6003SemicolonsMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6003MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies that continuation-line indentation before a semicolon does not produce a diagnostic
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyContinuationLineIndentationDoesNotProduceDiagnostic()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method()
+                                    {
+                                        int value = 1
+                                            ;
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatting/RH6003SemicolonsMustBeSpacedCorrectlyAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH6003SemicolonsMustBeSpacedCorrectlyAnalyzerTests.cs
@@ -1,8 +1,10 @@
 ﻿using System.Threading.Tasks;
 
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Reihitsu.Analyzer.CodeFixes.Rules.Spacing;
+using Reihitsu.Analyzer.Core;
 using Reihitsu.Analyzer.Rules.Spacing;
 using Reihitsu.Analyzer.Test.Base;
 
@@ -136,6 +138,69 @@ public class RH6003SemicolonsMustBeSpacedCorrectlyAnalyzerTests : AnalyzerTestsB
                                 """;
 
         await Verify(NormalizeToCarriageReturnLineFeed(testData));
+    }
+
+    /// <summary>
+    /// Verifies that disabled text and a directive boundary before a continuation-line semicolon do not produce a diagnostic
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDirectiveAndDisabledTextBeforeContinuationLineSemicolonDoNotProduceDiagnostic()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method()
+                                    {
+                                #if false
+                                        int disabled = 0 ;
+                                #endif
+                                        ;
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that disabled text and a directive boundary before a continuation-line semicolon do not produce a diagnostic with CRLF line endings
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDirectiveAndDisabledTextBeforeContinuationLineSemicolonDoNotProduceDiagnosticWithCarriageReturnLineFeed()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method()
+                                    {
+                                #if false
+                                        int disabled = 0 ;
+                                #endif
+                                        ;
+                                    }
+                                }
+                                """;
+
+        await Verify(NormalizeToCarriageReturnLineFeed(testData));
+    }
+
+    /// <summary>
+    /// Verifies that the shared whitespace-span policy reports only same-line runs and rejects continuation indentation
+    /// </summary>
+    [TestMethod]
+    public void VerifySharedWhitespaceSpanPolicyIsLineBounded()
+    {
+        const string sameLine = "value \t;";
+        const string continuation = "#if false\ndisabled ;\n#endif\n    ;";
+        var sameLineText = SourceText.From(sameLine);
+        var continuationText = SourceText.From(continuation);
+        var carriageReturnLineFeedText = SourceText.From(NormalizeToCarriageReturnLineFeed(continuation));
+
+        Assert.AreEqual(TextSpan.FromBounds(5, 7), SameLinePrecedingWhitespaceAnalysis.GetSpan(sameLineText, sameLine.Length - 1));
+        Assert.IsNull(SameLinePrecedingWhitespaceAnalysis.GetSpan(continuationText, continuation.LastIndexOf(';')));
+        Assert.IsNull(SameLinePrecedingWhitespaceAnalysis.GetSpan(carriageReturnLineFeedText, carriageReturnLineFeedText.ToString().LastIndexOf(';')));
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer.Test/Formatting/RH6011OpeningGenericBracketsMustBeSpacedCorrectlyAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH6011OpeningGenericBracketsMustBeSpacedCorrectlyAnalyzerTests.cs
@@ -177,6 +177,50 @@ public class RH6011OpeningGenericBracketsMustBeSpacedCorrectlyAnalyzerTests : An
     }
 
     /// <summary>
+    /// Verifies that disabled text and a directive boundary before a continuation-line opening generic bracket do not produce a diagnostic
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDirectiveAndDisabledTextBeforeContinuationLineOpeningGenericBracketDoNotProduceDiagnostic()
+    {
+        const string testData = """
+                                using System.Collections.Generic;
+                                internal class TestClass
+                                {
+                                #if false
+                                    List <string> Disabled() => new();
+                                #endif
+                                    List
+                                        <int> Method() => new();
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that disabled text and a directive boundary before a continuation-line opening generic bracket do not produce a diagnostic with CRLF line endings
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDirectiveAndDisabledTextBeforeContinuationLineOpeningGenericBracketDoNotProduceDiagnosticWithCarriageReturnLineFeed()
+    {
+        const string testData = """
+                                using System.Collections.Generic;
+                                internal class TestClass
+                                {
+                                #if false
+                                    List <string> Disabled() => new();
+                                #endif
+                                    List
+                                        <int> Method() => new();
+                                }
+                                """;
+
+        await Verify(NormalizeToCarriageReturnLineFeed(testData));
+    }
+
+    /// <summary>
     /// Verifies that Fix All removes multiple same-line whitespace runs in one iteration
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer.Test/Formatting/RH6011OpeningGenericBracketsMustBeSpacedCorrectlyAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH6011OpeningGenericBracketsMustBeSpacedCorrectlyAnalyzerTests.cs
@@ -177,7 +177,7 @@ public class RH6011OpeningGenericBracketsMustBeSpacedCorrectlyAnalyzerTests : An
     }
 
     /// <summary>
-    /// Verifies that disabled text and a directive boundary before a continuation-line opening generic bracket do not produce a diagnostic
+    /// Verifies that disabled text and a directive inside the gap before a continuation-line opening generic bracket do not produce a diagnostic
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
     [TestMethod]
@@ -187,10 +187,10 @@ public class RH6011OpeningGenericBracketsMustBeSpacedCorrectlyAnalyzerTests : An
                                 using System.Collections.Generic;
                                 internal class TestClass
                                 {
-                                #if false
-                                    List <string> Disabled() => new();
-                                #endif
                                     List
+                                #if false
+                                    disabled text
+                                #endif
                                         <int> Method() => new();
                                 }
                                 """;
@@ -199,7 +199,7 @@ public class RH6011OpeningGenericBracketsMustBeSpacedCorrectlyAnalyzerTests : An
     }
 
     /// <summary>
-    /// Verifies that disabled text and a directive boundary before a continuation-line opening generic bracket do not produce a diagnostic with CRLF line endings
+    /// Verifies that disabled text and a directive inside the gap before a continuation-line opening generic bracket do not produce a diagnostic with CRLF line endings
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
     [TestMethod]
@@ -209,10 +209,10 @@ public class RH6011OpeningGenericBracketsMustBeSpacedCorrectlyAnalyzerTests : An
                                 using System.Collections.Generic;
                                 internal class TestClass
                                 {
-                                #if false
-                                    List <string> Disabled() => new();
-                                #endif
                                     List
+                                #if false
+                                    disabled text
+                                #endif
                                         <int> Method() => new();
                                 }
                                 """;

--- a/Reihitsu.Analyzer.Test/Formatting/RH6011OpeningGenericBracketsMustBeSpacedCorrectlyAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH6011OpeningGenericBracketsMustBeSpacedCorrectlyAnalyzerTests.cs
@@ -95,5 +95,116 @@ public class RH6011OpeningGenericBracketsMustBeSpacedCorrectlyAnalyzerTests : An
         await Verify(testData, fixedData, Diagnostics(RH6011OpeningGenericBracketsMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6011MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies that a tab before an opening generic bracket is detected and fixed
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyTabBeforeOpeningGenericBracketIsDetectedAndFixed()
+    {
+        const string testData = """
+                                using System.Collections.Generic;
+                                internal class TestClass
+                                {
+                                    List{|#0:	|}<int> Method() => new();
+                                }
+                                """;
+        const string fixedData = """
+                                 using System.Collections.Generic;
+                                 internal class TestClass
+                                 {
+                                     List<int> Method() => new();
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH6011OpeningGenericBracketsMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6011MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that a comment before an opening generic bracket does not broaden the diagnostic span
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCommentBeforeOpeningGenericBracketDoesNotBroadenDiagnosticSpan()
+    {
+        const string testData = """
+                                using System.Collections.Generic;
+                                internal class TestClass
+                                {
+                                    List /* Keep. */{|#0: |}<int> Method() => new();
+                                }
+                                """;
+
+        await Verify(testData, Diagnostics(RH6011OpeningGenericBracketsMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6011MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that an opening generic bracket on a continuation line does not produce a diagnostic with LF line endings
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyContinuationLineOpeningGenericBracketDoesNotProduceDiagnostic()
+    {
+        const string testData = """
+                                using System.Collections.Generic;
+                                internal class TestClass
+                                {
+                                    List
+                                        <int> Method() => new();
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that an opening generic bracket on a continuation line does not produce a diagnostic with CRLF line endings
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyContinuationLineOpeningGenericBracketDoesNotProduceDiagnosticWithCarriageReturnLineFeed()
+    {
+        const string testData = """
+                                using System.Collections.Generic;
+                                internal class TestClass
+                                {
+                                    List
+                                        <int> Method() => new();
+                                }
+                                """;
+
+        await Verify(NormalizeToCarriageReturnLineFeed(testData));
+    }
+
+    /// <summary>
+    /// Verifies that Fix All removes multiple same-line whitespace runs in one iteration
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyMultipleSameLineDiagnosticsAreFixedInOneFixAllIteration()
+    {
+        const string testData = """
+                                using System.Collections.Generic;
+                                internal class TestClass
+                                {
+                                    List{|#0: |}<int> First() => new();
+                                    List{|#1:	|}<string> Second() => new();
+                                }
+                                """;
+        const string fixedData = """
+                                 using System.Collections.Generic;
+                                 internal class TestClass
+                                 {
+                                     List<int> First() => new();
+                                     List<string> Second() => new();
+                                 }
+                                 """;
+
+        await Verify(testData,
+                     fixedData,
+                     static config => config.NumberOfFixAllIterations = 1,
+                     Diagnostics(RH6011OpeningGenericBracketsMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6011MessageFormat, 2));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatting/RH6012ClosingGenericBracketsMustBeSpacedCorrectlyAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH6012ClosingGenericBracketsMustBeSpacedCorrectlyAnalyzerTests.cs
@@ -184,6 +184,50 @@ public class RH6012ClosingGenericBracketsMustBeSpacedCorrectlyAnalyzerTests : An
     }
 
     /// <summary>
+    /// Verifies that disabled text and a directive boundary before a continuation-line closing generic bracket do not produce a diagnostic
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDirectiveAndDisabledTextBeforeContinuationLineClosingGenericBracketDoNotProduceDiagnostic()
+    {
+        const string testData = """
+                                using System.Collections.Generic;
+                                internal class TestClass
+                                {
+                                #if false
+                                    List<string > Disabled() => new();
+                                #endif
+                                    List<int
+                                        > Method() => new();
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that disabled text and a directive boundary before a continuation-line closing generic bracket do not produce a diagnostic with CRLF line endings
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDirectiveAndDisabledTextBeforeContinuationLineClosingGenericBracketDoNotProduceDiagnosticWithCarriageReturnLineFeed()
+    {
+        const string testData = """
+                                using System.Collections.Generic;
+                                internal class TestClass
+                                {
+                                #if false
+                                    List<string > Disabled() => new();
+                                #endif
+                                    List<int
+                                        > Method() => new();
+                                }
+                                """;
+
+        await Verify(NormalizeToCarriageReturnLineFeed(testData));
+    }
+
+    /// <summary>
     /// Verifies that Fix All removes multiple same-line whitespace runs in one iteration
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer.Test/Formatting/RH6012ClosingGenericBracketsMustBeSpacedCorrectlyAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH6012ClosingGenericBracketsMustBeSpacedCorrectlyAnalyzerTests.cs
@@ -184,7 +184,7 @@ public class RH6012ClosingGenericBracketsMustBeSpacedCorrectlyAnalyzerTests : An
     }
 
     /// <summary>
-    /// Verifies that disabled text and a directive boundary before a continuation-line closing generic bracket do not produce a diagnostic
+    /// Verifies that disabled text and a directive inside the gap before a continuation-line closing generic bracket do not produce a diagnostic
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
     [TestMethod]
@@ -194,10 +194,10 @@ public class RH6012ClosingGenericBracketsMustBeSpacedCorrectlyAnalyzerTests : An
                                 using System.Collections.Generic;
                                 internal class TestClass
                                 {
-                                #if false
-                                    List<string > Disabled() => new();
-                                #endif
                                     List<int
+                                #if false
+                                    disabled text
+                                #endif
                                         > Method() => new();
                                 }
                                 """;
@@ -206,7 +206,7 @@ public class RH6012ClosingGenericBracketsMustBeSpacedCorrectlyAnalyzerTests : An
     }
 
     /// <summary>
-    /// Verifies that disabled text and a directive boundary before a continuation-line closing generic bracket do not produce a diagnostic with CRLF line endings
+    /// Verifies that disabled text and a directive inside the gap before a continuation-line closing generic bracket do not produce a diagnostic with CRLF line endings
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
     [TestMethod]
@@ -216,10 +216,10 @@ public class RH6012ClosingGenericBracketsMustBeSpacedCorrectlyAnalyzerTests : An
                                 using System.Collections.Generic;
                                 internal class TestClass
                                 {
-                                #if false
-                                    List<string > Disabled() => new();
-                                #endif
                                     List<int
+                                #if false
+                                    disabled text
+                                #endif
                                         > Method() => new();
                                 }
                                 """;

--- a/Reihitsu.Analyzer.Test/Formatting/RH6012ClosingGenericBracketsMustBeSpacedCorrectlyAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH6012ClosingGenericBracketsMustBeSpacedCorrectlyAnalyzerTests.cs
@@ -95,5 +95,123 @@ public class RH6012ClosingGenericBracketsMustBeSpacedCorrectlyAnalyzerTests : An
         await Verify(testData, fixedData, Diagnostics(RH6012ClosingGenericBracketsMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6012MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies that a tab before a closing generic bracket is detected and fixed
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyTabBeforeClosingGenericBracketIsDetectedAndFixed()
+    {
+        const string testData = """
+                                using System.Collections.Generic;
+                                internal class TestClass
+                                {
+                                    List<int{|#0:	|}> Method() => new();
+                                }
+                                """;
+        const string fixedData = """
+                                 using System.Collections.Generic;
+                                 internal class TestClass
+                                 {
+                                     List<int> Method() => new();
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH6012ClosingGenericBracketsMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6012MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that the code fix preserves a comment before a closing generic bracket
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCommentBeforeClosingGenericBracketIsPreservedByCodeFix()
+    {
+        const string testData = """
+                                using System.Collections.Generic;
+                                internal class TestClass
+                                {
+                                    List<int /* Keep. */{|#0: |}> Method() => new();
+                                }
+                                """;
+        const string fixedData = """
+                                 using System.Collections.Generic;
+                                 internal class TestClass
+                                 {
+                                     List<int /* Keep. */> Method() => new();
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH6012ClosingGenericBracketsMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6012MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that a closing generic bracket on a continuation line does not produce a diagnostic with LF line endings
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyContinuationLineClosingGenericBracketDoesNotProduceDiagnostic()
+    {
+        const string testData = """
+                                using System.Collections.Generic;
+                                internal class TestClass
+                                {
+                                    List<int
+                                        > Method() => new();
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that a closing generic bracket on a continuation line does not produce a diagnostic with CRLF line endings
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyContinuationLineClosingGenericBracketDoesNotProduceDiagnosticWithCarriageReturnLineFeed()
+    {
+        const string testData = """
+                                using System.Collections.Generic;
+                                internal class TestClass
+                                {
+                                    List<int
+                                        > Method() => new();
+                                }
+                                """;
+
+        await Verify(NormalizeToCarriageReturnLineFeed(testData));
+    }
+
+    /// <summary>
+    /// Verifies that Fix All removes multiple same-line whitespace runs in one iteration
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyMultipleSameLineDiagnosticsAreFixedInOneFixAllIteration()
+    {
+        const string testData = """
+                                using System.Collections.Generic;
+                                internal class TestClass
+                                {
+                                    List<int{|#0: |}> First() => new();
+                                    List<string{|#1:	|}> Second() => new();
+                                }
+                                """;
+        const string fixedData = """
+                                 using System.Collections.Generic;
+                                 internal class TestClass
+                                 {
+                                     List<int> First() => new();
+                                     List<string> Second() => new();
+                                 }
+                                 """;
+
+        await Verify(testData,
+                     fixedData,
+                     static config => config.NumberOfFixAllIterations = 1,
+                     Diagnostics(RH6012ClosingGenericBracketsMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6012MessageFormat, 2));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatting/RH6014ClosingAttributeBracketsMustBeSpacedCorrectlyAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH6014ClosingAttributeBracketsMustBeSpacedCorrectlyAnalyzerTests.cs
@@ -141,6 +141,48 @@ public class RH6014ClosingAttributeBracketsMustBeSpacedCorrectlyAnalyzerTests : 
     }
 
     /// <summary>
+    /// Verifies that disabled text and a directive boundary before a continuation-line closing attribute bracket do not produce a diagnostic
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDirectiveAndDisabledTextBeforeContinuationLineClosingAttributeBracketDoNotProduceDiagnostic()
+    {
+        const string testData = """
+                                #if false
+                                [System.Obsolete ]
+                                internal class Disabled;
+                                #endif
+                                [
+                                    System.Obsolete
+                                    ]
+                                internal class TestClass;
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that disabled text and a directive boundary before a continuation-line closing attribute bracket do not produce a diagnostic with CRLF line endings
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDirectiveAndDisabledTextBeforeContinuationLineClosingAttributeBracketDoNotProduceDiagnosticWithCarriageReturnLineFeed()
+    {
+        const string testData = """
+                                #if false
+                                [System.Obsolete ]
+                                internal class Disabled;
+                                #endif
+                                [
+                                    System.Obsolete
+                                    ]
+                                internal class TestClass;
+                                """;
+
+        await Verify(NormalizeToCarriageReturnLineFeed(testData));
+    }
+
+    /// <summary>
     /// Verifies that Fix All removes multiple same-line whitespace runs in one iteration
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer.Test/Formatting/RH6014ClosingAttributeBracketsMustBeSpacedCorrectlyAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH6014ClosingAttributeBracketsMustBeSpacedCorrectlyAnalyzerTests.cs
@@ -56,5 +56,117 @@ public class RH6014ClosingAttributeBracketsMustBeSpacedCorrectlyAnalyzerTests : 
         await Verify(testData, fixedData, Diagnostics(RH6014ClosingAttributeBracketsMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6014MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies that a tab before a closing attribute bracket is detected and fixed
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyTabBeforeClosingAttributeBracketIsDetectedAndFixed()
+    {
+        const string testData = """
+                                [System.Obsolete{|#0:	|}]
+                                internal class TestClass
+                                {
+                                }
+                                """;
+        const string fixedData = """
+                                 [System.Obsolete]
+                                 internal class TestClass
+                                 {
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH6014ClosingAttributeBracketsMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6014MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that the code fix preserves a comment before a closing attribute bracket
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCommentBeforeClosingAttributeBracketIsPreservedByCodeFix()
+    {
+        const string testData = """
+                                [System.Obsolete /* Keep. */{|#0: |}]
+                                internal class TestClass
+                                {
+                                }
+                                """;
+        const string fixedData = """
+                                 [System.Obsolete /* Keep. */]
+                                 internal class TestClass
+                                 {
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH6014ClosingAttributeBracketsMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6014MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that a closing attribute bracket on a continuation line does not produce a diagnostic with LF line endings
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyContinuationLineClosingAttributeBracketDoesNotProduceDiagnostic()
+    {
+        const string testData = """
+                                [
+                                    System.Obsolete
+                                    ]
+                                internal class TestClass
+                                {
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that a closing attribute bracket on a continuation line does not produce a diagnostic with CRLF line endings
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyContinuationLineClosingAttributeBracketDoesNotProduceDiagnosticWithCarriageReturnLineFeed()
+    {
+        const string testData = """
+                                [
+                                    System.Obsolete
+                                    ]
+                                internal class TestClass
+                                {
+                                }
+                                """;
+
+        await Verify(NormalizeToCarriageReturnLineFeed(testData));
+    }
+
+    /// <summary>
+    /// Verifies that Fix All removes multiple same-line whitespace runs in one iteration
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyMultipleSameLineDiagnosticsAreFixedInOneFixAllIteration()
+    {
+        const string testData = """
+                                [System.Obsolete{|#0: |}]
+                                [System.CLSCompliant(true){|#1:	|}]
+                                internal class TestClass
+                                {
+                                }
+                                """;
+        const string fixedData = """
+                                 [System.Obsolete]
+                                 [System.CLSCompliant(true)]
+                                 internal class TestClass
+                                 {
+                                 }
+                                 """;
+
+        await Verify(testData,
+                     fixedData,
+                     static config => config.NumberOfFixAllIterations = 1,
+                     Diagnostics(RH6014ClosingAttributeBracketsMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6014MessageFormat, 2));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatting/RH6014ClosingAttributeBracketsMustBeSpacedCorrectlyAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH6014ClosingAttributeBracketsMustBeSpacedCorrectlyAnalyzerTests.cs
@@ -141,19 +141,17 @@ public class RH6014ClosingAttributeBracketsMustBeSpacedCorrectlyAnalyzerTests : 
     }
 
     /// <summary>
-    /// Verifies that disabled text and a directive boundary before a continuation-line closing attribute bracket do not produce a diagnostic
+    /// Verifies that disabled text and a directive inside the gap before a continuation-line closing attribute bracket do not produce a diagnostic
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
     [TestMethod]
     public async Task VerifyDirectiveAndDisabledTextBeforeContinuationLineClosingAttributeBracketDoNotProduceDiagnostic()
     {
         const string testData = """
+                                [System.Obsolete
                                 #if false
-                                [System.Obsolete ]
-                                internal class Disabled;
+                                disabled text
                                 #endif
-                                [
-                                    System.Obsolete
                                     ]
                                 internal class TestClass;
                                 """;
@@ -162,19 +160,17 @@ public class RH6014ClosingAttributeBracketsMustBeSpacedCorrectlyAnalyzerTests : 
     }
 
     /// <summary>
-    /// Verifies that disabled text and a directive boundary before a continuation-line closing attribute bracket do not produce a diagnostic with CRLF line endings
+    /// Verifies that disabled text and a directive inside the gap before a continuation-line closing attribute bracket do not produce a diagnostic with CRLF line endings
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
     [TestMethod]
     public async Task VerifyDirectiveAndDisabledTextBeforeContinuationLineClosingAttributeBracketDoNotProduceDiagnosticWithCarriageReturnLineFeed()
     {
         const string testData = """
+                                [System.Obsolete
                                 #if false
-                                [System.Obsolete ]
-                                internal class Disabled;
+                                disabled text
                                 #endif
-                                [
-                                    System.Obsolete
                                     ]
                                 internal class TestClass;
                                 """;

--- a/Reihitsu.Analyzer.Test/Formatting/RH6015NullableTypeSymbolsMustNotBePrecededBySpaceAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH6015NullableTypeSymbolsMustNotBePrecededBySpaceAnalyzerTests.cs
@@ -65,5 +65,129 @@ public class RH6015NullableTypeSymbolsMustNotBePrecededBySpaceAnalyzerTests : An
         await Verify(testData, fixedData, Diagnostics(RH6015NullableTypeSymbolsMustNotBePrecededBySpaceAnalyzer.DiagnosticId, AnalyzerResources.RH6015MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies that a tab before a nullable type symbol is detected and fixed
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyTabBeforeNullableTypeSymbolIsDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method(int{|#0:	|}? value)
+                                    {
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     void Method(int? value)
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH6015NullableTypeSymbolsMustNotBePrecededBySpaceAnalyzer.DiagnosticId, AnalyzerResources.RH6015MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that the code fix preserves a comment before a nullable type symbol
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCommentBeforeNullableTypeSymbolIsPreservedByCodeFix()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method(int /* Keep. */{|#0: |}? value)
+                                    {
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     void Method(int /* Keep. */? value)
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH6015NullableTypeSymbolsMustNotBePrecededBySpaceAnalyzer.DiagnosticId, AnalyzerResources.RH6015MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that a nullable type symbol on a continuation line does not produce a diagnostic with LF line endings
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyContinuationLineNullableTypeSymbolDoesNotProduceDiagnostic()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method(int
+                                        ? value)
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that a nullable type symbol on a continuation line does not produce a diagnostic with CRLF line endings
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyContinuationLineNullableTypeSymbolDoesNotProduceDiagnosticWithCarriageReturnLineFeed()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method(int
+                                        ? value)
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(NormalizeToCarriageReturnLineFeed(testData));
+    }
+
+    /// <summary>
+    /// Verifies that Fix All removes multiple same-line whitespace runs in one iteration
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyMultipleSameLineDiagnosticsAreFixedInOneFixAllIteration()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method(int{|#0: |}? first, long{|#1:	|}? second)
+                                    {
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     void Method(int? first, long? second)
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData,
+                     fixedData,
+                     static config => config.NumberOfFixAllIterations = 1,
+                     Diagnostics(RH6015NullableTypeSymbolsMustNotBePrecededBySpaceAnalyzer.DiagnosticId, AnalyzerResources.RH6015MessageFormat, 2));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatting/RH6015NullableTypeSymbolsMustNotBePrecededBySpaceAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH6015NullableTypeSymbolsMustNotBePrecededBySpaceAnalyzerTests.cs
@@ -160,7 +160,7 @@ public class RH6015NullableTypeSymbolsMustNotBePrecededBySpaceAnalyzerTests : An
     }
 
     /// <summary>
-    /// Verifies that disabled text and a directive boundary before a continuation-line nullable type symbol do not produce a diagnostic
+    /// Verifies that disabled text and a directive inside the gap before a continuation-line nullable type symbol do not produce a diagnostic
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
     [TestMethod]
@@ -169,12 +169,10 @@ public class RH6015NullableTypeSymbolsMustNotBePrecededBySpaceAnalyzerTests : An
         const string testData = """
                                 internal class TestClass
                                 {
-                                #if false
-                                    void Disabled(int ? value)
-                                    {
-                                    }
-                                #endif
                                     void Method(int
+                                #if false
+                                    disabled text
+                                #endif
                                         ? value)
                                     {
                                     }
@@ -185,7 +183,7 @@ public class RH6015NullableTypeSymbolsMustNotBePrecededBySpaceAnalyzerTests : An
     }
 
     /// <summary>
-    /// Verifies that disabled text and a directive boundary before a continuation-line nullable type symbol do not produce a diagnostic with CRLF line endings
+    /// Verifies that disabled text and a directive inside the gap before a continuation-line nullable type symbol do not produce a diagnostic with CRLF line endings
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
     [TestMethod]
@@ -194,12 +192,10 @@ public class RH6015NullableTypeSymbolsMustNotBePrecededBySpaceAnalyzerTests : An
         const string testData = """
                                 internal class TestClass
                                 {
-                                #if false
-                                    void Disabled(int ? value)
-                                    {
-                                    }
-                                #endif
                                     void Method(int
+                                #if false
+                                    disabled text
+                                #endif
                                         ? value)
                                     {
                                     }

--- a/Reihitsu.Analyzer.Test/Formatting/RH6015NullableTypeSymbolsMustNotBePrecededBySpaceAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH6015NullableTypeSymbolsMustNotBePrecededBySpaceAnalyzerTests.cs
@@ -160,6 +160,56 @@ public class RH6015NullableTypeSymbolsMustNotBePrecededBySpaceAnalyzerTests : An
     }
 
     /// <summary>
+    /// Verifies that disabled text and a directive boundary before a continuation-line nullable type symbol do not produce a diagnostic
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDirectiveAndDisabledTextBeforeContinuationLineNullableTypeSymbolDoNotProduceDiagnostic()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                #if false
+                                    void Disabled(int ? value)
+                                    {
+                                    }
+                                #endif
+                                    void Method(int
+                                        ? value)
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that disabled text and a directive boundary before a continuation-line nullable type symbol do not produce a diagnostic with CRLF line endings
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDirectiveAndDisabledTextBeforeContinuationLineNullableTypeSymbolDoNotProduceDiagnosticWithCarriageReturnLineFeed()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                #if false
+                                    void Disabled(int ? value)
+                                    {
+                                    }
+                                #endif
+                                    void Method(int
+                                        ? value)
+                                    {
+                                    }
+                                }
+                                """;
+
+        await Verify(NormalizeToCarriageReturnLineFeed(testData));
+    }
+
+    /// <summary>
     /// Verifies that Fix All removes multiple same-line whitespace runs in one iteration
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer.Test/Formatting/RH6024BinaryOperatorsMustBeSpacedCorrectlyAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH6024BinaryOperatorsMustBeSpacedCorrectlyAnalyzerTests.cs
@@ -174,23 +174,114 @@ public class RH6024BinaryOperatorsMustBeSpacedCorrectlyAnalyzerTests : AnalyzerT
     }
 
     /// <summary>
-    /// Verifies that keyword operators such as "is" do not produce diagnostics
+    /// Verifies that extra padding around the <c>is</c> keyword operator is detected and fixed
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
     [TestMethod]
-    public async Task VerifyKeywordOperatorIsIgnored()
+    public async Task VerifyIsKeywordOperatorIsDetectedAndFixed()
     {
         const string testData = """
                                 internal class TestClass
                                 {
                                     bool Method(object value)
                                     {
-                                        return value  is  string;
+                                        return value  {|#0:is|}  string;
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     bool Method(object value)
+                                     {
+                                         return value is string;
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH6024BinaryOperatorsMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6024MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that extra padding around the <c>as</c> keyword operator is detected and fixed
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyAsKeywordOperatorIsDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    string Method(object value)
+                                    {
+                                        return value  {|#0:as|}  string;
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     string Method(object value)
+                                     {
+                                         return value as string;
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH6024BinaryOperatorsMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6024MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that a keyword operator on a continuation line does not produce diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyWrappedKeywordOperatorIsIgnored()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    string Method(object value)
+                                    {
+                                        return value
+                                               as string;
                                     }
                                 }
                                 """;
 
         await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that Fix All normalizes multiple keyword-operator diagnostics in one iteration
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyMultipleKeywordOperatorDiagnosticsAreFixedInOneFixAllIteration()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    bool Method(object value)
+                                    {
+                                        return value  {|#0:is|}  string && value  {|#1:as|}  string != null;
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     bool Method(object value)
+                                     {
+                                         return value is string && value as string != null;
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData,
+                     fixedData,
+                     static config => config.NumberOfFixAllIterations = 1,
+                     Diagnostics(RH6024BinaryOperatorsMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6024MessageFormat, 2));
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer.Test/Naming/RH4001TypeNameShouldMatchFileNameAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Naming/RH4001TypeNameShouldMatchFileNameAnalyzerTests.cs
@@ -585,5 +585,49 @@ public class RH4001TypeNameShouldMatchFileNameAnalyzerTests : AnalyzerTestsBase<
         }
     }
 
+    /// <summary>
+    /// Verifies that an empty first namespace does not prevent discovery of a type in a later sibling namespace
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task LaterSiblingNamespaceTypeIsDetectedAndFileIsRenamed()
+    {
+        const string testCode = """
+                                namespace EmptyNamespace
+                                {
+                                }
+
+                                namespace PopulatedNamespace
+                                {
+                                    internal class {|#0:LaterType|}
+                                    {
+                                    }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 namespace EmptyNamespace
+                                 {
+                                 }
+
+                                 namespace PopulatedNamespace
+                                 {
+                                     internal class LaterType
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testCode,
+                     null,
+                     test =>
+                     {
+                         test.TestState.Sources.Clear();
+                         test.TestState.Sources.Add(("/0/Mismatched.cs", testCode));
+                         test.FixedState.Sources.Add(("/0/LaterType.cs", fixedCode));
+                     },
+                     Diagnostics(RH4001TypeNameShouldMatchFileNameAnalyzer.DiagnosticId, AnalyzerResources.RH4001MessageFormat));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Naming/RH4102EventNameCasingAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Naming/RH4102EventNameCasingAnalyzerTests.cs
@@ -228,5 +228,41 @@ public class RH4102EventNameCasingAnalyzerTests : AnalyzerTestsBase<RH4102EventN
         await Verify(testCode, fixedCode, Diagnostics(RH4102EventNameCasingAnalyzer.DiagnosticId, AnalyzerResources.RH4102MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies that property-style event declarations are checked and renamed at the event identifier
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyPropertyStyleEventIsDetectedAndFixed()
+    {
+        const string testCode = """
+                                using System;
+
+                                internal class EventSource
+                                {
+                                    public event EventHandler {|#0:dataChanged|}
+                                    {
+                                        add { }
+                                        remove { }
+                                    }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 using System;
+
+                                 internal class EventSource
+                                 {
+                                     public event EventHandler DataChanged
+                                     {
+                                         add { }
+                                         remove { }
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH4102EventNameCasingAnalyzer.DiagnosticId, AnalyzerResources.RH4102MessageFormat));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Naming/RH4102EventNameCasingAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Naming/RH4102EventNameCasingAnalyzerTests.cs
@@ -247,6 +247,14 @@ public class RH4102EventNameCasingAnalyzerTests : AnalyzerTestsBase<RH4102EventN
                                         add { }
                                         remove { }
                                     }
+
+                                    public void Subscribe()
+                                    {
+                                        dataChanged += OnDataChanged;
+                                        dataChanged -= OnDataChanged;
+                                    }
+
+                                    private void OnDataChanged(object sender, EventArgs args) { }
                                 }
                                 """;
 
@@ -260,6 +268,14 @@ public class RH4102EventNameCasingAnalyzerTests : AnalyzerTestsBase<RH4102EventN
                                          add { }
                                          remove { }
                                      }
+
+                                     public void Subscribe()
+                                     {
+                                         DataChanged += OnDataChanged;
+                                         DataChanged -= OnDataChanged;
+                                     }
+
+                                     private void OnDataChanged(object sender, EventArgs args) { }
                                  }
                                  """;
 

--- a/Reihitsu.Analyzer.Test/Naming/RH4102EventNameCasingAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Naming/RH4102EventNameCasingAnalyzerTests.cs
@@ -1,10 +1,12 @@
 ﻿using System.Threading.Tasks;
 
+using Microsoft.CodeAnalysis.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Reihitsu.Analyzer.CodeFixes.Rules.Naming;
 using Reihitsu.Analyzer.Rules.Naming;
 using Reihitsu.Analyzer.Test.Base;
+using Reihitsu.Analyzer.Test.Verifiers;
 
 namespace Reihitsu.Analyzer.Test.Naming;
 
@@ -261,7 +263,207 @@ public class RH4102EventNameCasingAnalyzerTests : AnalyzerTestsBase<RH4102EventN
                                  }
                                  """;
 
+        await VerifyCustomEvent(testCode, fixedCode, 1);
+    }
+
+    /// <summary>
+    /// Verifies the event rename retargets subscriptions and references
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyEventRenameRetargetsSubscriptionsAndReferences()
+    {
+        const string testCode = """
+                                using System;
+
+                                internal class EventSource
+                                {
+                                    public event EventHandler {|#0:dataChanged|};
+
+                                    public void Subscribe()
+                                    {
+                                        dataChanged += OnDataChanged;
+                                        dataChanged?.Invoke(this, EventArgs.Empty);
+                                    }
+
+                                    private void OnDataChanged(object sender, EventArgs args) { }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 using System;
+
+                                 internal class EventSource
+                                 {
+                                     public event EventHandler DataChanged;
+
+                                     public void Subscribe()
+                                     {
+                                         DataChanged += OnDataChanged;
+                                         DataChanged?.Invoke(this, EventArgs.Empty);
+                                     }
+
+                                     private void OnDataChanged(object sender, EventArgs args) { }
+                                 }
+                                 """;
+
         await Verify(testCode, fixedCode, Diagnostics(RH4102EventNameCasingAnalyzer.DiagnosticId, AnalyzerResources.RH4102MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies two field-like events are fixed in one Fix All iteration
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyTwoEventsAreFixedInOneFixAllIteration()
+    {
+        const string testCode = """
+                                using System;
+
+                                internal class EventSource
+                                {
+                                    public event EventHandler {|#0:firstChanged|};
+
+                                    public event EventHandler {|#1:secondChanged|};
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 using System;
+
+                                 internal class EventSource
+                                 {
+                                     public event EventHandler FirstChanged;
+
+                                     public event EventHandler SecondChanged;
+                                 }
+                                 """;
+
+        await Verify(testCode,
+                     fixedCode,
+                     static config => config.NumberOfFixAllIterations = 1,
+                     Diagnostics(RH4102EventNameCasingAnalyzer.DiagnosticId, AnalyzerResources.RH4102MessageFormat, 2));
+    }
+
+    /// <summary>
+    /// Verifies two custom events are fixed by their dedicated provider in one Fix All iteration
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyTwoCustomEventsAreFixedInOneFixAllIteration()
+    {
+        const string testCode = """
+                                using System;
+
+                                internal class EventSource
+                                {
+                                    public event EventHandler {|#0:firstChanged|}
+                                    {
+                                        add { }
+                                        remove { }
+                                    }
+
+                                    public event EventHandler {|#1:secondChanged|}
+                                    {
+                                        add { }
+                                        remove { }
+                                    }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 using System;
+
+                                 internal class EventSource
+                                 {
+                                     public event EventHandler FirstChanged
+                                     {
+                                         add { }
+                                         remove { }
+                                     }
+
+                                     public event EventHandler SecondChanged
+                                     {
+                                         add { }
+                                         remove { }
+                                     }
+                                 }
+                                 """;
+
+        await VerifyCustomEvent(testCode, fixedCode, 2, fixAll: true);
+    }
+
+    /// <summary>
+    /// Verifies explicit-interface event implementations are not diagnosed separately from their interface declaration
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyExplicitInterfaceEventImplementationIsExcluded()
+    {
+        const string testCode = """
+                                using System;
+
+                                internal interface IEventSource
+                                {
+                                    event EventHandler {|#0:dataChanged|};
+                                }
+
+                                internal class EventSource : IEventSource
+                                {
+                                    event EventHandler IEventSource.dataChanged
+                                    {
+                                        add { }
+                                        remove { }
+                                    }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 using System;
+
+                                 internal interface IEventSource
+                                 {
+                                     event EventHandler DataChanged;
+                                 }
+
+                                 internal class EventSource : IEventSource
+                                 {
+                                     event EventHandler IEventSource.DataChanged
+                                     {
+                                         add { }
+                                         remove { }
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH4102EventNameCasingAnalyzer.DiagnosticId, AnalyzerResources.RH4102MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies a custom-event code fix with the dedicated internal provider
+    /// </summary>
+    /// <param name="testCode">Test source</param>
+    /// <param name="fixedCode">Expected fixed source</param>
+    /// <param name="diagnosticCount">Expected diagnostic count</param>
+    /// <param name="fixAll">Whether the provider must fix all diagnostics in one iteration</param>
+    /// <returns>A task that represents the asynchronous operation</returns>
+    private static async Task VerifyCustomEvent(string testCode, string fixedCode, int diagnosticCount, bool fixAll = false)
+    {
+        var test = new CSharpCodeFixVerifierTest<RH4102EventNameCasingAnalyzer, RH4102CustomEventNameCasingCodeFixProvider>
+                   {
+                       TestCode = testCode,
+                       FixedCode = fixedCode,
+                       ReferenceAssemblies = ReferenceAssemblies.Net.Net90
+                   };
+
+        test.ExpectedDiagnostics.AddRange(Diagnostics(RH4102EventNameCasingAnalyzer.DiagnosticId, AnalyzerResources.RH4102MessageFormat, diagnosticCount));
+
+        if (fixAll)
+        {
+            test.NumberOfFixAllIterations = 1;
+        }
+
+        await test.RunAsync();
     }
 
     #endregion // Tests

--- a/Reihitsu.Analyzer.Test/Naming/RH4106PrivateFieldCasingAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Naming/RH4106PrivateFieldCasingAnalyzerTests.cs
@@ -186,5 +186,29 @@ public class RH4106PrivateFieldCasingAnalyzerTests : AnalyzerTestsBase<RH4106Pri
         Assert.IsEmpty(actions);
     }
 
+    /// <summary>
+    /// Verifies that a field without an accessibility modifier is treated as effectively private
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyImplicitlyPrivateFieldIsDetectedAndFixed()
+    {
+        const string testCode = """
+                                internal class ResourceCache
+                                {
+                                    int {|#0:cacheCount|};
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 internal class ResourceCache
+                                 {
+                                     int _cacheCount;
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH4106PrivateFieldCasingAnalyzer.DiagnosticId, AnalyzerResources.RH4106MessageFormat));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Naming/RH4107ProtectedFieldCasingAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Naming/RH4107ProtectedFieldCasingAnalyzerTests.cs
@@ -126,5 +126,22 @@ public class RH4107ProtectedFieldCasingAnalyzerTests : AnalyzerTestsBase<RH4107P
         await Verify(testCode, fixedCode, Diagnostics(RH4107ProtectedFieldCasingAnalyzer.DiagnosticId, AnalyzerResources.RH4107MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies that an implicitly private field is not claimed by the protected field rule
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForImplicitlyPrivateField()
+    {
+        const string testCode = """
+                                internal class ResourceCache
+                                {
+                                    int cacheCount;
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Naming/RH4108InternalFieldCasingAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Naming/RH4108InternalFieldCasingAnalyzerTests.cs
@@ -136,5 +136,22 @@ public class RH4108InternalFieldCasingAnalyzerTests : AnalyzerTestsBase<RH4108In
         await Verify(testCode, fixedCode, Diagnostics(RH4108InternalFieldCasingAnalyzer.DiagnosticId, AnalyzerResources.RH4108MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies that an implicitly private field is not claimed by the internal field rule
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForImplicitlyPrivateField()
+    {
+        const string testCode = """
+                                internal class ResourceCache
+                                {
+                                    int cacheCount;
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Naming/RH4109PublicFieldCasingAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Naming/RH4109PublicFieldCasingAnalyzerTests.cs
@@ -106,5 +106,22 @@ public class RH4109PublicFieldCasingAnalyzerTests : AnalyzerTestsBase<RH4109Publ
         await Verify(testCode, fixedCode, Diagnostics(RH4109PublicFieldCasingAnalyzer.DiagnosticId, AnalyzerResources.RH4109MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies that an implicitly private field is not claimed by the public field rule
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForImplicitlyPrivateField()
+    {
+        const string testCode = """
+                                internal class ResourceCache
+                                {
+                                    int cacheCount;
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Naming/RH4111PrivatePropertyCasingAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Naming/RH4111PrivatePropertyCasingAnalyzerTests.cs
@@ -126,5 +126,46 @@ public class RH4111PrivatePropertyCasingAnalyzerTests : AnalyzerTestsBase<RH4111
         await Verify(testCode);
     }
 
+    /// <summary>
+    /// Verifies that a class property without an accessibility modifier is treated as effectively private
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyImplicitlyPrivateClassPropertyIsDetectedAndFixed()
+    {
+        const string testCode = """
+                                internal class ResourceSettings
+                                {
+                                    int {|#0:resourceCount|} { get; set; }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 internal class ResourceSettings
+                                 {
+                                     int ResourceCount { get; set; }
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH4111PrivatePropertyCasingAnalyzer.DiagnosticId, AnalyzerResources.RH4111MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that an implicit interface property is owned by the public property rule
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForImplicitInterfaceProperty()
+    {
+        const string testCode = """
+                                internal interface IResourceSettings
+                                {
+                                    int resourceCount { get; }
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Naming/RH4111PrivatePropertyCasingAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Naming/RH4111PrivatePropertyCasingAnalyzerTests.cs
@@ -167,5 +167,27 @@ public class RH4111PrivatePropertyCasingAnalyzerTests : AnalyzerTestsBase<RH4111
         await Verify(testCode);
     }
 
+    /// <summary>
+    /// Verifies an explicit-interface property implementation is not owned by the private property rule
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForExplicitInterfacePropertyImplementation()
+    {
+        const string testCode = """
+                                internal interface IResourceSettings
+                                {
+                                    int resourceCount { get; }
+                                }
+
+                                internal class ResourceSettings : IResourceSettings
+                                {
+                                    int IResourceSettings.resourceCount => 42;
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Naming/RH4112ProtectedPropertyCasingAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Naming/RH4112ProtectedPropertyCasingAnalyzerTests.cs
@@ -126,5 +126,27 @@ public class RH4112ProtectedPropertyCasingAnalyzerTests : AnalyzerTestsBase<RH41
         await Verify(testCode, fixedCode, Diagnostics(RH4112ProtectedPropertyCasingAnalyzer.DiagnosticId, AnalyzerResources.RH4112MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies that implicit class and interface properties are owned by the private and public rules
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForImplicitProperties()
+    {
+        const string testCode = """
+                                internal class ResourceSettings
+                                {
+                                    int classProperty { get; set; }
+                                }
+
+                                internal interface IResourceSettings
+                                {
+                                    int interfaceProperty { get; }
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Naming/RH4113InternalPropertyCasingAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Naming/RH4113InternalPropertyCasingAnalyzerTests.cs
@@ -136,5 +136,27 @@ public class RH4113InternalPropertyCasingAnalyzerTests : AnalyzerTestsBase<RH411
         await Verify(testCode, fixedCode, Diagnostics(RH4113InternalPropertyCasingAnalyzer.DiagnosticId, AnalyzerResources.RH4113MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies that implicit class and interface properties are owned by the private and public rules
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForImplicitProperties()
+    {
+        const string testCode = """
+                                internal class ResourceSettings
+                                {
+                                    int classProperty { get; set; }
+                                }
+
+                                internal interface IResourceSettings
+                                {
+                                    int interfaceProperty { get; }
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Naming/RH4114PublicPropertyCasingAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Naming/RH4114PublicPropertyCasingAnalyzerTests.cs
@@ -106,5 +106,46 @@ public class RH4114PublicPropertyCasingAnalyzerTests : AnalyzerTestsBase<RH4114P
         await Verify(testCode, fixedCode, Diagnostics(RH4114PublicPropertyCasingAnalyzer.DiagnosticId, AnalyzerResources.RH4114MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies that an interface property without an accessibility modifier is treated as effectively public
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyImplicitlyPublicInterfacePropertyIsDetectedAndFixed()
+    {
+        const string testCode = """
+                                internal interface IResourceSettings
+                                {
+                                    int {|#0:resourceCount|} { get; }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 internal interface IResourceSettings
+                                 {
+                                     int ResourceCount { get; }
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH4114PublicPropertyCasingAnalyzer.DiagnosticId, AnalyzerResources.RH4114MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that an implicit class property is owned by the private property rule
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsForImplicitClassProperty()
+    {
+        const string testCode = """
+                                internal class ResourceSettings
+                                {
+                                    int resourceCount { get; set; }
+                                }
+                                """;
+
+        await Verify(testCode);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Naming/RH4114PublicPropertyCasingAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Naming/RH4114PublicPropertyCasingAnalyzerTests.cs
@@ -147,5 +147,39 @@ public class RH4114PublicPropertyCasingAnalyzerTests : AnalyzerTestsBase<RH4114P
         await Verify(testCode);
     }
 
+    /// <summary>
+    /// Verifies the interface declaration owns casing and its explicit implementation is renamed through the symbol
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyInterfacePropertyOwnsExplicitImplementationCasing()
+    {
+        const string testCode = """
+                                internal interface IResourceSettings
+                                {
+                                    int {|#0:resourceCount|} { get; }
+                                }
+
+                                internal class ResourceSettings : IResourceSettings
+                                {
+                                    int IResourceSettings.resourceCount => 42;
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 internal interface IResourceSettings
+                                 {
+                                     int ResourceCount { get; }
+                                 }
+
+                                 internal class ResourceSettings : IResourceSettings
+                                 {
+                                     int IResourceSettings.ResourceCount => 42;
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH4114PublicPropertyCasingAnalyzer.DiagnosticId, AnalyzerResources.RH4114MessageFormat));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Ordering/RH7104PartialElementsMustDeclareAccessModifierAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Ordering/RH7104PartialElementsMustDeclareAccessModifierAnalyzerTests.cs
@@ -28,6 +28,18 @@ public class RH7104PartialElementsMustDeclareAccessModifierAnalyzerTests : Analy
                                 {
                                     public int Bar { get; set; }
                                 }
+
+                                partial struct {|#1:TestStruct|}
+                                {
+                                }
+
+                                partial interface {|#2:ITest|}
+                                {
+                                }
+
+                                partial record {|#3:TestRecord|};
+
+                                partial record struct {|#4:TestRecordStruct|};
                                 """;
 
         const string fixedCode = """
@@ -35,9 +47,17 @@ public class RH7104PartialElementsMustDeclareAccessModifierAnalyzerTests : Analy
                                  {
                                      public int Bar { get; set; }
                                  }
+
+                                 internal partial struct TestStruct;
+
+                                 internal partial interface ITest;
+
+                                 internal partial record TestRecord;
+
+                                 internal partial record struct TestRecordStruct;
                                  """;
 
-        await Verify(testCode, fixedCode, Diagnostics(RH7104PartialElementsMustDeclareAccessModifierAnalyzer.DiagnosticId, AnalyzerResources.RH7104MessageFormat));
+        await Verify(testCode, fixedCode, Diagnostics(RH7104PartialElementsMustDeclareAccessModifierAnalyzer.DiagnosticId, AnalyzerResources.RH7104MessageFormat, 5));
     }
 
     #endregion // Tests

--- a/Reihitsu.Analyzer.Test/Ordering/RH7104PartialElementsMustDeclareAccessModifierAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Ordering/RH7104PartialElementsMustDeclareAccessModifierAnalyzerTests.cs
@@ -60,5 +60,52 @@ public class RH7104PartialElementsMustDeclareAccessModifierAnalyzerTests : Analy
         await Verify(testCode, fixedCode, Diagnostics(RH7104PartialElementsMustDeclareAccessModifierAnalyzer.DiagnosticId, AnalyzerResources.RH7104MessageFormat, 5));
     }
 
+    /// <summary>
+    /// Verifying that partial parts inherit and declare the accessibility selected by another part
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task PartialTypesWithPublicAndCompoundAccessibilityAreFixed()
+    {
+        const string testCode = """
+                                public partial class Sample
+                                {
+                                }
+
+                                partial class {|#0:Sample|}
+                                {
+                                }
+
+                                internal partial class Outer
+                                {
+                                    protected internal partial class Inner
+                                    {
+                                    }
+
+                                    partial class {|#1:Inner|}
+                                    {
+                                    }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 public partial class Sample
+                                 {
+                                 }
+
+                                 public partial class Sample;
+
+                                 internal partial class Outer
+                                 {
+                                     protected internal partial class Inner
+                                     {
+                                     }
+                                     protected internal partial class Inner;
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH7104PartialElementsMustDeclareAccessModifierAnalyzer.DiagnosticId, AnalyzerResources.RH7104MessageFormat, 2));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer/Core/DebugMessageTextAnalysisUtilities.cs
+++ b/Reihitsu.Analyzer/Core/DebugMessageTextAnalysisUtilities.cs
@@ -1,0 +1,32 @@
+using System.Threading;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Reihitsu.Analyzer.Core;
+
+/// <summary>
+/// Utilities for determining whether a Debug message argument provides usable text
+/// </summary>
+internal static class DebugMessageTextAnalysisUtilities
+{
+    #region Methods
+
+    /// <summary>
+    /// Determines whether the argument is a constant message without usable text
+    /// </summary>
+    /// <param name="messageExpression">Message expression</param>
+    /// <param name="semanticModel">Semantic model</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns><see langword="true"/> when the message is <see langword="null"/>, empty, or whitespace</returns>
+    internal static bool IsConstantMessageWithoutText(ExpressionSyntax messageExpression, SemanticModel semanticModel, CancellationToken cancellationToken)
+    {
+        var constantValue = semanticModel.GetConstantValue(messageExpression, cancellationToken);
+
+        return constantValue.HasValue
+               && (constantValue.Value is null
+                   || (constantValue.Value is string text && string.IsNullOrWhiteSpace(text)));
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Analyzer/Core/NamingAccessibilityClassifier.cs
+++ b/Reihitsu.Analyzer/Core/NamingAccessibilityClassifier.cs
@@ -1,0 +1,58 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+using Reihitsu.Core;
+
+namespace Reihitsu.Analyzer.Core;
+
+/// <summary>
+/// Classifies field and property declarations by their effective accessibility for casing-rule ownership
+/// </summary>
+internal static class NamingAccessibilityClassifier
+{
+    #region Methods
+
+    /// <summary>
+    /// Gets the single casing-rule accessibility owner for a declaration
+    /// </summary>
+    /// <param name="declaration">Declaration</param>
+    /// <returns>The effective accessibility owner, or <see cref="Accessibility.NotApplicable"/> when no rule owns it</returns>
+    internal static Accessibility GetEffectiveAccessibility(MemberDeclarationSyntax declaration)
+    {
+        if (declaration is PropertyDeclarationSyntax { ExplicitInterfaceSpecifier: not null })
+        {
+            return Accessibility.NotApplicable;
+        }
+
+        var modifiers = declaration.Modifiers;
+
+        if (modifiers.Any(SyntaxKind.PublicKeyword))
+        {
+            return Accessibility.Public;
+        }
+
+        if (modifiers.Any(SyntaxKind.ProtectedKeyword))
+        {
+            return modifiers.Any(SyntaxKind.InternalKeyword)
+                       ? Accessibility.Internal
+                       : Accessibility.Protected;
+        }
+
+        if (modifiers.Any(SyntaxKind.InternalKeyword))
+        {
+            return Accessibility.Internal;
+        }
+
+        if (modifiers.Any(SyntaxKind.PrivateKeyword))
+        {
+            return Accessibility.Private;
+        }
+
+        return declaration.Parent is InterfaceDeclarationSyntax
+                   ? Accessibility.Public
+                   : Accessibility.Private;
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Analyzer/Core/SameLinePrecedingWhitespaceAnalysis.cs
+++ b/Reihitsu.Analyzer/Core/SameLinePrecedingWhitespaceAnalysis.cs
@@ -1,0 +1,36 @@
+using Microsoft.CodeAnalysis.Text;
+
+namespace Reihitsu.Analyzer.Core;
+
+/// <summary>
+/// Analyzes horizontal whitespace immediately before a source position
+/// </summary>
+internal static class SameLinePrecedingWhitespaceAnalysis
+{
+    #region Methods
+
+    /// <summary>
+    /// Gets the horizontal whitespace run immediately before a source position when the run follows source on the same line
+    /// </summary>
+    /// <param name="sourceText">Source text to inspect</param>
+    /// <param name="position">Exclusive end of the whitespace run</param>
+    /// <returns>The same-line whitespace span, or <see langword="null"/> when there is no run or the run is line-leading indentation</returns>
+    internal static TextSpan? GetSpan(SourceText sourceText, int position)
+    {
+        var start = position;
+        var lineStart = sourceText.Lines.GetLineFromPosition(position).Start;
+
+        while (start > lineStart
+               && (sourceText[start - 1] == ' ' || sourceText[start - 1] == '\t'))
+        {
+            start--;
+        }
+
+        return start > lineStart
+               && start < position
+                   ? TextSpan.FromBounds(start, position)
+                   : null;
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Analyzer/Rules/Clarity/RH3202ExpressionStyleMethodsShouldNotBeUsedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Clarity/RH3202ExpressionStyleMethodsShouldNotBeUsedAnalyzer.cs
@@ -61,7 +61,7 @@ public class RH3202ExpressionStyleMethodsShouldNotBeUsedAnalyzer : DiagnosticAna
             return;
         }
 
-        context.ReportDiagnostic(CreateDiagnostic(methodDeclaration.GetLocation()));
+        context.ReportDiagnostic(CreateDiagnostic(methodDeclaration.ExpressionBody.GetLocation()));
     }
 
     #endregion // Methods

--- a/Reihitsu.Analyzer/Rules/Clarity/RH3203ExpressionStyleConstructorsShouldNotBeUsedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Clarity/RH3203ExpressionStyleConstructorsShouldNotBeUsedAnalyzer.cs
@@ -61,7 +61,7 @@ public class RH3203ExpressionStyleConstructorsShouldNotBeUsedAnalyzer : Diagnost
             return;
         }
 
-        context.ReportDiagnostic(CreateDiagnostic(constructorDeclaration.GetLocation()));
+        context.ReportDiagnostic(CreateDiagnostic(constructorDeclaration.ExpressionBody.GetLocation()));
     }
 
     #endregion // Methods

--- a/Reihitsu.Analyzer/Rules/Design/RH2003NotImplementedExceptionShouldNotBeUsedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Design/RH2003NotImplementedExceptionShouldNotBeUsedAnalyzer.cs
@@ -38,6 +38,18 @@ public class RH2003NotImplementedExceptionShouldNotBeUsedAnalyzer : DiagnosticAn
     #region Methods
 
     /// <summary>
+    /// Determine whether the expression creates <see cref="System.NotImplementedException"/>
+    /// </summary>
+    /// <param name="expression">Creation expression</param>
+    /// <param name="context">Context</param>
+    /// <returns><see langword="true"/> if the created type is <see cref="System.NotImplementedException"/></returns>
+    private static bool IsNotImplementedException(ExpressionSyntax expression, SyntaxNodeAnalysisContext context)
+    {
+        return context.SemanticModel.GetTypeInfo(expression, context.CancellationToken).Type is INamedTypeSymbol typeSymbol
+               && typeSymbol.ToDisplayString() == "System.NotImplementedException";
+    }
+
+    /// <summary>
     /// Gets the simple (rightmost) type name of a type syntax
     /// </summary>
     /// <param name="type">Type syntax</param>
@@ -70,14 +82,22 @@ public class RH2003NotImplementedExceptionShouldNotBeUsedAnalyzer : DiagnosticAn
             return;
         }
 
-        if (context.SemanticModel.GetTypeInfo(objectCreation).Type is not INamedTypeSymbol typeSymbol)
-        {
-            return;
-        }
-
-        if (typeSymbol.ToDisplayString() == "System.NotImplementedException")
+        if (IsNotImplementedException(objectCreation, context))
         {
             context.ReportDiagnostic(CreateDiagnostic(objectCreation.Type.GetLocation()));
+        }
+    }
+
+    /// <summary>
+    /// Analyzing all <see cref="SyntaxKind.ImplicitObjectCreationExpression"/> nodes
+    /// </summary>
+    /// <param name="context">Context</param>
+    private void OnImplicitObjectCreationExpression(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is ImplicitObjectCreationExpressionSyntax implicitObjectCreation
+            && IsNotImplementedException(implicitObjectCreation, context))
+        {
+            context.ReportDiagnostic(CreateDiagnostic(implicitObjectCreation.NewKeyword.GetLocation()));
         }
     }
 
@@ -91,6 +111,7 @@ public class RH2003NotImplementedExceptionShouldNotBeUsedAnalyzer : DiagnosticAn
         base.Initialize(context);
 
         context.RegisterSyntaxNodeAction(OnObjectCreationExpression, SyntaxKind.ObjectCreationExpression);
+        context.RegisterSyntaxNodeAction(OnImplicitObjectCreationExpression, SyntaxKind.ImplicitObjectCreationExpression);
     }
 
     #endregion // DiagnosticAnalyzer

--- a/Reihitsu.Analyzer/Rules/Design/RH2004AccessModifierMustBeDeclaredAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Design/RH2004AccessModifierMustBeDeclaredAnalyzer.cs
@@ -45,7 +45,15 @@ public class RH2004AccessModifierMustBeDeclaredAnalyzer : DiagnosticAnalyzerBase
     /// <returns><see langword="true"/> if the declaration should be skipped</returns>
     private static bool ShouldSkip(MemberDeclarationSyntax memberDeclaration)
     {
-        if (memberDeclaration.Ancestors().OfType<InterfaceDeclarationSyntax>().Any())
+        if (memberDeclaration is TypeDeclarationSyntax typeDeclaration
+            && typeDeclaration.Modifiers.Any(SyntaxKind.PartialKeyword))
+        {
+            return true;
+        }
+
+        if (memberDeclaration.Parent is InterfaceDeclarationSyntax
+            && memberDeclaration is not BaseTypeDeclarationSyntax
+            && memberDeclaration is not DelegateDeclarationSyntax)
         {
             return true;
         }
@@ -127,6 +135,7 @@ public class RH2004AccessModifierMustBeDeclaredAnalyzer : DiagnosticAnalyzerBase
                                          SyntaxKind.InterfaceDeclaration,
                                          SyntaxKind.EnumDeclaration,
                                          SyntaxKind.RecordDeclaration,
+                                         SyntaxKind.RecordStructDeclaration,
                                          SyntaxKind.DelegateDeclaration,
                                          SyntaxKind.MethodDeclaration,
                                          SyntaxKind.PropertyDeclaration,

--- a/Reihitsu.Analyzer/Rules/Design/RH2005FieldsMustBePrivateAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Design/RH2005FieldsMustBePrivateAnalyzer.cs
@@ -46,7 +46,8 @@ public class RH2005FieldsMustBePrivateAnalyzer : DiagnosticAnalyzerBase
     private static bool ShouldSkip(FieldDeclarationSyntax fieldDeclaration)
     {
         if (fieldDeclaration.Parent is not ClassDeclarationSyntax
-            && fieldDeclaration.Parent is not RecordDeclarationSyntax)
+            && (fieldDeclaration.Parent is not RecordDeclarationSyntax recordDeclaration
+                || recordDeclaration.ClassOrStructKeyword.IsKind(SyntaxKind.StructKeyword)))
         {
             return true;
         }
@@ -66,16 +67,13 @@ public class RH2005FieldsMustBePrivateAnalyzer : DiagnosticAnalyzerBase
     }
 
     /// <summary>
-    /// Determine whether the modifiers declare only <see langword="private"/> accessibility
+    /// Determine whether the modifiers declare <see langword="public"/> accessibility
     /// </summary>
     /// <param name="modifiers">Modifiers</param>
-    /// <returns><see langword="true"/> if the field is explicitly private</returns>
-    private static bool HasOnlyPrivateAccessibility(SyntaxTokenList modifiers)
+    /// <returns><see langword="true"/> if the field is explicitly public</returns>
+    private static bool HasPublicAccessibility(SyntaxTokenList modifiers)
     {
-        return modifiers.Any(SyntaxKind.PrivateKeyword)
-               && modifiers.Any(SyntaxKind.PublicKeyword) == false
-               && modifiers.Any(SyntaxKind.ProtectedKeyword) == false
-               && modifiers.Any(SyntaxKind.InternalKeyword) == false;
+        return modifiers.Any(SyntaxKind.PublicKeyword);
     }
 
     /// <summary>
@@ -94,7 +92,7 @@ public class RH2005FieldsMustBePrivateAnalyzer : DiagnosticAnalyzerBase
             return;
         }
 
-        if (HasOnlyPrivateAccessibility(fieldDeclaration.Modifiers))
+        if (HasPublicAccessibility(fieldDeclaration.Modifiers) == false)
         {
             return;
         }

--- a/Reihitsu.Analyzer/Rules/Design/RH2006DebugAssertMustProvideMessageTextAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Design/RH2006DebugAssertMustProvideMessageTextAnalyzer.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using System.Threading;
+
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -55,6 +57,31 @@ public class RH2006DebugAssertMustProvideMessageTextAnalyzer : DiagnosticAnalyze
     }
 
     /// <summary>
+    /// Determine whether the message argument is absent, <see langword="null"/>, empty, or whitespace
+    /// </summary>
+    /// <param name="invocationExpression">Invocation expression</param>
+    /// <param name="semanticModel">Semantic model</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns><see langword="true"/> if the invocation should be reported</returns>
+    private static bool ShouldReport(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken)
+    {
+        if (invocationExpression.ArgumentList.Arguments.Count < 2)
+        {
+            return true;
+        }
+
+        var constantValue = semanticModel.GetConstantValue(invocationExpression.ArgumentList.Arguments[1].Expression, cancellationToken);
+
+        if (constantValue.HasValue == false)
+        {
+            return false;
+        }
+
+        return constantValue.Value is null
+               || (constantValue.Value is string text && string.IsNullOrWhiteSpace(text));
+    }
+
+    /// <summary>
     /// Analyzing all <see cref="SyntaxKind.InvocationExpression"/> nodes
     /// </summary>
     /// <param name="context">Context</param>
@@ -89,7 +116,7 @@ public class RH2006DebugAssertMustProvideMessageTextAnalyzer : DiagnosticAnalyze
             return;
         }
 
-        if (invocationExpression.ArgumentList.Arguments.Count >= 2)
+        if (ShouldReport(invocationExpression, context.SemanticModel, context.CancellationToken) == false)
         {
             return;
         }

--- a/Reihitsu.Analyzer/Rules/Design/RH2006DebugAssertMustProvideMessageTextAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Design/RH2006DebugAssertMustProvideMessageTextAnalyzer.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Core;
 using Reihitsu.Analyzer.Enumerations;
 
 namespace Reihitsu.Analyzer.Rules.Design;
@@ -60,25 +61,25 @@ public class RH2006DebugAssertMustProvideMessageTextAnalyzer : DiagnosticAnalyze
     /// Determine whether the message argument is absent, <see langword="null"/>, empty, or whitespace
     /// </summary>
     /// <param name="invocationExpression">Invocation expression</param>
+    /// <param name="methodSymbol">Method symbol</param>
     /// <param name="semanticModel">Semantic model</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns><see langword="true"/> if the invocation should be reported</returns>
-    private static bool ShouldReport(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken)
+    private static bool ShouldReport(InvocationExpressionSyntax invocationExpression, IMethodSymbol methodSymbol, SemanticModel semanticModel, CancellationToken cancellationToken)
     {
-        if (invocationExpression.ArgumentList.Arguments.Count < 2)
+        var messageParameter = methodSymbol.Parameters.FirstOrDefault(parameter => parameter.Name == "message");
+
+        if (messageParameter == null)
         {
             return true;
         }
 
-        var constantValue = semanticModel.GetConstantValue(invocationExpression.ArgumentList.Arguments[1].Expression, cancellationToken);
+        var arguments = invocationExpression.ArgumentList.Arguments;
+        var messageArgument = arguments.FirstOrDefault(argument => argument.NameColon?.Name.Identifier.ValueText == "message")
+                                  ?? (arguments.Count > messageParameter.Ordinal ? arguments[messageParameter.Ordinal] : null);
 
-        if (constantValue.HasValue == false)
-        {
-            return false;
-        }
-
-        return constantValue.Value is null
-               || (constantValue.Value is string text && string.IsNullOrWhiteSpace(text));
+        return messageArgument == null
+               || DebugMessageTextAnalysisUtilities.IsConstantMessageWithoutText(messageArgument.Expression, semanticModel, cancellationToken);
     }
 
     /// <summary>
@@ -116,7 +117,7 @@ public class RH2006DebugAssertMustProvideMessageTextAnalyzer : DiagnosticAnalyze
             return;
         }
 
-        if (ShouldReport(invocationExpression, context.SemanticModel, context.CancellationToken) == false)
+        if (ShouldReport(invocationExpression, methodSymbol, context.SemanticModel, context.CancellationToken) == false)
         {
             return;
         }

--- a/Reihitsu.Analyzer/Rules/Design/RH2007DebugFailMustProvideMessageTextAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Design/RH2007DebugFailMustProvideMessageTextAnalyzer.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Core;
 using Reihitsu.Analyzer.Enumerations;
 
 namespace Reihitsu.Analyzer.Rules.Design;
@@ -71,25 +72,25 @@ public class RH2007DebugFailMustProvideMessageTextAnalyzer : DiagnosticAnalyzerB
     /// Determine whether the message argument is <see langword="null"/>, empty, or whitespace
     /// </summary>
     /// <param name="invocationExpression">Invocation expression</param>
+    /// <param name="methodSymbol">Method symbol</param>
     /// <param name="semanticModel">Semantic model</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns><see langword="true"/> if the invocation should be reported</returns>
-    private static bool ShouldReport(InvocationExpressionSyntax invocationExpression, SemanticModel semanticModel, CancellationToken cancellationToken)
+    private static bool ShouldReport(InvocationExpressionSyntax invocationExpression, IMethodSymbol methodSymbol, SemanticModel semanticModel, CancellationToken cancellationToken)
     {
-        if (invocationExpression.ArgumentList.Arguments.Count == 0)
+        var messageParameter = methodSymbol.Parameters.FirstOrDefault(parameter => parameter.Name == "message");
+
+        if (messageParameter == null)
         {
             return false;
         }
 
-        var constantValue = semanticModel.GetConstantValue(invocationExpression.ArgumentList.Arguments[0].Expression, cancellationToken);
+        var arguments = invocationExpression.ArgumentList.Arguments;
+        var messageArgument = arguments.FirstOrDefault(argument => argument.NameColon?.Name.Identifier.ValueText == "message")
+                                  ?? (arguments.Count > messageParameter.Ordinal ? arguments[messageParameter.Ordinal] : null);
 
-        if (constantValue.HasValue == false)
-        {
-            return false;
-        }
-
-        return constantValue.Value is null
-               || (constantValue.Value is string text && string.IsNullOrWhiteSpace(text));
+        return messageArgument != null
+               && DebugMessageTextAnalysisUtilities.IsConstantMessageWithoutText(messageArgument.Expression, semanticModel, cancellationToken);
     }
 
     /// <summary>
@@ -114,7 +115,7 @@ public class RH2007DebugFailMustProvideMessageTextAnalyzer : DiagnosticAnalyzerB
 
         if (methodSymbol == null
             || IsDebugFail(methodSymbol) == false
-            || ShouldReport(invocationExpression, context.SemanticModel, context.CancellationToken) == false)
+            || ShouldReport(invocationExpression, methodSymbol, context.SemanticModel, context.CancellationToken) == false)
         {
             return;
         }

--- a/Reihitsu.Analyzer/Rules/Naming/RH4001TypeNameShouldMatchFileNameAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Naming/RH4001TypeNameShouldMatchFileNameAnalyzer.cs
@@ -52,7 +52,12 @@ public class RH4001TypeNameShouldMatchFileNameAnalyzer : DiagnosticAnalyzerBase
 
             if (child is BaseNamespaceDeclarationSyntax)
             {
-                return FindFirstTypeDeclaration(child);
+                var declaration = FindFirstTypeDeclaration(child);
+
+                if (declaration != null)
+                {
+                    return declaration;
+                }
             }
         }
 

--- a/Reihitsu.Analyzer/Rules/Naming/RH4102EventNameCasingAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Naming/RH4102EventNameCasingAnalyzer.cs
@@ -57,7 +57,7 @@ public class RH4102EventNameCasingAnalyzer : CasingAnalyzerBase
                 yield return (identifier.ValueText, identifier.GetLocation());
             }
         }
-        else if (node is EventDeclarationSyntax eventDeclaration)
+        else if (node is EventDeclarationSyntax { ExplicitInterfaceSpecifier: null } eventDeclaration)
         {
             yield return (eventDeclaration.Identifier.ValueText, eventDeclaration.Identifier.GetLocation());
         }

--- a/Reihitsu.Analyzer/Rules/Naming/RH4102EventNameCasingAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Naming/RH4102EventNameCasingAnalyzer.cs
@@ -32,7 +32,12 @@ public class RH4102EventNameCasingAnalyzer : CasingAnalyzerBase
     /// Constructor
     /// </summary>
     public RH4102EventNameCasingAnalyzer()
-        : base(DiagnosticId, DiagnosticCategory.Naming, nameof(AnalyzerResources.RH4102Title), nameof(AnalyzerResources.RH4102MessageFormat), SyntaxKind.EventFieldDeclaration, CasingUtilities.IsPascalCase)
+        : base(DiagnosticId,
+               DiagnosticCategory.Naming,
+               nameof(AnalyzerResources.RH4102Title),
+               nameof(AnalyzerResources.RH4102MessageFormat),
+               [SyntaxKind.EventFieldDeclaration, SyntaxKind.EventDeclaration],
+               CasingUtilities.IsPascalCase)
     {
     }
 
@@ -51,6 +56,10 @@ public class RH4102EventNameCasingAnalyzer : CasingAnalyzerBase
             {
                 yield return (identifier.ValueText, identifier.GetLocation());
             }
+        }
+        else if (node is EventDeclarationSyntax eventDeclaration)
+        {
+            yield return (eventDeclaration.Identifier.ValueText, eventDeclaration.Identifier.GetLocation());
         }
     }
 

--- a/Reihitsu.Analyzer/Rules/Naming/RH4106PrivateFieldCasingAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Naming/RH4106PrivateFieldCasingAnalyzer.cs
@@ -45,8 +45,12 @@ public class RH4106PrivateFieldCasingAnalyzer : CasingAnalyzerBase
     {
         if (node is FieldDeclarationSyntax declaration
             && declaration.Modifiers.Any(SyntaxKind.ConstKeyword) == false
-            && declaration.Modifiers.Any(SyntaxKind.PrivateKeyword)
-            && declaration.Modifiers.Any(SyntaxKind.ProtectedKeyword) == false)
+            && ((declaration.Modifiers.Any(SyntaxKind.PrivateKeyword)
+                 && declaration.Modifiers.Any(SyntaxKind.ProtectedKeyword) == false)
+                || (declaration.Modifiers.Any(SyntaxKind.PrivateKeyword) == false
+                    && declaration.Modifiers.Any(SyntaxKind.ProtectedKeyword) == false
+                    && declaration.Modifiers.Any(SyntaxKind.InternalKeyword) == false
+                    && declaration.Modifiers.Any(SyntaxKind.PublicKeyword) == false)))
         {
             foreach (var identifier in declaration.Declaration
                                                   .Variables

--- a/Reihitsu.Analyzer/Rules/Naming/RH4106PrivateFieldCasingAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Naming/RH4106PrivateFieldCasingAnalyzer.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Core;
 using Reihitsu.Analyzer.Enumerations;
 using Reihitsu.Core;
 
@@ -45,12 +46,7 @@ public class RH4106PrivateFieldCasingAnalyzer : CasingAnalyzerBase
     {
         if (node is FieldDeclarationSyntax declaration
             && declaration.Modifiers.Any(SyntaxKind.ConstKeyword) == false
-            && ((declaration.Modifiers.Any(SyntaxKind.PrivateKeyword)
-                 && declaration.Modifiers.Any(SyntaxKind.ProtectedKeyword) == false)
-                || (declaration.Modifiers.Any(SyntaxKind.PrivateKeyword) == false
-                    && declaration.Modifiers.Any(SyntaxKind.ProtectedKeyword) == false
-                    && declaration.Modifiers.Any(SyntaxKind.InternalKeyword) == false
-                    && declaration.Modifiers.Any(SyntaxKind.PublicKeyword) == false)))
+            && NamingAccessibilityClassifier.GetEffectiveAccessibility(declaration) == Accessibility.Private)
         {
             foreach (var identifier in declaration.Declaration
                                                   .Variables

--- a/Reihitsu.Analyzer/Rules/Naming/RH4107ProtectedFieldCasingAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Naming/RH4107ProtectedFieldCasingAnalyzer.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Core;
 using Reihitsu.Analyzer.Enumerations;
 using Reihitsu.Core;
 
@@ -45,8 +46,7 @@ public class RH4107ProtectedFieldCasingAnalyzer : CasingAnalyzerBase
     {
         if (node is FieldDeclarationSyntax declaration
             && declaration.Modifiers.Any(SyntaxKind.ConstKeyword) == false
-            && declaration.Modifiers.Any(SyntaxKind.ProtectedKeyword)
-            && declaration.Modifiers.Any(SyntaxKind.InternalKeyword) == false)
+            && NamingAccessibilityClassifier.GetEffectiveAccessibility(declaration) == Accessibility.Protected)
         {
             foreach (var identifier in declaration.Declaration
                                                   .Variables

--- a/Reihitsu.Analyzer/Rules/Naming/RH4108InternalFieldCasingAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Naming/RH4108InternalFieldCasingAnalyzer.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Core;
 using Reihitsu.Analyzer.Enumerations;
 using Reihitsu.Core;
 
@@ -45,7 +46,7 @@ public class RH4108InternalFieldCasingAnalyzer : CasingAnalyzerBase
     {
         if (node is FieldDeclarationSyntax declaration
             && declaration.Modifiers.Any(SyntaxKind.ConstKeyword) == false
-            && declaration.Modifiers.Any(SyntaxKind.InternalKeyword))
+            && NamingAccessibilityClassifier.GetEffectiveAccessibility(declaration) == Accessibility.Internal)
         {
             foreach (var identifier in declaration.Declaration
                                                   .Variables

--- a/Reihitsu.Analyzer/Rules/Naming/RH4109PublicFieldCasingAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Naming/RH4109PublicFieldCasingAnalyzer.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Core;
 using Reihitsu.Analyzer.Enumerations;
 using Reihitsu.Core;
 
@@ -45,7 +46,7 @@ public class RH4109PublicFieldCasingAnalyzer : CasingAnalyzerBase
     {
         if (node is FieldDeclarationSyntax declaration
             && declaration.Modifiers.Any(SyntaxKind.ConstKeyword) == false
-            && declaration.Modifiers.Any(SyntaxKind.PublicKeyword))
+            && NamingAccessibilityClassifier.GetEffectiveAccessibility(declaration) == Accessibility.Public)
         {
             foreach (var identifier in declaration.Declaration
                                                   .Variables

--- a/Reihitsu.Analyzer/Rules/Naming/RH4111PrivatePropertyCasingAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Naming/RH4111PrivatePropertyCasingAnalyzer.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Core;
 using Reihitsu.Analyzer.Enumerations;
 using Reihitsu.Core;
 
@@ -44,13 +45,7 @@ public class RH4111PrivatePropertyCasingAnalyzer : CasingAnalyzerBase
     protected override IEnumerable<(string Name, Location Location)> GetLocations(SyntaxNode node)
     {
         if (node is PropertyDeclarationSyntax declaration
-            && ((declaration.Modifiers.Any(SyntaxKind.PrivateKeyword)
-                 && declaration.Modifiers.Any(SyntaxKind.ProtectedKeyword) == false)
-                || (declaration.Parent is TypeDeclarationSyntax and not InterfaceDeclarationSyntax
-                    && declaration.Modifiers.Any(SyntaxKind.PrivateKeyword) == false
-                    && declaration.Modifiers.Any(SyntaxKind.ProtectedKeyword) == false
-                    && declaration.Modifiers.Any(SyntaxKind.InternalKeyword) == false
-                    && declaration.Modifiers.Any(SyntaxKind.PublicKeyword) == false)))
+            && NamingAccessibilityClassifier.GetEffectiveAccessibility(declaration) == Accessibility.Private)
         {
             yield return (declaration.Identifier.ValueText, declaration.Identifier.GetLocation());
         }

--- a/Reihitsu.Analyzer/Rules/Naming/RH4111PrivatePropertyCasingAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Naming/RH4111PrivatePropertyCasingAnalyzer.cs
@@ -44,8 +44,13 @@ public class RH4111PrivatePropertyCasingAnalyzer : CasingAnalyzerBase
     protected override IEnumerable<(string Name, Location Location)> GetLocations(SyntaxNode node)
     {
         if (node is PropertyDeclarationSyntax declaration
-            && declaration.Modifiers.Any(SyntaxKind.PrivateKeyword)
-            && declaration.Modifiers.Any(SyntaxKind.ProtectedKeyword) == false)
+            && ((declaration.Modifiers.Any(SyntaxKind.PrivateKeyword)
+                 && declaration.Modifiers.Any(SyntaxKind.ProtectedKeyword) == false)
+                || (declaration.Parent is TypeDeclarationSyntax and not InterfaceDeclarationSyntax
+                    && declaration.Modifiers.Any(SyntaxKind.PrivateKeyword) == false
+                    && declaration.Modifiers.Any(SyntaxKind.ProtectedKeyword) == false
+                    && declaration.Modifiers.Any(SyntaxKind.InternalKeyword) == false
+                    && declaration.Modifiers.Any(SyntaxKind.PublicKeyword) == false)))
         {
             yield return (declaration.Identifier.ValueText, declaration.Identifier.GetLocation());
         }

--- a/Reihitsu.Analyzer/Rules/Naming/RH4112ProtectedPropertyCasingAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Naming/RH4112ProtectedPropertyCasingAnalyzer.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Core;
 using Reihitsu.Analyzer.Enumerations;
 using Reihitsu.Core;
 
@@ -44,8 +45,7 @@ public class RH4112ProtectedPropertyCasingAnalyzer : CasingAnalyzerBase
     protected override IEnumerable<(string Name, Location Location)> GetLocations(SyntaxNode node)
     {
         if (node is PropertyDeclarationSyntax declaration
-            && declaration.Modifiers.Any(SyntaxKind.ProtectedKeyword)
-            && declaration.Modifiers.Any(SyntaxKind.InternalKeyword) == false)
+            && NamingAccessibilityClassifier.GetEffectiveAccessibility(declaration) == Accessibility.Protected)
         {
             yield return (declaration.Identifier.ValueText, declaration.Identifier.GetLocation());
         }

--- a/Reihitsu.Analyzer/Rules/Naming/RH4113InternalPropertyCasingAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Naming/RH4113InternalPropertyCasingAnalyzer.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Core;
 using Reihitsu.Analyzer.Enumerations;
 using Reihitsu.Core;
 
@@ -44,7 +45,7 @@ public class RH4113InternalPropertyCasingAnalyzer : CasingAnalyzerBase
     protected override IEnumerable<(string Name, Location Location)> GetLocations(SyntaxNode node)
     {
         if (node is PropertyDeclarationSyntax declaration
-            && declaration.Modifiers.Any(SyntaxKind.InternalKeyword))
+            && NamingAccessibilityClassifier.GetEffectiveAccessibility(declaration) == Accessibility.Internal)
         {
             yield return (declaration.Identifier.ValueText, declaration.Identifier.GetLocation());
         }

--- a/Reihitsu.Analyzer/Rules/Naming/RH4114PublicPropertyCasingAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Naming/RH4114PublicPropertyCasingAnalyzer.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Core;
 using Reihitsu.Analyzer.Enumerations;
 using Reihitsu.Core;
 
@@ -44,12 +45,7 @@ public class RH4114PublicPropertyCasingAnalyzer : CasingAnalyzerBase
     protected override IEnumerable<(string Name, Location Location)> GetLocations(SyntaxNode node)
     {
         if (node is PropertyDeclarationSyntax declaration
-            && (declaration.Modifiers.Any(SyntaxKind.PublicKeyword)
-                || (declaration.Parent is InterfaceDeclarationSyntax
-                    && declaration.Modifiers.Any(SyntaxKind.PrivateKeyword) == false
-                    && declaration.Modifiers.Any(SyntaxKind.ProtectedKeyword) == false
-                    && declaration.Modifiers.Any(SyntaxKind.InternalKeyword) == false
-                    && declaration.Modifiers.Any(SyntaxKind.PublicKeyword) == false)))
+            && NamingAccessibilityClassifier.GetEffectiveAccessibility(declaration) == Accessibility.Public)
         {
             yield return (declaration.Identifier.ValueText, declaration.Identifier.GetLocation());
         }

--- a/Reihitsu.Analyzer/Rules/Naming/RH4114PublicPropertyCasingAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Naming/RH4114PublicPropertyCasingAnalyzer.cs
@@ -44,7 +44,12 @@ public class RH4114PublicPropertyCasingAnalyzer : CasingAnalyzerBase
     protected override IEnumerable<(string Name, Location Location)> GetLocations(SyntaxNode node)
     {
         if (node is PropertyDeclarationSyntax declaration
-            && declaration.Modifiers.Any(SyntaxKind.PublicKeyword))
+            && (declaration.Modifiers.Any(SyntaxKind.PublicKeyword)
+                || (declaration.Parent is InterfaceDeclarationSyntax
+                    && declaration.Modifiers.Any(SyntaxKind.PrivateKeyword) == false
+                    && declaration.Modifiers.Any(SyntaxKind.ProtectedKeyword) == false
+                    && declaration.Modifiers.Any(SyntaxKind.InternalKeyword) == false
+                    && declaration.Modifiers.Any(SyntaxKind.PublicKeyword) == false)))
         {
             yield return (declaration.Identifier.ValueText, declaration.Identifier.GetLocation());
         }

--- a/Reihitsu.Analyzer/Rules/Spacing/RH6003SemicolonsMustBeSpacedCorrectlyAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Spacing/RH6003SemicolonsMustBeSpacedCorrectlyAnalyzer.cs
@@ -1,9 +1,9 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
 
 using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Core;
 using Reihitsu.Analyzer.Enumerations;
 
 namespace Reihitsu.Analyzer.Rules.Spacing;
@@ -50,20 +50,9 @@ public class RH6003SemicolonsMustBeSpacedCorrectlyAnalyzer : DiagnosticAnalyzerB
                                            .Where(currentToken => currentToken.IsKind(SyntaxKind.SemicolonToken))
                                            .Select(token => token.SpanStart))
         {
-            var start = tokenSpanStart;
-            var end = start;
-            var lineStart = sourceText.Lines.GetLineFromPosition(tokenSpanStart).Start;
-
-            while (start > lineStart
-                   && (sourceText[start - 1] == ' ' || sourceText[start - 1] == '\t'))
+            if (SameLinePrecedingWhitespaceAnalysis.GetSpan(sourceText, tokenSpanStart) is { } whitespaceSpan)
             {
-                start--;
-            }
-
-            if (start > lineStart
-                && start < end)
-            {
-                context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, TextSpan.FromBounds(start, end))));
+                context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, whitespaceSpan)));
             }
         }
     }

--- a/Reihitsu.Analyzer/Rules/Spacing/RH6003SemicolonsMustBeSpacedCorrectlyAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Spacing/RH6003SemicolonsMustBeSpacedCorrectlyAnalyzer.cs
@@ -52,14 +52,16 @@ public class RH6003SemicolonsMustBeSpacedCorrectlyAnalyzer : DiagnosticAnalyzerB
         {
             var start = tokenSpanStart;
             var end = start;
+            var lineStart = sourceText.Lines.GetLineFromPosition(tokenSpanStart).Start;
 
-            while (start > 0
+            while (start > lineStart
                    && (sourceText[start - 1] == ' ' || sourceText[start - 1] == '\t'))
             {
                 start--;
             }
 
-            if (start < end)
+            if (start > lineStart
+                && start < end)
             {
                 context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, TextSpan.FromBounds(start, end))));
             }

--- a/Reihitsu.Analyzer/Rules/Spacing/RH6011OpeningGenericBracketsMustBeSpacedCorrectlyAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Spacing/RH6011OpeningGenericBracketsMustBeSpacedCorrectlyAnalyzer.cs
@@ -66,14 +66,16 @@ public class RH6011OpeningGenericBracketsMustBeSpacedCorrectlyAnalyzer : Diagnos
                                        .Where(spanStart => spanStart >= 0))
         {
             var start = tokenStart;
+            var lineStart = sourceText.Lines.GetLineFromPosition(tokenStart).Start;
 
-            while (start > 0
+            while (start > lineStart
                    && (sourceText[start - 1] == ' ' || sourceText[start - 1] == '\t'))
             {
                 start--;
             }
 
-            if (start < tokenStart)
+            if (start > lineStart
+                && start < tokenStart)
             {
                 context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, TextSpan.FromBounds(start, tokenStart))));
             }

--- a/Reihitsu.Analyzer/Rules/Spacing/RH6011OpeningGenericBracketsMustBeSpacedCorrectlyAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Spacing/RH6011OpeningGenericBracketsMustBeSpacedCorrectlyAnalyzer.cs
@@ -1,9 +1,9 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
 
 using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Core;
 using Reihitsu.Analyzer.Enumerations;
 
 namespace Reihitsu.Analyzer.Rules.Spacing;
@@ -65,19 +65,9 @@ public class RH6011OpeningGenericBracketsMustBeSpacedCorrectlyAnalyzer : Diagnos
                                        .Select(GetLessThanTokenStart)
                                        .Where(spanStart => spanStart >= 0))
         {
-            var start = tokenStart;
-            var lineStart = sourceText.Lines.GetLineFromPosition(tokenStart).Start;
-
-            while (start > lineStart
-                   && (sourceText[start - 1] == ' ' || sourceText[start - 1] == '\t'))
+            if (SameLinePrecedingWhitespaceAnalysis.GetSpan(sourceText, tokenStart) is { } whitespaceSpan)
             {
-                start--;
-            }
-
-            if (start > lineStart
-                && start < tokenStart)
-            {
-                context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, TextSpan.FromBounds(start, tokenStart))));
+                context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, whitespaceSpan)));
             }
         }
     }

--- a/Reihitsu.Analyzer/Rules/Spacing/RH6012ClosingGenericBracketsMustBeSpacedCorrectlyAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Spacing/RH6012ClosingGenericBracketsMustBeSpacedCorrectlyAnalyzer.cs
@@ -1,9 +1,9 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
 
 using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Core;
 using Reihitsu.Analyzer.Enumerations;
 
 namespace Reihitsu.Analyzer.Rules.Spacing;
@@ -65,19 +65,9 @@ public class RH6012ClosingGenericBracketsMustBeSpacedCorrectlyAnalyzer : Diagnos
                                        .Select(GetGreaterThanTokenStart)
                                        .Where(spanStart => spanStart >= 0))
         {
-            var start = tokenStart;
-            var lineStart = sourceText.Lines.GetLineFromPosition(tokenStart).Start;
-
-            while (start > lineStart
-                   && (sourceText[start - 1] == ' ' || sourceText[start - 1] == '\t'))
+            if (SameLinePrecedingWhitespaceAnalysis.GetSpan(sourceText, tokenStart) is { } whitespaceSpan)
             {
-                start--;
-            }
-
-            if (start > lineStart
-                && start < tokenStart)
-            {
-                context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, TextSpan.FromBounds(start, tokenStart))));
+                context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, whitespaceSpan)));
             }
         }
     }

--- a/Reihitsu.Analyzer/Rules/Spacing/RH6012ClosingGenericBracketsMustBeSpacedCorrectlyAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Spacing/RH6012ClosingGenericBracketsMustBeSpacedCorrectlyAnalyzer.cs
@@ -66,14 +66,16 @@ public class RH6012ClosingGenericBracketsMustBeSpacedCorrectlyAnalyzer : Diagnos
                                        .Where(spanStart => spanStart >= 0))
         {
             var start = tokenStart;
+            var lineStart = sourceText.Lines.GetLineFromPosition(tokenStart).Start;
 
-            while (start > 0
+            while (start > lineStart
                    && (sourceText[start - 1] == ' ' || sourceText[start - 1] == '\t'))
             {
                 start--;
             }
 
-            if (start < tokenStart)
+            if (start > lineStart
+                && start < tokenStart)
             {
                 context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, TextSpan.FromBounds(start, tokenStart))));
             }

--- a/Reihitsu.Analyzer/Rules/Spacing/RH6014ClosingAttributeBracketsMustBeSpacedCorrectlyAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Spacing/RH6014ClosingAttributeBracketsMustBeSpacedCorrectlyAnalyzer.cs
@@ -1,9 +1,9 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
 
 using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Core;
 using Reihitsu.Analyzer.Enumerations;
 
 namespace Reihitsu.Analyzer.Rules.Spacing;
@@ -50,19 +50,9 @@ public class RH6014ClosingAttributeBracketsMustBeSpacedCorrectlyAnalyzer : Diagn
                                        .OfType<AttributeListSyntax>()
                                        .Select(node => node.CloseBracketToken.SpanStart))
         {
-            var start = tokenStart;
-            var lineStart = sourceText.Lines.GetLineFromPosition(tokenStart).Start;
-
-            while (start > lineStart
-                   && (sourceText[start - 1] == ' ' || sourceText[start - 1] == '\t'))
+            if (SameLinePrecedingWhitespaceAnalysis.GetSpan(sourceText, tokenStart) is { } whitespaceSpan)
             {
-                start--;
-            }
-
-            if (start > lineStart
-                && start < tokenStart)
-            {
-                context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, TextSpan.FromBounds(start, tokenStart))));
+                context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, whitespaceSpan)));
             }
         }
     }

--- a/Reihitsu.Analyzer/Rules/Spacing/RH6014ClosingAttributeBracketsMustBeSpacedCorrectlyAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Spacing/RH6014ClosingAttributeBracketsMustBeSpacedCorrectlyAnalyzer.cs
@@ -51,14 +51,16 @@ public class RH6014ClosingAttributeBracketsMustBeSpacedCorrectlyAnalyzer : Diagn
                                        .Select(node => node.CloseBracketToken.SpanStart))
         {
             var start = tokenStart;
+            var lineStart = sourceText.Lines.GetLineFromPosition(tokenStart).Start;
 
-            while (start > 0
+            while (start > lineStart
                    && (sourceText[start - 1] == ' ' || sourceText[start - 1] == '\t'))
             {
                 start--;
             }
 
-            if (start < tokenStart)
+            if (start > lineStart
+                && start < tokenStart)
             {
                 context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, TextSpan.FromBounds(start, tokenStart))));
             }

--- a/Reihitsu.Analyzer/Rules/Spacing/RH6015NullableTypeSymbolsMustNotBePrecededBySpaceAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Spacing/RH6015NullableTypeSymbolsMustNotBePrecededBySpaceAnalyzer.cs
@@ -51,14 +51,16 @@ public class RH6015NullableTypeSymbolsMustNotBePrecededBySpaceAnalyzer : Diagnos
                                        .Select(node => node.QuestionToken.SpanStart))
         {
             var start = tokenStart;
+            var lineStart = sourceText.Lines.GetLineFromPosition(tokenStart).Start;
 
-            while (start > 0
+            while (start > lineStart
                    && (sourceText[start - 1] == ' ' || sourceText[start - 1] == '\t'))
             {
                 start--;
             }
 
-            if (start < tokenStart)
+            if (start > lineStart
+                && start < tokenStart)
             {
                 context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, TextSpan.FromBounds(start, tokenStart))));
             }

--- a/Reihitsu.Analyzer/Rules/Spacing/RH6015NullableTypeSymbolsMustNotBePrecededBySpaceAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Spacing/RH6015NullableTypeSymbolsMustNotBePrecededBySpaceAnalyzer.cs
@@ -1,9 +1,9 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
 
 using Reihitsu.Analyzer.Base;
+using Reihitsu.Analyzer.Core;
 using Reihitsu.Analyzer.Enumerations;
 
 namespace Reihitsu.Analyzer.Rules.Spacing;
@@ -50,19 +50,9 @@ public class RH6015NullableTypeSymbolsMustNotBePrecededBySpaceAnalyzer : Diagnos
                                        .OfType<NullableTypeSyntax>()
                                        .Select(node => node.QuestionToken.SpanStart))
         {
-            var start = tokenStart;
-            var lineStart = sourceText.Lines.GetLineFromPosition(tokenStart).Start;
-
-            while (start > lineStart
-                   && (sourceText[start - 1] == ' ' || sourceText[start - 1] == '\t'))
+            if (SameLinePrecedingWhitespaceAnalysis.GetSpan(sourceText, tokenStart) is { } whitespaceSpan)
             {
-                start--;
-            }
-
-            if (start > lineStart
-                && start < tokenStart)
-            {
-                context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, TextSpan.FromBounds(start, tokenStart))));
+                context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, whitespaceSpan)));
             }
         }
     }

--- a/Reihitsu.Analyzer/Rules/Spacing/RH6024BinaryOperatorsMustBeSpacedCorrectlyAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Spacing/RH6024BinaryOperatorsMustBeSpacedCorrectlyAnalyzer.cs
@@ -47,10 +47,8 @@ public class RH6024BinaryOperatorsMustBeSpacedCorrectlyAnalyzer : DiagnosticAnal
         var root = context.Tree.GetRoot(context.CancellationToken);
         var sourceText = context.Tree.GetText(context.CancellationToken);
 
-        // Keyword operators such as "is" and "as" are covered by RH6005
         foreach (var operatorToken in root.DescendantNodes()
                                           .OfType<BinaryExpressionSyntax>()
-                                          .Where(binaryExpression => binaryExpression.OperatorToken.IsKeyword() == false)
                                           .Select(binaryExpression => binaryExpression.OperatorToken))
         {
             if (FormattingTextAnalysisUtilities.HasOperatorSpacingViolation(sourceText, operatorToken))

--- a/documentation/rules/RH2003.md
+++ b/documentation/rules/RH2003.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-`NotImplementedException` should not be used. This rule flags any usage of `throw new NotImplementedException()` in the codebase.
+`NotImplementedException` should not be used. This rule flags explicit and target-typed creation of `NotImplementedException`.
 
 ## Why is this a problem?
 

--- a/documentation/rules/RH2004.md
+++ b/documentation/rules/RH2004.md
@@ -13,6 +13,8 @@ Every type and member that supports accessibility should declare it explicitly. 
 
 Partial methods without an explicit accessibility modifier are exempt because that form is valid C# syntax and intentionally relies on the language default.
 
+Partial type declarations are handled exclusively by [RH7104](RH7104.md) and are therefore exempt from this rule.
+
 File-local types (declared with the `file` modifier) are exempt as well: `file` already declares the type's visibility, and file-local types cannot also carry an accessibility modifier such as `internal` (CS9052).
 
 ## Why is this a problem?

--- a/documentation/rules/RH2005.md
+++ b/documentation/rules/RH2005.md
@@ -9,11 +9,11 @@
 
 ## Description
 
-Fields in classes and records should be private. Exposed state should be represented through properties instead of directly accessible fields.
+Public fields in classes and record classes should be private. Public fields in structs and record structs, and non-public fields, are outside this rule's scope.
 
 ## Why is this a problem?
 
-Non-private fields weaken encapsulation and make it harder to evolve an API without breaking consumers.
+Public fields on reference types weaken encapsulation and make it harder to evolve an API without breaking consumers.
 
 ## How to fix it
 

--- a/documentation/rules/RH2006.md
+++ b/documentation/rules/RH2006.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-Calls to `Debug.Assert` must include message text in addition to the asserted condition.
+Calls to `Debug.Assert` must include nonempty message text in addition to the asserted condition. Constant `null`, empty, and whitespace-only messages are treated as missing text.
 
 ## Why is this a problem?
 

--- a/documentation/rules/RH4102.md
+++ b/documentation/rules/RH4102.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-Checks that event names follow PascalCase naming conventions. Each word in the name should start with an uppercase letter, with no underscores or other separators.
+Checks that event names follow PascalCase naming conventions, including events with explicit `add` and `remove` accessors. Each word in the name should start with an uppercase letter, with no underscores or other separators.
 
 ## Why is this a problem?
 

--- a/documentation/rules/RH4106.md
+++ b/documentation/rules/RH4106.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-Checks that private field names follow _camelCase naming conventions with an underscore prefix. The first word after the underscore should start with a lowercase letter, and each subsequent word should start with an uppercase letter.
+Checks that private field names follow _camelCase naming conventions with an underscore prefix. This includes fields whose `private` accessibility is implicit because no accessibility modifier is declared. The first word after the underscore should start with a lowercase letter, and each subsequent word should start with an uppercase letter.
 
 ## Why is this a problem?
 

--- a/documentation/rules/RH4111.md
+++ b/documentation/rules/RH4111.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-Checks that private property names follow PascalCase naming conventions. Each word in the name should start with an uppercase letter, with no underscores or other separators.
+Checks that private property names follow PascalCase naming conventions. This includes class, record, and struct properties whose `private` accessibility is implicit because no accessibility modifier is declared. Each word in the name should start with an uppercase letter, with no underscores or other separators.
 
 ## Why is this a problem?
 

--- a/documentation/rules/RH4114.md
+++ b/documentation/rules/RH4114.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-Checks that public property names follow PascalCase naming conventions. Each word in the name should start with an uppercase letter, with no underscores or other separators.
+Checks that public property names follow PascalCase naming conventions. This includes interface properties whose `public` accessibility is implicit because no accessibility modifier is declared. Each word in the name should start with an uppercase letter, with no underscores or other separators.
 
 ## Why is this a problem?
 

--- a/documentation/rules/RH6003.md
+++ b/documentation/rules/RH6003.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-A semicolon must not be preceded by a space.
+A semicolon must not be preceded by horizontal whitespace on the same line. Indentation before a semicolon on a continuation line is left unchanged.
 
 ## Why is this a problem?
 
@@ -17,7 +17,7 @@ A space before a semicolon is non-standard and creates visual noise that draws a
 
 ## How to fix it
 
-Remove any space immediately before the semicolon. The code fix applies this change automatically.
+Remove any same-line space or tab immediately before the semicolon. The code fix applies this change automatically.
 
 ## Examples
 

--- a/documentation/rules/RH6011.md
+++ b/documentation/rules/RH6011.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-No space may appear immediately before the opening angle bracket `<` of a generic type argument list.
+No same-line horizontal whitespace may appear immediately before the opening angle bracket `<` of a generic type argument list. Indentation before a bracket that begins a continuation line is left unchanged.
 
 ## Why is this a problem?
 
@@ -17,7 +17,7 @@ A space before the opening angle bracket separates the type name from its type a
 
 ## How to fix it
 
-Remove the space immediately before the opening generic angle bracket. The code fix applies this change automatically.
+Remove the same-line space or tab immediately before the opening generic angle bracket. The code fix applies this change automatically.
 
 ## Examples
 

--- a/documentation/rules/RH6012.md
+++ b/documentation/rules/RH6012.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-No space may appear immediately before the closing angle bracket `>` of a generic type argument list.
+No same-line horizontal whitespace may appear immediately before the closing angle bracket `>` of a generic type argument list. Indentation before a bracket that begins a continuation line is left unchanged.
 
 ## Why is this a problem?
 
@@ -17,7 +17,7 @@ A trailing space inside generic angle brackets is inconsistent with the rest of 
 
 ## How to fix it
 
-Remove the space immediately before the closing generic angle bracket. The code fix applies this change automatically.
+Remove the same-line space or tab immediately before the closing generic angle bracket. The code fix applies this change automatically.
 
 ## Examples
 

--- a/documentation/rules/RH6014.md
+++ b/documentation/rules/RH6014.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-No space may appear immediately before the closing bracket `]` of an attribute.
+No same-line horizontal whitespace may appear immediately before the closing bracket `]` of an attribute. Indentation before a bracket that begins a continuation line is left unchanged.
 
 ## Why is this a problem?
 
@@ -17,7 +17,7 @@ A trailing space inside an attribute's brackets is non-standard and makes the at
 
 ## How to fix it
 
-Remove the space immediately before the closing attribute bracket. The code fix applies this change automatically.
+Remove the same-line space or tab immediately before the closing attribute bracket. The code fix applies this change automatically.
 
 ## Examples
 

--- a/documentation/rules/RH6015.md
+++ b/documentation/rules/RH6015.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-The nullable type operator `?` must not be preceded by a space.
+The nullable type operator `?` must not be preceded by same-line horizontal whitespace. Indentation before a nullable type symbol that begins a continuation line is left unchanged.
 
 ## Why is this a problem?
 
@@ -17,7 +17,7 @@ A space before `?` visually separates the operator from the base type, making nu
 
 ## How to fix it
 
-Remove the space immediately before the `?` operator. The code fix applies this change automatically.
+Remove the same-line space or tab immediately before the `?` operator. The code fix applies this change automatically.
 
 ## Examples
 

--- a/documentation/rules/RH6024.md
+++ b/documentation/rules/RH6024.md
@@ -9,9 +9,9 @@
 
 ## Description
 
-A binary operator must be separated from the token before it and the token after it by exactly one space. This covers the arithmetic (`+`, `-`, `*`, `/`, `%`), comparison (`==`, `!=`, `<`, `>`, `<=`, `>=`), logical (`&&`, `||`), bitwise (`&`, `|`, `^`), shift (`<<`, `>>`, `>>>`) and null-coalescing (`??`) operators.
+A binary operator must be separated from the token before it and the token after it by exactly one space. This covers the arithmetic (`+`, `-`, `*`, `/`, `%`), comparison (`==`, `!=`, `<`, `>`, `<=`, `>=`), logical (`&&`, `||`), bitwise (`&`, `|`, `^`), shift (`<<`, `>>`, `>>>`), null-coalescing (`??`), and keyword (`is`, `as`) operators.
 
-The keyword operators `is` and `as` are governed by RH6005, and operators that wrap to a new line are left untouched.
+Operators that wrap to a new line are left untouched.
 
 ## Why is this a problem?
 


### PR DESCRIPTION
## Summary

Corrects analyzer coverage, diagnostic ownership, code-fix targeting, casing classification, and same-line spacing boundaries across the Design, Clarity, Naming, Organization, and Spacing rule families.

## Why

Several rules missed valid syntax shapes, overlapped another rule's responsibility, selected arguments by source position, or treated continuation indentation as removable spacing. The changes align those decisions with their effective C# semantics and preserve safe fix convergence.

## Linked issues

Closes #468

## Review notes

RH7104 is the sole owner of partial types. RH2005 reports only public fields in classes and record classes. The existing public RH4102 code-fix API is unchanged; custom events use a separate internal provider. Same-line spacing policy is centralized for RH6003, RH6011, RH6012, RH6014, and RH6015. Two preflight attempts were used; their three remaining test-coverage findings are addressed, while a third preflight is intentionally deferred pending maintainer direction.

## Follow-up work

Expression-body rule expansion remains in #628, spacing performance remains in #629, and the shared whitespace-run code-fix guard remains in #469.