### PR TITLE
Detect XML documentation newlines in RH5604

### DIFF
--- a/Reihitsu.Analyzer.CodeFixes/Rules/Layout/RH5604CodeMustNotContainMixedLineEndingsCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Layout/RH5604CodeMustNotContainMixedLineEndingsCodeFixProvider.cs
@@ -38,16 +38,31 @@ public class RH5604CodeMustNotContainMixedLineEndingsCodeFixProvider : CodeFixPr
         }
 
         var endOfLine = ReihitsuFormatterHelpers.DetectEndOfLine(root);
-        var endOfLinesToReplace = root.DescendantTrivia(descendIntoTrivia: true)
-                                      .Where(trivia => trivia.IsKind(SyntaxKind.EndOfLineTrivia) && trivia.ToString() != endOfLine)
-                                      .ToArray();
+        var documentationEndOfLinesToReplace = root.DescendantTokens(descendIntoTrivia: true)
+                                                   .Where(token => token.IsKind(SyntaxKind.XmlTextLiteralNewLineToken) && token.Text != endOfLine)
+                                                   .ToArray();
+        var normalizedRoot = documentationEndOfLinesToReplace.Length == 0
+                                 ? root
+                                 : root.ReplaceTokens(documentationEndOfLinesToReplace,
+                                                      (original, _) => original.CopyAnnotationsTo(SyntaxFactory.XmlTextNewLine(original.LeadingTrivia,
+                                                                                                                               endOfLine,
+                                                                                                                               original.ValueText,
+                                                                                                                               original.TrailingTrivia)));
+        var endOfLinesToReplace = normalizedRoot.DescendantTrivia(descendIntoTrivia: true)
+                                                .Where(trivia => trivia.IsKind(SyntaxKind.EndOfLineTrivia) && trivia.ToString() != endOfLine)
+                                                .ToArray();
 
-        if (endOfLinesToReplace.Length == 0)
+        if (documentationEndOfLinesToReplace.Length == 0 && endOfLinesToReplace.Length == 0)
         {
             return document;
         }
 
-        return document.WithSyntaxRoot(root.ReplaceTrivia(endOfLinesToReplace, (_, _) => SyntaxFactory.EndOfLine(endOfLine)));
+        if (endOfLinesToReplace.Length == 0)
+        {
+            return document.WithSyntaxRoot(normalizedRoot);
+        }
+
+        return document.WithSyntaxRoot(normalizedRoot.ReplaceTrivia(endOfLinesToReplace, (_, _) => SyntaxFactory.EndOfLine(endOfLine)));
     }
 
     #endregion // Methods

--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5604CodeMustNotContainMixedLineEndingsFormatterTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5604CodeMustNotContainMixedLineEndingsFormatterTests.cs
@@ -92,7 +92,7 @@ public class RH5604CodeMustNotContainMixedLineEndingsFormatterTests : FormatterT
     }
 
     /// <summary>
-    /// Verifies syntax-tree and node formatting normalize mixed input and all formatter entry points remain stable
+    /// Verifies syntax-tree and detached-node formatting normalize mixed input, and document-scoped formatting remains stable
     /// </summary>
     /// <param name="input">Mixed-line-ending input</param>
     /// <param name="expected">Expected normalized output</param>

--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5604CodeMustNotContainMixedLineEndingsFormatterTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5604CodeMustNotContainMixedLineEndingsFormatterTests.cs
@@ -1,10 +1,16 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Reihitsu.Analyzer.Rules.Layout;
 using Reihitsu.Analyzer.Test.Base;
+using Reihitsu.Formatter;
 
 namespace Reihitsu.Analyzer.Test.Formatter.Formatting;
 
@@ -33,6 +39,116 @@ public class RH5604CodeMustNotContainMixedLineEndingsFormatterTests : FormatterT
         await VerifyFormatterFix(input,
                                  fixedData,
                                  ExpectedDiagnostic(RH5604CodeMustNotContainMixedLineEndingsAnalyzer.DiagnosticId, 2, 1, 3, 1, AnalyzerResources.RH5604MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies XML CRLF normalizes to predominant LF and formatter entry points remain stable
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFormatterNormalizesXmlCrLfToPredominantLfAndIsIdempotent()
+    {
+        const string input = "/// <summary>\r\n"
+                             + "/// Documentation.\n"
+                             + "/// </summary>\n"
+                             + "internal class Example\n"
+                             + "{\n"
+                             + "    internal int Value => 42;\n"
+                             + "}";
+        const string expected = "/// <summary>\n"
+                                + "/// Documentation.\n"
+                                + "/// </summary>\n"
+                                + "internal class Example\n"
+                                + "{\n"
+                                + "    internal int Value => 42;\n"
+                                + "}";
+
+        await VerifyFormatterEntryPointsAndIdempotency(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies XML LF normalizes to predominant CRLF and formatter entry points remain stable
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFormatterNormalizesXmlLfToPredominantCrLfAndIsIdempotent()
+    {
+        const string input = "/// <summary>\n"
+                             + "/// Documentation.\r\n"
+                             + "/// </summary>\r\n"
+                             + "internal class Example\r\n"
+                             + "{\r\n"
+                             + "    internal int Value => 42;\r\n"
+                             + "}";
+        const string expected = "/// <summary>\r\n"
+                                + "/// Documentation.\r\n"
+                                + "/// </summary>\r\n"
+                                + "internal class Example\r\n"
+                                + "{\r\n"
+                                + "    internal int Value => 42;\r\n"
+                                + "}";
+
+        await VerifyFormatterEntryPointsAndIdempotency(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies syntax-tree and node formatting normalize mixed input and all formatter entry points remain stable
+    /// </summary>
+    /// <param name="input">Mixed-line-ending input</param>
+    /// <param name="expected">Expected normalized output</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    private static async Task VerifyFormatterEntryPointsAndIdempotency(string input, string expected)
+    {
+        // Suppression verification injects directives whose line endings change this document-wide policy fixture.
+        await Verify(input,
+                     static config => config.TestBehaviors |= TestBehaviors.SkipSuppressionCheck,
+                     ExpectedDiagnostic(RH5604CodeMustNotContainMixedLineEndingsAnalyzer.DiagnosticId,
+                                        1,
+                                        1,
+                                        2,
+                                        1,
+                                        AnalyzerResources.RH5604MessageFormat));
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(input, cancellationToken: CancellationToken.None);
+        var firstTree = ReihitsuFormatter.FormatSyntaxTree(syntaxTree, CancellationToken.None);
+        var firstTreeText = firstTree.GetRoot(CancellationToken.None).ToFullString();
+
+        Assert.AreEqual(expected, firstTreeText);
+        await Verify(firstTreeText);
+
+        var secondTree = ReihitsuFormatter.FormatSyntaxTree(firstTree, CancellationToken.None);
+
+        Assert.AreEqual(firstTreeText, secondTree.GetRoot(CancellationToken.None).ToFullString());
+
+        var root = CSharpSyntaxTree.ParseText(input, cancellationToken: CancellationToken.None).GetRoot(CancellationToken.None);
+        var firstNodeText = ReihitsuFormatter.FormatNode(root, cancellationToken: CancellationToken.None).ToFullString();
+        var secondNode = CSharpSyntaxTree.ParseText(firstNodeText, cancellationToken: CancellationToken.None).GetRoot(CancellationToken.None);
+
+        Assert.AreEqual(expected, firstNodeText);
+        Assert.AreEqual(firstNodeText, ReihitsuFormatter.FormatNode(secondNode, cancellationToken: CancellationToken.None).ToFullString());
+
+        using (var workspace = new AdhocWorkspace())
+        {
+            var project = workspace.AddProject("TestProject", LanguageNames.CSharp)
+                                   .WithParseOptions(CSharpParseOptions.Default.WithDocumentationMode(DocumentationMode.Parse));
+
+            // Document-scoped formatting must remain stable after the mixed input has converged.
+            var document = project.AddDocument("Test.cs", SourceText.From(expected));
+            var documentRoot = await document.GetSyntaxRootAsync(CancellationToken.None);
+
+            Assert.IsNotNull(documentRoot);
+
+            var firstDocument = await ReihitsuFormatter.FormatNodeInDocumentAsync(document, documentRoot, CancellationToken.None);
+            var firstDocumentText = (await firstDocument.GetTextAsync(CancellationToken.None)).ToString();
+            var firstDocumentRoot = await firstDocument.GetSyntaxRootAsync(CancellationToken.None);
+
+            Assert.AreEqual(expected, firstDocumentText);
+            Assert.IsNotNull(firstDocumentRoot);
+
+            var secondDocument = await ReihitsuFormatter.FormatNodeInDocumentAsync(firstDocument, firstDocumentRoot, CancellationToken.None);
+
+            Assert.AreEqual(firstDocumentText, (await secondDocument.GetTextAsync(CancellationToken.None)).ToString());
+        }
     }
 
     #endregion // Tests

--- a/Reihitsu.Analyzer.Test/Formatting/RH5604CodeMustNotContainMixedLineEndingsAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH5604CodeMustNotContainMixedLineEndingsAnalyzerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 
+using Microsoft.CodeAnalysis.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Reihitsu.Analyzer.CodeFixes.Rules.Layout;
@@ -36,7 +37,7 @@ public class RH5604CodeMustNotContainMixedLineEndingsAnalyzerTests : AnalyzerTes
     [TestMethod]
     public async Task VerifyMixedLineEndingsInsideXmlDocumentationAreDetectedAndFixed()
     {
-        const string testData = "/// <summary>{|#0:\r\n|}"
+        const string testData = "{|#0:/// <summary>\r\n|}"
                                 + "/// Documentation.\n"
                                 + "/// </summary>\n"
                                 + "internal class TestClass\n"
@@ -49,9 +50,121 @@ public class RH5604CodeMustNotContainMixedLineEndingsAnalyzerTests : AnalyzerTes
                                  + "{\n"
                                  + "}";
 
+        // Suppression verification injects directives whose line endings change this document-wide policy fixture.
+        await Verify(testData,
+                     fixedData,
+                     static config => config.TestBehaviors |= TestBehaviors.SkipSuppressionCheck,
+                     Diagnostic(RH5604CodeMustNotContainMixedLineEndingsAnalyzer.DiagnosticId).WithSpan(1, 1, 2, 1).WithMessage(AnalyzerResources.RH5604MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that an LF XML documentation line ending is detected and fixed when CRLF is predominant
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyLfInsideXmlDocumentationIsDetectedWhenCrLfIsPredominant()
+    {
+        const string testData = "{|#0:/// <summary>\n|}"
+                                + "/// Documentation.\r\n"
+                                + "/// </summary>\r\n"
+                                + "internal class TestClass\r\n"
+                                + "{\r\n"
+                                + "}";
+        const string fixedData = "/// <summary>\r\n"
+                                 + "/// Documentation.\r\n"
+                                 + "/// </summary>\r\n"
+                                 + "internal class TestClass\r\n"
+                                 + "{\r\n"
+                                 + "}";
+
         await Verify(testData,
                      fixedData,
                      Diagnostic(RH5604CodeMustNotContainMixedLineEndingsAnalyzer.DiagnosticId).WithSpan(1, 1, 2, 1).WithMessage(AnalyzerResources.RH5604MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that a lone CR XML documentation line ending is normalized to predominant LF
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyLoneCarriageReturnInsideXmlDocumentationIsNormalizedToLf()
+    {
+        const string testData = "{|#0:/// <summary>\r|}"
+                                + "/// Documentation.\n"
+                                + "/// </summary>\n"
+                                + "internal class TestClass\n"
+                                + "{\n"
+                                + "}";
+        const string fixedData = "/// <summary>\n"
+                                 + "/// Documentation.\n"
+                                 + "/// </summary>\n"
+                                 + "internal class TestClass\n"
+                                 + "{\n"
+                                 + "}";
+
+        // Suppression verification injects directives whose line endings change this document-wide policy fixture.
+        await Verify(testData,
+                     fixedData,
+                     static config => config.TestBehaviors |= TestBehaviors.SkipSuppressionCheck,
+                     Diagnostic(RH5604CodeMustNotContainMixedLineEndingsAnalyzer.DiagnosticId).WithSpan(1, 1, 2, 1).WithMessage(AnalyzerResources.RH5604MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that an XML and ordinary line-ending tie uses CRLF
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCrLfWinsTieIncludingXmlDocumentationLineEnding()
+    {
+        const string testData = "{|#0:/// Documentation\n|}"
+                                + "internal class TestClass { }\r\n";
+        const string fixedData = "/// Documentation\r\n"
+                                 + "internal class TestClass { }\r\n";
+
+        await Verify(testData,
+                     fixedData,
+                     Diagnostic(RH5604CodeMustNotContainMixedLineEndingsAnalyzer.DiagnosticId).WithSpan(1, 1, 2, 1).WithMessage(AnalyzerResources.RH5604MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that uniform XML documentation line endings do not produce diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticsWhenOnlyXmlDocumentationLineEndingsAreUniform()
+    {
+        const string testData = "/// <summary>\n"
+                                + "/// Documentation.\n"
+                                + "/// </summary>\n"
+                                + "internal class TestClass { }";
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that XML and ordinary minority line endings are fixed in one Fix All iteration
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyXmlAndOrdinaryMinoritiesAreFixedInOneFixAllIteration()
+    {
+        const string testData = "{|#0:/// <summary>\r\n|}"
+                                + "/// Documentation.\n"
+                                + "/// </summary>\n"
+                                + "{|#1:internal class TestClass\r\n|}"
+                                + "{\n"
+                                + "}";
+        const string fixedData = "/// <summary>\n"
+                                 + "/// Documentation.\n"
+                                 + "/// </summary>\n"
+                                 + "internal class TestClass\n"
+                                 + "{\n"
+                                 + "}";
+
+        await Verify(testData,
+                     fixedData,
+                     static config => config.NumberOfFixAllIterations = 1,
+                     Diagnostics(RH5604CodeMustNotContainMixedLineEndingsAnalyzer.DiagnosticId, AnalyzerResources.RH5604MessageFormat, 2));
     }
 
     /// <summary>
@@ -147,6 +260,58 @@ public class RH5604CodeMustNotContainMixedLineEndingsAnalyzerTests : AnalyzerTes
                                 + "{\r\n"
                                 + "    string Value = @\"line1\nline2\";\r\n"
                                 + "}";
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that line endings embedded in raw strings do not produce diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyLineEndingsInsideRawStringsDoNotProduceDiagnostics()
+    {
+        const string testData = "internal class TestClass\r\n"
+                                + "{\r\n"
+                                + "    private const string Value = \"\"\"\n"
+                                + "line1\n"
+                                + "line2\n"
+                                + "\"\"\";\r\n"
+                                + "}";
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that line endings embedded in multi-line comments do not produce diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyLineEndingsInsideMultiLineCommentsDoNotProduceDiagnostics()
+    {
+        const string testData = "internal class TestClass\r\n"
+                                + "{\r\n"
+                                + "    /* line1\n"
+                                + "    line2 */\r\n"
+                                + "}";
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that documentation-shaped text and line endings in disabled text do not produce diagnostics
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyLineEndingsInsideDisabledTextDoNotProduceDiagnostics()
+    {
+        const string testData = "#if false\r\n"
+                                + "/// <summary>\n"
+                                + "/// Disabled documentation.\n"
+                                + "/// </summary>\n"
+                                + "internal class DisabledClass { }\n"
+                                + "#endif\r\n"
+                                + "internal class TestClass { }";
 
         await Verify(testData);
     }

--- a/Reihitsu.Analyzer.Test/Formatting/RH5604CodeMustNotContainMixedLineEndingsAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH5604CodeMustNotContainMixedLineEndingsAnalyzerTests.cs
@@ -30,6 +30,31 @@ public class RH5604CodeMustNotContainMixedLineEndingsAnalyzerTests : AnalyzerTes
     }
 
     /// <summary>
+    /// Verifies that a mixed XML documentation line ending is detected and fixed
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyMixedLineEndingsInsideXmlDocumentationAreDetectedAndFixed()
+    {
+        const string testData = "/// <summary>{|#0:\r\n|}"
+                                + "/// Documentation.\n"
+                                + "/// </summary>\n"
+                                + "internal class TestClass\n"
+                                + "{\n"
+                                + "}";
+        const string fixedData = "/// <summary>\n"
+                                 + "/// Documentation.\n"
+                                 + "/// </summary>\n"
+                                 + "internal class TestClass\n"
+                                 + "{\n"
+                                 + "}";
+
+        await Verify(testData,
+                     fixedData,
+                     Diagnostic(RH5604CodeMustNotContainMixedLineEndingsAnalyzer.DiagnosticId).WithSpan(1, 1, 2, 1).WithMessage(AnalyzerResources.RH5604MessageFormat));
+    }
+
+    /// <summary>
     /// Verifies that LF-only files do not produce diagnostics
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/Reihitsu.Analyzer/Rules/Layout/RH5604CodeMustNotContainMixedLineEndingsAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Layout/RH5604CodeMustNotContainMixedLineEndingsAnalyzer.cs
@@ -49,6 +49,7 @@ public class RH5604CodeMustNotContainMixedLineEndingsAnalyzer : DiagnosticAnalyz
         var root = context.Tree.GetRoot(context.CancellationToken);
         var sourceText = context.Tree.GetText(context.CancellationToken);
         var endOfLineTrivia = new List<SyntaxTrivia>();
+        var documentationEndOfLineTokens = new List<SyntaxToken>();
         var counts = new Dictionary<string, int>(StringComparer.Ordinal);
 
         foreach (var trivia in root.DescendantTrivia(descendIntoTrivia: true).Where(trivia => trivia.IsKind(SyntaxKind.EndOfLineTrivia)))
@@ -57,6 +58,14 @@ public class RH5604CodeMustNotContainMixedLineEndingsAnalyzer : DiagnosticAnalyz
 
             endOfLineTrivia.Add(trivia);
             counts[lineEnding] = counts.TryGetValue(lineEnding, out var count)
+                                     ? count + 1
+                                     : 1;
+        }
+
+        foreach (var token in root.DescendantTokens(descendIntoTrivia: true).Where(token => token.IsKind(SyntaxKind.XmlTextLiteralNewLineToken)))
+        {
+            documentationEndOfLineTokens.Add(token);
+            counts[token.Text] = counts.TryGetValue(token.Text, out var count)
                                      ? count + 1
                                      : 1;
         }
@@ -71,6 +80,13 @@ public class RH5604CodeMustNotContainMixedLineEndingsAnalyzer : DiagnosticAnalyz
         foreach (var trivia in endOfLineTrivia.Where(trivia => trivia.ToString() != predominantLineEnding))
         {
             var line = sourceText.Lines.GetLineFromPosition(trivia.SpanStart);
+
+            context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, TextSpan.FromBounds(line.Start, line.EndIncludingLineBreak))));
+        }
+
+        foreach (var token in documentationEndOfLineTokens.Where(token => token.Text != predominantLineEnding))
+        {
+            var line = sourceText.Lines.GetLineFromPosition(token.SpanStart);
 
             context.ReportDiagnostic(CreateDiagnostic(Location.Create(context.Tree, TextSpan.FromBounds(line.Start, line.EndIncludingLineBreak))));
         }


### PR DESCRIPTION
## Summary

Teach RH5604 and its code fix to include active XML-documentation newline tokens in the existing predominant line-ending policy. Add convergence, Fix All, boundary, and formatter-parity coverage for LF, CRLF, and lone-CR variants.

## Why

The formatter already normalizes XML-documentation newlines, while RH5604 previously ignored them, allowing analyzer-clean files to change during formatting.

## Linked issues

Closes #602

## Review notes

The change preserves the existing Core tie policy and formatter implementation; diagnostic metadata and public APIs remain unchanged.

## Follow-up work

None.