### PR TITLE
Make analyzer code fixes safe and convergent

### DIFF
--- a/Reihitsu.Analyzer.CodeFixes/Base/CasingCodeFixProviderBase{T}.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Base/CasingCodeFixProviderBase{T}.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -8,6 +10,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Rename;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Reihitsu.Analyzer.CodeFixes.Base;
 
@@ -162,55 +165,518 @@ public abstract class CasingCodeFixProviderBase<T> : CodeFixProvider
     }
 
     /// <summary>
-    /// Determines whether Roslyn reports a conflict for the proposed comprehensive rename
+    /// Applies every safe aggregate rename while refusing candidates that share a conflicting normalized target
     /// </summary>
-    /// <param name="solution">Solution containing the declaration</param>
-    /// <param name="declaredSymbol">Declared symbol to rename</param>
+    /// <param name="context">Fix All context</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The solution containing every safe aggregate rename</returns>
+    private async Task<Solution> ApplyFixAllAsync(FixAllContext context, CancellationToken cancellationToken)
+    {
+        var solution = context.Solution;
+        var diagnostics = await GetFixAllDiagnosticsAsync(context).ConfigureAwait(false);
+        var candidates = await GetFixAllCandidatesAsync(solution, diagnostics, cancellationToken).ConfigureAwait(false);
+
+        if (candidates.IsEmpty)
+        {
+            return solution;
+        }
+
+        solution = await AnnotateFixAllCandidatesAsync(solution, candidates, cancellationToken).ConfigureAwait(false);
+
+        var duplicateTargetCandidates = await GetDuplicateTargetCandidatesAsync(solution, candidates, cancellationToken).ConfigureAwait(false);
+
+        foreach (var candidate in candidates)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (duplicateTargetCandidates.Any(duplicate => duplicate.Annotation == candidate.Annotation))
+            {
+                continue;
+            }
+
+            var resolvedCandidate = await ResolveFixAllCandidateAsync(solution, candidate, cancellationToken).ConfigureAwait(false);
+
+            if (resolvedCandidate == null
+                || CanRegisterCodeFix(resolvedCandidate.Value.Node) == false
+                || TryGetFixedIdentifier(resolvedCandidate.Value.Node, out var identifier) == false
+                || string.Equals(identifier, candidate.Identifier, StringComparison.Ordinal) == false)
+            {
+                continue;
+            }
+
+            var renamedSolution = await RenameWithoutConflictAsync(solution,
+                                                                   candidate.DocumentId,
+                                                                   candidate.Annotation,
+                                                                   identifier,
+                                                                   cancellationToken).ConfigureAwait(false);
+
+            if (renamedSolution != null)
+            {
+                solution = renamedSolution;
+            }
+        }
+
+        return solution;
+    }
+
+    /// <summary>
+    /// Gets the diagnostics covered by the requested Document, Project, or Solution Fix All scope
+    /// </summary>
+    /// <param name="context">Fix All context</param>
+    /// <returns>Diagnostics in deterministic project and document order</returns>
+    private async Task<ImmutableArray<Diagnostic>> GetFixAllDiagnosticsAsync(FixAllContext context)
+    {
+        switch (context.Scope)
+        {
+            case FixAllScope.Document when context.Document != null:
+                {
+                    return await context.GetDocumentDiagnosticsAsync(context.Document).ConfigureAwait(false);
+                }
+
+            case FixAllScope.Project when context.Project != null:
+                {
+                    return await context.GetAllDiagnosticsAsync(context.Project).ConfigureAwait(false);
+                }
+
+            case FixAllScope.Solution:
+                {
+                    var diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
+
+                    foreach (var project in context.Solution.Projects)
+                    {
+                        diagnostics.AddRange(await context.GetAllDiagnosticsAsync(project).ConfigureAwait(false));
+                    }
+
+                    return diagnostics.ToImmutable();
+                }
+
+            default:
+                {
+                    return [];
+                }
+        }
+    }
+
+    /// <summary>
+    /// Resolves aggregate diagnostics to supported declarations and their proposed identifiers
+    /// </summary>
+    /// <param name="solution">Solution containing the diagnostics</param>
+    /// <param name="diagnostics">Diagnostics to resolve</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Supported aggregate rename candidates in deterministic order</returns>
+    private async Task<ImmutableArray<FixAllCandidate>> GetFixAllCandidatesAsync(Solution solution,
+                                                                                 ImmutableArray<Diagnostic> diagnostics,
+                                                                                 CancellationToken cancellationToken)
+    {
+        var candidates = ImmutableArray.CreateBuilder<FixAllCandidate>();
+        var orderedDiagnostics = diagnostics.Where(static diagnostic => diagnostic.Location.IsInSource)
+                                            .OrderBy(diagnostic => GetDocumentSortKey(solution, diagnostic.Location.SourceTree), StringComparer.Ordinal)
+                                            .ThenBy(static diagnostic => diagnostic.Location.SourceSpan.Start)
+                                            .ThenBy(static diagnostic => diagnostic.Location.SourceSpan.Length);
+
+        foreach (var diagnostic in orderedDiagnostics)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var sourceTree = diagnostic.Location.SourceTree;
+            var document = sourceTree == null
+                               ? null
+                               : solution.GetDocument(sourceTree);
+            var root = document == null
+                           ? null
+                           : await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var model = document == null
+                            ? null
+                            : await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+
+            if (document == null
+                || root == null
+                || model == null
+                || root.FindNode(diagnostic.Location.SourceSpan) is not T node
+                || CanRegisterCodeFix(node) == false
+                || TryGetFixedIdentifier(node, out var identifier) == false)
+            {
+                continue;
+            }
+
+            var declaredSymbol = GetDeclaredSymbol(model, node, cancellationToken);
+
+            if (declaredSymbol != null)
+            {
+                candidates.Add(new FixAllCandidate(document.Id,
+                                                   diagnostic.Location.SourceSpan,
+                                                   new SyntaxAnnotation(nameof(FixAllCandidate), candidates.Count.ToString(CultureInfo.InvariantCulture)),
+                                                   identifier,
+                                                   declaredSymbol.ContainingSymbol));
+            }
+        }
+
+        return candidates.ToImmutable();
+    }
+
+    /// <summary>
+    /// Gets a stable project, path, and document key for diagnostic ordering
+    /// </summary>
+    /// <param name="solution">Solution containing the diagnostic</param>
+    /// <param name="sourceTree">Diagnostic source tree</param>
+    /// <returns>Stable diagnostic document key</returns>
+    private string GetDocumentSortKey(Solution solution, SyntaxTree sourceTree)
+    {
+        var document = sourceTree == null
+                           ? null
+                           : solution.GetDocument(sourceTree);
+
+        return document == null
+                   ? string.Empty
+                   : $"{document.Project.Name}\0{document.FilePath ?? document.Name}\0{document.Name}";
+    }
+
+    /// <summary>
+    /// Adds tracking annotations so every declaration can be re-resolved after earlier solution-wide renames
+    /// </summary>
+    /// <param name="solution">Solution containing the candidates</param>
+    /// <param name="candidates">Candidates to annotate</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The annotated solution</returns>
+    private async Task<Solution> AnnotateFixAllCandidatesAsync(Solution solution,
+                                                               ImmutableArray<FixAllCandidate> candidates,
+                                                               CancellationToken cancellationToken)
+    {
+        foreach (var candidate in candidates)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var document = solution.GetDocument(candidate.DocumentId);
+            var root = document == null
+                           ? null
+                           : await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+            if (document == null
+                || root == null
+                || root.FindNode(candidate.OriginalSpan) is not T node)
+            {
+                continue;
+            }
+
+            solution = document.WithSyntaxRoot(root.ReplaceNode(node, node.WithAdditionalAnnotations(candidate.Annotation))).Project.Solution;
+        }
+
+        return solution;
+    }
+
+    /// <summary>
+    /// Finds candidates whose shared normalized target cannot coexist in the same declaration or binding domain
+    /// </summary>
+    /// <param name="solution">Annotated solution</param>
+    /// <param name="candidates">Aggregate rename candidates</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Candidates belonging to conflicting duplicate-target groups</returns>
+    private async Task<ImmutableArray<FixAllCandidate>> GetDuplicateTargetCandidatesAsync(Solution solution,
+                                                                                          ImmutableArray<FixAllCandidate> candidates,
+                                                                                          CancellationToken cancellationToken)
+    {
+        var duplicateTargetCandidates = ImmutableArray.CreateBuilder<FixAllCandidate>();
+
+        for (var firstIndex = 0; firstIndex < candidates.Length; firstIndex++)
+        {
+            for (var secondIndex = firstIndex + 1; secondIndex < candidates.Length; secondIndex++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var first = candidates[firstIndex];
+                var second = candidates[secondIndex];
+
+                if (string.Equals(first.Identifier, second.Identifier, StringComparison.Ordinal) == false
+                    || SymbolEqualityComparer.Default.Equals(first.ContainingSymbol, second.ContainingSymbol) == false)
+                {
+                    continue;
+                }
+
+                if (await CandidatesConflictAsync(solution, first, second, cancellationToken).ConfigureAwait(false) == false)
+                {
+                    continue;
+                }
+
+                if (duplicateTargetCandidates.Any(candidate => candidate.Annotation == first.Annotation) == false)
+                {
+                    duplicateTargetCandidates.Add(first);
+                }
+
+                if (duplicateTargetCandidates.Any(candidate => candidate.Annotation == second.Annotation) == false)
+                {
+                    duplicateTargetCandidates.Add(second);
+                }
+            }
+        }
+
+        return duplicateTargetCandidates.ToImmutable();
+    }
+
+    /// <summary>
+    /// Determines whether two candidates with one normalized target conflict when composed
+    /// </summary>
+    /// <param name="solution">Annotated solution</param>
+    /// <param name="first">First candidate</param>
+    /// <param name="second">Second candidate</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns><see langword="true"/> when applying both candidates would create a rename conflict; otherwise, <see langword="false"/></returns>
+    private async Task<bool> CandidatesConflictAsync(Solution solution,
+                                                     FixAllCandidate first,
+                                                     FixAllCandidate second,
+                                                     CancellationToken cancellationToken)
+    {
+        var firstRenamedSolution = await RenameWithoutConflictAsync(solution,
+                                                                    first.DocumentId,
+                                                                    first.Annotation,
+                                                                    first.Identifier,
+                                                                    cancellationToken).ConfigureAwait(false);
+
+        return firstRenamedSolution != null
+               && await RenameWithoutConflictAsync(firstRenamedSolution,
+                                                   second.DocumentId,
+                                                   second.Annotation,
+                                                   second.Identifier,
+                                                   cancellationToken).ConfigureAwait(false) == null;
+    }
+
+    /// <summary>
+    /// Re-resolves an aggregate rename candidate in the current evolving solution
+    /// </summary>
+    /// <param name="solution">Current solution</param>
+    /// <param name="candidate">Candidate to resolve</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The current declaration node and symbol, or <see langword="null"/> when either is unavailable</returns>
+    private async Task<(T Node, ISymbol Symbol)?> ResolveFixAllCandidateAsync(Solution solution,
+                                                                              FixAllCandidate candidate,
+                                                                              CancellationToken cancellationToken)
+    {
+        var document = solution.GetDocument(candidate.DocumentId);
+        var root = document == null
+                       ? null
+                       : await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        var model = document == null
+                        ? null
+                        : await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        var node = root?.GetAnnotatedNodes(candidate.Annotation).OfType<T>().SingleOrDefault();
+        var symbol = model == null || node == null
+                         ? null
+                         : GetDeclaredSymbol(model, node, cancellationToken);
+
+        return node == null || symbol == null
+                   ? null
+                   : (node, symbol);
+    }
+
+    /// <summary>
+    /// Determines whether a comprehensive rename produces Roslyn conflict annotations or added declaration errors
+    /// </summary>
+    /// <param name="document">Document containing the declaration</param>
+    /// <param name="node">Declaration node to rename</param>
     /// <param name="identifier">Proposed replacement identifier</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns><see langword="true"/> when the rename would conflict; otherwise, <see langword="false"/></returns>
-    private async Task<bool> HasRenameConflictAsync(Solution solution, ISymbol declaredSymbol, string identifier, CancellationToken cancellationToken)
+    private async Task<bool> HasRenameConflictAsync(Document document, T node, string identifier, CancellationToken cancellationToken)
     {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+        if (root == null)
+        {
+            return true;
+        }
+
+        var annotation = new SyntaxAnnotation(nameof(HasRenameConflictAsync));
+        var annotatedSolution = document.WithSyntaxRoot(root.ReplaceNode(node, node.WithAdditionalAnnotations(annotation))).Project.Solution;
+
+        return await RenameWithoutConflictAsync(annotatedSolution,
+                                                document.Id,
+                                                annotation,
+                                                identifier,
+                                                cancellationToken).ConfigureAwait(false) == null;
+    }
+
+    /// <summary>
+    /// Applies a rename only when Roslyn produces no conflict annotations or added declaration errors
+    /// </summary>
+    /// <param name="solution">Solution containing the declaration</param>
+    /// <param name="documentId">Declaration document</param>
+    /// <param name="annotation">Declaration tracking annotation</param>
+    /// <param name="identifier">Proposed replacement identifier</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The renamed solution when conflict-free; otherwise, <see langword="null"/></returns>
+    private async Task<Solution> RenameWithoutConflictAsync(Solution solution,
+                                                            DocumentId documentId,
+                                                            SyntaxAnnotation annotation,
+                                                            string identifier,
+                                                            CancellationToken cancellationToken)
+    {
+        var document = solution.GetDocument(documentId);
+        var root = document == null
+                       ? null
+                       : await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        var model = document == null
+                        ? null
+                        : await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        var node = root?.GetAnnotatedNodes(annotation).OfType<T>().SingleOrDefault();
+        var declaredSymbol = model == null || node == null
+                                 ? null
+                                 : GetDeclaredSymbol(model, node, cancellationToken);
+
+        if (document == null
+            || model == null
+            || node == null
+            || declaredSymbol == null)
+        {
+            return null;
+        }
+
+        // The declaration-node span is the narrowest stable region that owns the proven duplicate-declaration errors.
+        // Comparing error-ID multiplicities keeps unrelated pre-existing errors elsewhere in the document out of the
+        // decision while still allowing an existing error inside the declaration to remain unchanged.
+        var originalErrors = model.GetDiagnostics(node.Span, cancellationToken)
+                                  .Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+                                  .ToImmutableArray();
         var renamedSolution = await Renamer.RenameSymbolAsync(solution, declaredSymbol, default, identifier, cancellationToken).ConfigureAwait(false);
         var changes = renamedSolution.GetChanges(solution);
 
         foreach (var projectChanges in changes.GetProjectChanges())
         {
-            var originalProject = solution.GetProject(projectChanges.ProjectId);
-            var renamedProject = renamedSolution.GetProject(projectChanges.ProjectId);
-            var originalCompilation = originalProject == null
-                                          ? null
-                                          : await originalProject.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
-            var renamedCompilation = renamedProject == null
-                                         ? null
-                                         : await renamedProject.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
-
-            if (originalCompilation != null
-                && renamedCompilation != null
-                && renamedCompilation.GetDiagnostics(cancellationToken).Count(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
-                   > originalCompilation.GetDiagnostics(cancellationToken).Count(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error))
+            foreach (var changedDocumentId in projectChanges.GetChangedDocuments())
             {
-                return true;
-            }
+                var changedDocument = renamedSolution.GetDocument(changedDocumentId);
+                var changedRoot = changedDocument == null
+                                      ? null
+                                      : await changedDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
-            foreach (var documentId in projectChanges.GetChangedDocuments())
-            {
-                var document = renamedSolution.GetDocument(documentId);
-                var root = document == null
-                               ? null
-                               : await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-
-                if (root?.GetAnnotatedNodesAndTokens(ConflictAnnotation.Kind).Any() == true)
+                if (changedRoot?.GetAnnotatedNodesAndTokens(ConflictAnnotation.Kind).Any() == true)
                 {
-                    return true;
+                    return null;
                 }
             }
         }
 
-        return false;
+        var renamedDocument = renamedSolution.GetDocument(documentId);
+        var renamedRoot = renamedDocument == null
+                              ? null
+                              : await renamedDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        var renamedModel = renamedDocument == null
+                               ? null
+                               : await renamedDocument.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        var renamedNode = renamedRoot?.GetAnnotatedNodes(annotation).OfType<T>().SingleOrDefault();
+
+        if (renamedModel == null
+            || renamedNode == null)
+        {
+            return null;
+        }
+
+        var renamedErrors = renamedModel.GetDiagnostics(renamedNode.Span, cancellationToken)
+                                        .Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+                                        .ToImmutableArray();
+
+        foreach (var errorGroup in renamedErrors.GroupBy(static diagnostic => diagnostic.Id))
+        {
+            if (errorGroup.Count() > originalErrors.Count(diagnostic => string.Equals(diagnostic.Id, errorGroup.Key, StringComparison.Ordinal)))
+            {
+                return null;
+            }
+        }
+
+        return renamedSolution;
     }
 
     #endregion // Methods
+
+    #region Types
+
+    /// <summary>
+    /// Immutable aggregate rename candidate
+    /// </summary>
+#pragma warning disable RH2104 // The immutable candidate is private to the shared casing policy owner by design
+    private readonly struct FixAllCandidate
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="documentId">Declaration document</param>
+        /// <param name="originalSpan">Original diagnostic span</param>
+        /// <param name="annotation">Tracking annotation</param>
+        /// <param name="identifier">Proposed identifier</param>
+        /// <param name="containingSymbol">Declaration or binding domain owner</param>
+        public FixAllCandidate(DocumentId documentId,
+                               TextSpan originalSpan,
+                               SyntaxAnnotation annotation,
+                               string identifier,
+                               ISymbol containingSymbol)
+        {
+            DocumentId = documentId;
+            OriginalSpan = originalSpan;
+            Annotation = annotation;
+            Identifier = identifier;
+            ContainingSymbol = containingSymbol;
+        }
+
+        /// <summary>
+        /// Declaration document
+        /// </summary>
+        public DocumentId DocumentId { get; }
+
+        /// <summary>
+        /// Original diagnostic span
+        /// </summary>
+        public TextSpan OriginalSpan { get; }
+
+        /// <summary>
+        /// Tracking annotation
+        /// </summary>
+        public SyntaxAnnotation Annotation { get; }
+
+        /// <summary>
+        /// Proposed identifier
+        /// </summary>
+        public string Identifier { get; }
+
+        /// <summary>
+        /// Declaration or binding domain owner
+        /// </summary>
+        public ISymbol ContainingSymbol { get; }
+    }
+#pragma warning restore RH2104
+
+#pragma warning disable RH2101 // The provider is private to the shared casing policy owner by design
+    /// <summary>
+    /// Fix All provider that composes casing renames against an evolving solution
+    /// </summary>
+    private sealed class CasingFixAllProvider : FixAllProvider
+    {
+        #region FixAllProvider
+
+        /// <inheritdoc/>
+        public override IEnumerable<FixAllScope> GetSupportedFixAllScopes()
+        {
+            return [FixAllScope.Document, FixAllScope.Project, FixAllScope.Solution];
+        }
+
+        /// <inheritdoc/>
+        public override Task<CodeAction> GetFixAsync(FixAllContext fixAllContext)
+        {
+            if (fixAllContext.CodeFixProvider is not CasingCodeFixProviderBase<T> provider)
+            {
+                return Task.FromResult<CodeAction>(null);
+            }
+
+            var equivalenceKey = fixAllContext.CodeActionEquivalenceKey ?? provider.GetType().Name;
+            var action = CodeAction.Create(provider._title,
+                                           cancellationToken => provider.ApplyFixAllAsync(fixAllContext.WithCancellationToken(cancellationToken), cancellationToken),
+                                           equivalenceKey);
+
+            return Task.FromResult(action);
+        }
+
+        #endregion // FixAllProvider
+    }
+#pragma warning restore RH2101
+
+    #endregion // Types
 
     #region CodeFixProvider
 
@@ -220,7 +686,7 @@ public abstract class CasingCodeFixProviderBase<T> : CodeFixProvider
     /// <inheritdoc/>
     public sealed override FixAllProvider GetFixAllProvider()
     {
-        return WellKnownFixAllProviders.BatchFixer;
+        return new CasingFixAllProvider();
     }
 
     /// <inheritdoc/>
@@ -249,7 +715,7 @@ public abstract class CasingCodeFixProviderBase<T> : CodeFixProvider
                 var declaredSymbol = GetDeclaredSymbol(model, node, context.CancellationToken);
 
                 if (declaredSymbol != null
-                    && await HasRenameConflictAsync(context.Document.Project.Solution, declaredSymbol, identifier, context.CancellationToken).ConfigureAwait(false) == false)
+                    && await HasRenameConflictAsync(context.Document, node, identifier, context.CancellationToken).ConfigureAwait(false) == false)
                 {
                     context.RegisterCodeFix(CodeAction.Create(_title,
                                                               cancellationToken => ApplyCodeFixAsync(context.Document, node, identifier, cancellationToken),

--- a/Reihitsu.Analyzer.CodeFixes/Base/CasingCodeFixProviderBase{T}.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Base/CasingCodeFixProviderBase{T}.cs
@@ -468,6 +468,109 @@ public abstract class CasingCodeFixProviderBase<T> : CodeFixProvider
     }
 
     /// <summary>
+    /// Annotates every source declaration that owns the target declaration's binding domain
+    /// </summary>
+    /// <param name="solution">Solution containing the declaration</param>
+    /// <param name="documentId">Target declaration document</param>
+    /// <param name="declaredSymbol">Target declaration symbol</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>The annotated solution and binding-domain document/annotation pairs</returns>
+    private async Task<(Solution Solution, ImmutableArray<(DocumentId DocumentId, SyntaxAnnotation Annotation)> Domains)> AnnotateBindingDomainsAsync(Solution solution,
+                                                                                                                                                      DocumentId documentId,
+                                                                                                                                                      ISymbol declaredSymbol,
+                                                                                                                                                      CancellationToken cancellationToken)
+    {
+        var domains = ImmutableArray.CreateBuilder<(DocumentId DocumentId, SyntaxAnnotation Annotation)>();
+        var containingDeclarations = declaredSymbol.ContainingSymbol == null
+                                         ? []
+                                         : declaredSymbol.ContainingSymbol.DeclaringSyntaxReferences
+                                                         .OrderBy(reference => GetDocumentSortKey(solution, reference.SyntaxTree), StringComparer.Ordinal)
+                                                         .ThenBy(static reference => reference.Span.Start)
+                                                         .Select(reference => (DocumentId: solution.GetDocument(reference.SyntaxTree)?.Id, reference.Span))
+                                                         .Where(static reference => reference.DocumentId != null)
+                                                         .ToImmutableArray();
+
+        foreach (var containingDeclaration in containingDeclarations)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var domainDocument = solution.GetDocument(containingDeclaration.DocumentId);
+            var domainRoot = domainDocument == null
+                                 ? null
+                                 : await domainDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var domainNode = domainRoot?.FindNode(containingDeclaration.Span, getInnermostNodeForTie: true);
+
+            if (domainDocument == null
+                || domainRoot == null
+                || domainNode == null)
+            {
+                continue;
+            }
+
+            var annotation = new SyntaxAnnotation(nameof(AnnotateBindingDomainsAsync), domains.Count.ToString(CultureInfo.InvariantCulture));
+            solution = domainDocument.WithSyntaxRoot(domainRoot.ReplaceNode(domainNode, domainNode.WithAdditionalAnnotations(annotation))).Project.Solution;
+            domains.Add((domainDocument.Id, annotation));
+        }
+
+        if (domains.Count == 0)
+        {
+            var declarationDocument = solution.GetDocument(documentId);
+            var declarationRoot = declarationDocument == null
+                                      ? null
+                                      : await declarationDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+            if (declarationDocument != null
+                && declarationRoot != null)
+            {
+                var annotation = new SyntaxAnnotation(nameof(AnnotateBindingDomainsAsync), "fallback");
+                solution = declarationDocument.WithSyntaxRoot(declarationRoot.WithAdditionalAnnotations(annotation)).Project.Solution;
+                domains.Add((declarationDocument.Id, annotation));
+            }
+        }
+
+        return (solution, domains.ToImmutable());
+    }
+
+    /// <summary>
+    /// Gets compiler errors from the tracked source declarations that own a rename's binding domain
+    /// </summary>
+    /// <param name="solution">Current solution</param>
+    /// <param name="domains">Binding-domain document/annotation pairs</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Binding-domain compiler errors, or a default array when a tracked domain cannot be resolved</returns>
+    private async Task<ImmutableArray<Diagnostic>> GetBindingDomainErrorsAsync(Solution solution,
+                                                                               ImmutableArray<(DocumentId DocumentId, SyntaxAnnotation Annotation)> domains,
+                                                                               CancellationToken cancellationToken)
+    {
+        var errors = ImmutableArray.CreateBuilder<Diagnostic>();
+
+        foreach (var domain in domains)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var document = solution.GetDocument(domain.DocumentId);
+            var root = document == null
+                           ? null
+                           : await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var model = document == null
+                            ? null
+                            : await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var node = root?.GetAnnotatedNodes(domain.Annotation).SingleOrDefault();
+
+            if (model == null
+                || node == null)
+            {
+                return default;
+            }
+
+            errors.AddRange(model.GetDiagnostics(node.Span, cancellationToken)
+                                 .Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
+        }
+
+        return errors.ToImmutable();
+    }
+
+    /// <summary>
     /// Determines whether a comprehensive rename produces Roslyn conflict annotations or added declaration errors
     /// </summary>
     /// <param name="document">Document containing the declaration</param>
@@ -529,12 +632,38 @@ public abstract class CasingCodeFixProviderBase<T> : CodeFixProvider
             return null;
         }
 
-        // The declaration-node span is the narrowest stable region that owns the proven duplicate-declaration errors.
-        // Comparing error-ID multiplicities keeps unrelated pre-existing errors elsewhere in the document out of the
-        // decision while still allowing an existing error inside the declaration to remain unchanged.
-        var originalErrors = model.GetDiagnostics(node.Span, cancellationToken)
-                                  .Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
-                                  .ToImmutableArray();
+        var (domainSolution, domains) = await AnnotateBindingDomainsAsync(solution,
+                                                                          documentId,
+                                                                          declaredSymbol,
+                                                                          cancellationToken).ConfigureAwait(false);
+
+        solution = domainSolution;
+        document = solution.GetDocument(documentId);
+        root = document == null
+                   ? null
+                   : await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        model = document == null
+                    ? null
+                    : await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        node = root?.GetAnnotatedNodes(annotation).OfType<T>().SingleOrDefault();
+        declaredSymbol = model == null || node == null
+                             ? null
+                             : GetDeclaredSymbol(model, node, cancellationToken);
+
+        if (declaredSymbol == null)
+        {
+            return null;
+        }
+
+        // Comparing error-ID multiplicities across only the containing symbol's source declaration spans includes
+        // either side of a duplicate declaration without requiring unrelated pre-existing errors to disappear.
+        var originalErrors = await GetBindingDomainErrorsAsync(solution, domains, cancellationToken).ConfigureAwait(false);
+
+        if (originalErrors.IsDefault)
+        {
+            return null;
+        }
+
         var renamedSolution = await Renamer.RenameSymbolAsync(solution, declaredSymbol, default, identifier, cancellationToken).ConfigureAwait(false);
         var changes = renamedSolution.GetChanges(solution);
 
@@ -569,9 +698,12 @@ public abstract class CasingCodeFixProviderBase<T> : CodeFixProvider
             return null;
         }
 
-        var renamedErrors = renamedModel.GetDiagnostics(renamedNode.Span, cancellationToken)
-                                        .Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
-                                        .ToImmutableArray();
+        var renamedErrors = await GetBindingDomainErrorsAsync(renamedSolution, domains, cancellationToken).ConfigureAwait(false);
+
+        if (renamedErrors.IsDefault)
+        {
+            return null;
+        }
 
         foreach (var errorGroup in renamedErrors.GroupBy(static diagnostic => diagnostic.Id))
         {

--- a/Reihitsu.Analyzer.CodeFixes/Base/CasingCodeFixProviderBase{T}.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Base/CasingCodeFixProviderBase{T}.cs
@@ -161,6 +161,55 @@ public abstract class CasingCodeFixProviderBase<T> : CodeFixProvider
         return await Renamer.RenameSymbolAsync(document.Project.Solution, declaredSymbol, default, identifier, cancellationToken).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Determines whether Roslyn reports a conflict for the proposed comprehensive rename
+    /// </summary>
+    /// <param name="solution">Solution containing the declaration</param>
+    /// <param name="declaredSymbol">Declared symbol to rename</param>
+    /// <param name="identifier">Proposed replacement identifier</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns><see langword="true"/> when the rename would conflict; otherwise, <see langword="false"/></returns>
+    private async Task<bool> HasRenameConflictAsync(Solution solution, ISymbol declaredSymbol, string identifier, CancellationToken cancellationToken)
+    {
+        var renamedSolution = await Renamer.RenameSymbolAsync(solution, declaredSymbol, default, identifier, cancellationToken).ConfigureAwait(false);
+        var changes = renamedSolution.GetChanges(solution);
+
+        foreach (var projectChanges in changes.GetProjectChanges())
+        {
+            var originalProject = solution.GetProject(projectChanges.ProjectId);
+            var renamedProject = renamedSolution.GetProject(projectChanges.ProjectId);
+            var originalCompilation = originalProject == null
+                                          ? null
+                                          : await originalProject.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
+            var renamedCompilation = renamedProject == null
+                                         ? null
+                                         : await renamedProject.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
+
+            if (originalCompilation != null
+                && renamedCompilation != null
+                && renamedCompilation.GetDiagnostics(cancellationToken).Count(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+                   > originalCompilation.GetDiagnostics(cancellationToken).Count(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error))
+            {
+                return true;
+            }
+
+            foreach (var documentId in projectChanges.GetChangedDocuments())
+            {
+                var document = renamedSolution.GetDocument(documentId);
+                var root = document == null
+                               ? null
+                               : await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+                if (root?.GetAnnotatedNodesAndTokens(ConflictAnnotation.Kind).Any() == true)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     #endregion // Methods
 
     #region CodeFixProvider
@@ -189,11 +238,18 @@ public abstract class CasingCodeFixProviderBase<T> : CodeFixProvider
 
                 // The fix is only offered when the declared symbol resolves, so the rename covers the declaration and
                 // every reference. A declaration-only rename would leave references stale and produce non-compiling code
-                if (model != null
-                    && root.FindNode(diagnosticSpan) is T node
-                    && CanRegisterCodeFix(node)
-                    && TryGetFixedIdentifier(node, out var identifier)
-                    && GetDeclaredSymbol(model, node, context.CancellationToken) != null)
+                if (model == null
+                    || root.FindNode(diagnosticSpan) is not T node
+                    || CanRegisterCodeFix(node) == false
+                    || TryGetFixedIdentifier(node, out var identifier) == false)
+                {
+                    continue;
+                }
+
+                var declaredSymbol = GetDeclaredSymbol(model, node, context.CancellationToken);
+
+                if (declaredSymbol != null
+                    && await HasRenameConflictAsync(context.Document.Project.Solution, declaredSymbol, identifier, context.CancellationToken).ConfigureAwait(false) == false)
                 {
                     context.RegisterCodeFix(CodeAction.Create(_title,
                                                               cancellationToken => ApplyCodeFixAsync(context.Document, node, identifier, cancellationToken),

--- a/Reihitsu.Analyzer.CodeFixes/Base/CasingCodeFixProviderBase{T}.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Base/CasingCodeFixProviderBase{T}.cs
@@ -468,7 +468,7 @@ public abstract class CasingCodeFixProviderBase<T> : CodeFixProvider
     }
 
     /// <summary>
-    /// Annotates every non-global source declaration that owns the target declaration's binding domain
+    /// Annotates every source declaration that owns a non-namespace target's binding domain
     /// </summary>
     /// <param name="solution">Solution containing the declaration</param>
     /// <param name="documentId">Target declaration document</param>
@@ -532,7 +532,7 @@ public abstract class CasingCodeFixProviderBase<T> : CodeFixProvider
     }
 
     /// <summary>
-    /// Gets compiler errors from the tracked source declarations that own a rename's binding domain
+    /// Gets compiler errors from the tracked source declarations that own a non-namespace rename's binding domain
     /// </summary>
     /// <param name="solution">Current solution</param>
     /// <param name="domains">Binding-domain document/annotation pairs</param>
@@ -571,15 +571,15 @@ public abstract class CasingCodeFixProviderBase<T> : CodeFixProvider
     }
 
     /// <summary>
-    /// Determines whether a global-namespace declaration's proposed name collides with an existing source member
+    /// Determines whether a namespace-owned declaration's proposed name collides with an existing source member
     /// </summary>
     /// <param name="declaredSymbol">Declaration symbol</param>
     /// <param name="identifier">Proposed identifier</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns><see langword="true"/> when the proposed name collides; otherwise, <see langword="false"/></returns>
-    private bool HasGlobalNamespaceCollision(ISymbol declaredSymbol, string identifier, CancellationToken cancellationToken)
+    private bool HasNamespaceCollision(ISymbol declaredSymbol, string identifier, CancellationToken cancellationToken)
     {
-        if (declaredSymbol.ContainingSymbol is not INamespaceSymbol { IsGlobalNamespace: true } globalNamespace)
+        if (declaredSymbol.ContainingSymbol is not INamespaceSymbol containingNamespace)
         {
             return false;
         }
@@ -587,7 +587,7 @@ public abstract class CasingCodeFixProviderBase<T> : CodeFixProvider
         var declaringTrees = declaredSymbol.DeclaringSyntaxReferences.Select(static reference => reference.SyntaxTree)
                                                                      .ToImmutableHashSet();
 
-        foreach (var member in globalNamespace.GetMembers(identifier))
+        foreach (var member in containingNamespace.GetMembers(identifier))
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -615,7 +615,7 @@ public abstract class CasingCodeFixProviderBase<T> : CodeFixProvider
             }
 
             // Namespace merging is legal, but casing fixes deliberately refuse to merge declarations. A type and a
-            // namespace with the same source name also occupy a conflicting global-namespace member slot.
+            // namespace with the same source name also occupy a conflicting namespace member slot.
             return true;
         }
 
@@ -650,7 +650,7 @@ public abstract class CasingCodeFixProviderBase<T> : CodeFixProvider
     }
 
     /// <summary>
-    /// Applies a rename only when Roslyn produces no global member collision, conflict annotations, or added declaration errors
+    /// Applies a rename only when Roslyn produces no namespace member collision, conflict annotations, or added declaration errors
     /// </summary>
     /// <param name="solution">Solution containing the declaration</param>
     /// <param name="documentId">Declaration document</param>
@@ -686,15 +686,15 @@ public abstract class CasingCodeFixProviderBase<T> : CodeFixProvider
 
         cancellationToken.ThrowIfCancellationRequested();
 
-        var hasGlobalNamespaceOwner = declaredSymbol.ContainingSymbol is INamespaceSymbol { IsGlobalNamespace: true };
+        var hasNamespaceOwner = declaredSymbol.ContainingSymbol is INamespaceSymbol;
         var domains = ImmutableArray<(DocumentId DocumentId, SyntaxAnnotation Annotation)>.Empty;
         var originalErrors = ImmutableArray<Diagnostic>.Empty;
 
-        if (hasGlobalNamespaceOwner)
+        if (hasNamespaceOwner)
         {
-            // Global namespace syntax references cover every compilation unit. Membership lookup proves source
-            // collisions without turning the declaration-domain diagnostic check into a project-wide scan.
-            if (HasGlobalNamespaceCollision(declaredSymbol, identifier, cancellationToken))
+            // Namespace syntax references can cover every declaration of that namespace. Membership lookup proves
+            // source collisions without turning the declaration-domain diagnostic check into a multi-document scan.
+            if (HasNamespaceCollision(declaredSymbol, identifier, cancellationToken))
             {
                 return null;
             }
@@ -769,7 +769,7 @@ public abstract class CasingCodeFixProviderBase<T> : CodeFixProvider
             return null;
         }
 
-        if (hasGlobalNamespaceOwner == false)
+        if (hasNamespaceOwner == false)
         {
             var renamedErrors = await GetBindingDomainErrorsAsync(renamedSolution, domains, cancellationToken).ConfigureAwait(false);
 

--- a/Reihitsu.Analyzer.CodeFixes/Base/CasingCodeFixProviderBase{T}.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Base/CasingCodeFixProviderBase{T}.cs
@@ -468,7 +468,7 @@ public abstract class CasingCodeFixProviderBase<T> : CodeFixProvider
     }
 
     /// <summary>
-    /// Annotates every source declaration that owns the target declaration's binding domain
+    /// Annotates every non-global source declaration that owns the target declaration's binding domain
     /// </summary>
     /// <param name="solution">Solution containing the declaration</param>
     /// <param name="documentId">Target declaration document</param>
@@ -571,6 +571,58 @@ public abstract class CasingCodeFixProviderBase<T> : CodeFixProvider
     }
 
     /// <summary>
+    /// Determines whether a global-namespace declaration's proposed name collides with an existing source member
+    /// </summary>
+    /// <param name="declaredSymbol">Declaration symbol</param>
+    /// <param name="identifier">Proposed identifier</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns><see langword="true"/> when the proposed name collides; otherwise, <see langword="false"/></returns>
+    private bool HasGlobalNamespaceCollision(ISymbol declaredSymbol, string identifier, CancellationToken cancellationToken)
+    {
+        if (declaredSymbol.ContainingSymbol is not INamespaceSymbol { IsGlobalNamespace: true } globalNamespace)
+        {
+            return false;
+        }
+
+        var declaringTrees = declaredSymbol.DeclaringSyntaxReferences.Select(static reference => reference.SyntaxTree)
+                                                                     .ToImmutableHashSet();
+
+        foreach (var member in globalNamespace.GetMembers(identifier))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (SymbolEqualityComparer.Default.Equals(member, declaredSymbol)
+                || member.DeclaringSyntaxReferences.IsEmpty)
+            {
+                continue;
+            }
+
+            if (declaredSymbol is INamedTypeSymbol declaredType
+                && member is INamedTypeSymbol existingType)
+            {
+                if (declaredType.Arity != existingType.Arity)
+                {
+                    continue;
+                }
+
+                // File-local types occupy only their declaring syntax tree, so an equal name and arity in another
+                // document is not a collision.
+                if ((declaredType.IsFileLocal || existingType.IsFileLocal)
+                    && existingType.DeclaringSyntaxReferences.Any(reference => declaringTrees.Contains(reference.SyntaxTree)) == false)
+                {
+                    continue;
+                }
+            }
+
+            // Namespace merging is legal, but casing fixes deliberately refuse to merge declarations. A type and a
+            // namespace with the same source name also occupy a conflicting global-namespace member slot.
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Determines whether a comprehensive rename produces Roslyn conflict annotations or added declaration errors
     /// </summary>
     /// <param name="document">Document containing the declaration</param>
@@ -598,7 +650,7 @@ public abstract class CasingCodeFixProviderBase<T> : CodeFixProvider
     }
 
     /// <summary>
-    /// Applies a rename only when Roslyn produces no conflict annotations or added declaration errors
+    /// Applies a rename only when Roslyn produces no global member collision, conflict annotations, or added declaration errors
     /// </summary>
     /// <param name="solution">Solution containing the declaration</param>
     /// <param name="documentId">Declaration document</param>
@@ -632,36 +684,55 @@ public abstract class CasingCodeFixProviderBase<T> : CodeFixProvider
             return null;
         }
 
-        var (domainSolution, domains) = await AnnotateBindingDomainsAsync(solution,
-                                                                          documentId,
-                                                                          declaredSymbol,
-                                                                          cancellationToken).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
 
-        solution = domainSolution;
-        document = solution.GetDocument(documentId);
-        root = document == null
-                   ? null
-                   : await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-        model = document == null
-                    ? null
-                    : await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-        node = root?.GetAnnotatedNodes(annotation).OfType<T>().SingleOrDefault();
-        declaredSymbol = model == null || node == null
-                             ? null
-                             : GetDeclaredSymbol(model, node, cancellationToken);
+        var hasGlobalNamespaceOwner = declaredSymbol.ContainingSymbol is INamespaceSymbol { IsGlobalNamespace: true };
+        var domains = ImmutableArray<(DocumentId DocumentId, SyntaxAnnotation Annotation)>.Empty;
+        var originalErrors = ImmutableArray<Diagnostic>.Empty;
 
-        if (declaredSymbol == null)
+        if (hasGlobalNamespaceOwner)
         {
-            return null;
+            // Global namespace syntax references cover every compilation unit. Membership lookup proves source
+            // collisions without turning the declaration-domain diagnostic check into a project-wide scan.
+            if (HasGlobalNamespaceCollision(declaredSymbol, identifier, cancellationToken))
+            {
+                return null;
+            }
         }
-
-        // Comparing error-ID multiplicities across only the containing symbol's source declaration spans includes
-        // either side of a duplicate declaration without requiring unrelated pre-existing errors to disappear.
-        var originalErrors = await GetBindingDomainErrorsAsync(solution, domains, cancellationToken).ConfigureAwait(false);
-
-        if (originalErrors.IsDefault)
+        else
         {
-            return null;
+            var domainResult = await AnnotateBindingDomainsAsync(solution,
+                                                                 documentId,
+                                                                 declaredSymbol,
+                                                                 cancellationToken).ConfigureAwait(false);
+
+            solution = domainResult.Solution;
+            domains = domainResult.Domains;
+            document = solution.GetDocument(documentId);
+            root = document == null
+                       ? null
+                       : await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            model = document == null
+                        ? null
+                        : await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            node = root?.GetAnnotatedNodes(annotation).OfType<T>().SingleOrDefault();
+            declaredSymbol = model == null || node == null
+                                 ? null
+                                 : GetDeclaredSymbol(model, node, cancellationToken);
+
+            if (declaredSymbol == null)
+            {
+                return null;
+            }
+
+            // Comparing error-ID multiplicities across only the containing symbol's source declaration spans includes
+            // either side of a duplicate declaration without requiring unrelated pre-existing errors to disappear.
+            originalErrors = await GetBindingDomainErrorsAsync(solution, domains, cancellationToken).ConfigureAwait(false);
+
+            if (originalErrors.IsDefault)
+            {
+                return null;
+            }
         }
 
         var renamedSolution = await Renamer.RenameSymbolAsync(solution, declaredSymbol, default, identifier, cancellationToken).ConfigureAwait(false);
@@ -698,18 +769,21 @@ public abstract class CasingCodeFixProviderBase<T> : CodeFixProvider
             return null;
         }
 
-        var renamedErrors = await GetBindingDomainErrorsAsync(renamedSolution, domains, cancellationToken).ConfigureAwait(false);
-
-        if (renamedErrors.IsDefault)
+        if (hasGlobalNamespaceOwner == false)
         {
-            return null;
-        }
+            var renamedErrors = await GetBindingDomainErrorsAsync(renamedSolution, domains, cancellationToken).ConfigureAwait(false);
 
-        foreach (var errorGroup in renamedErrors.GroupBy(static diagnostic => diagnostic.Id))
-        {
-            if (errorGroup.Count() > originalErrors.Count(diagnostic => string.Equals(diagnostic.Id, errorGroup.Key, StringComparison.Ordinal)))
+            if (renamedErrors.IsDefault)
             {
                 return null;
+            }
+
+            foreach (var errorGroup in renamedErrors.GroupBy(static diagnostic => diagnostic.Id))
+            {
+                if (errorGroup.Count() > originalErrors.Count(diagnostic => string.Equals(diagnostic.Id, errorGroup.Key, StringComparison.Ordinal)))
+                {
+                    return null;
+                }
             }
         }
 

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Clarity/RH3001NotOperatorShouldNotBeUsedCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Clarity/RH3001NotOperatorShouldNotBeUsedCodeFixProvider.cs
@@ -9,8 +9,10 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Simplification;
+using Microsoft.CodeAnalysis.Text;
 
 using Reihitsu.Analyzer.Rules.Clarity;
+using Reihitsu.Core;
 
 namespace Reihitsu.Analyzer.CodeFixes.Rules.Clarity;
 
@@ -32,8 +34,22 @@ public class RH3001NotOperatorShouldNotBeUsedCodeFixProvider : CodeFixProvider
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
     private static async Task<Document> ApplyCodeFixAsync(Document document, PrefixUnaryExpressionSyntax node, CancellationToken cancellationToken)
     {
-        var replacementNode = SyntaxFactory.ParenthesizedExpression(SyntaxFactory.BinaryExpression(SyntaxKind.EqualsExpression, node.Operand.WithoutTrivia(), SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression)))
-                                           .WithTriviaFrom(node)
+        var operandLeadingTrivia = node.OperatorToken.TrailingTrivia.AddRange(node.Operand.GetLeadingTrivia());
+
+        while (operandLeadingTrivia.Count > 0
+               && operandLeadingTrivia[0].IsKind(SyntaxKind.WhitespaceTrivia))
+        {
+            operandLeadingTrivia = operandLeadingTrivia.RemoveAt(0);
+        }
+
+        var openParenthesis = SyntaxFactory.Token(SyntaxKind.OpenParenToken)
+                                           .WithLeadingTrivia(node.GetLeadingTrivia())
+                                           .WithTrailingTrivia(operandLeadingTrivia);
+        var operand = node.Operand.WithoutLeadingTrivia();
+        var replacementNode = SyntaxFactory.ParenthesizedExpression(openParenthesis,
+                                                                    SyntaxFactory.BinaryExpression(SyntaxKind.EqualsExpression, operand, SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression)),
+                                                                    SyntaxFactory.Token(SyntaxKind.CloseParenToken))
+                                           .WithTrailingTrivia(node.GetTrailingTrivia())
                                            .WithAdditionalAnnotations(Simplifier.Annotation);
 
         var syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
@@ -46,6 +62,21 @@ public class RH3001NotOperatorShouldNotBeUsedCodeFixProvider : CodeFixProvider
         }
 
         return document;
+    }
+
+    /// <summary>
+    /// Determines whether the operator-to-operand gap contains syntax that cannot be transferred safely
+    /// </summary>
+    /// <param name="node">Logical-not expression</param>
+    /// <returns><see langword="true"/> if the operand trivia can be preserved by the rewrite; otherwise, <see langword="false"/></returns>
+    private static bool HasSafeOperandTrivia(PrefixUnaryExpressionSyntax node)
+    {
+        var gap = TextSpan.FromBounds(node.OperatorToken.Span.End, node.Operand.SpanStart);
+        var gapTrivia = node.OperatorToken.TrailingTrivia.AddRange(node.Operand.GetLeadingTrivia());
+
+        return node.SyntaxTree.GetDiagnostics().Any(diagnostic => diagnostic.Location.SourceSpan.IntersectsWith(gap)) == false
+               && gapTrivia.All(static trivia => SyntaxTriviaUtilities.IsDirectiveOrDisabledTextTrivia(trivia) == false
+                                                 && trivia.IsKind(SyntaxKind.SkippedTokensTrivia) == false);
     }
 
     #endregion // Methods
@@ -70,7 +101,8 @@ public class RH3001NotOperatorShouldNotBeUsedCodeFixProvider : CodeFixProvider
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (root.FindNode(diagnostic.Location.SourceSpan) is PrefixUnaryExpressionSyntax node)
+                if (root.FindNode(diagnostic.Location.SourceSpan) is PrefixUnaryExpressionSyntax node
+                    && HasSafeOperandTrivia(node))
                 {
                     context.RegisterCodeFix(CodeAction.Create(CodeFixResources.RH3001Title,
                                                               cancellationToken => ApplyCodeFixAsync(context.Document, node, cancellationToken),

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Layout/RH5011BreakStatementsShouldBeFollowedByABlankLineCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Layout/RH5011BreakStatementsShouldBeFollowedByABlankLineCodeFixProvider.cs
@@ -6,9 +6,12 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 
 using Reihitsu.Analyzer.Rules.Layout;
+using Reihitsu.Core;
 using Reihitsu.Formatter.Utilities;
 
 namespace Reihitsu.Analyzer.CodeFixes.Rules.Layout;
@@ -26,10 +29,10 @@ public class RH5011BreakStatementsShouldBeFollowedByABlankLineCodeFixProvider : 
     /// Applies the code fix
     /// </summary>
     /// <param name="document">Document</param>
-    /// <param name="diagnosticSpan">Diagnostic span</param>
+    /// <param name="breakStatement">Break statement to update</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>The updated document</returns>
-    private static async Task<Document> ApplyCodeFixAsync(Document document, TextSpan diagnosticSpan, CancellationToken cancellationToken)
+    private static async Task<Document> ApplyCodeFixAsync(Document document, BreakStatementSyntax breakStatement, CancellationToken cancellationToken)
     {
         var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
@@ -39,12 +42,62 @@ public class RH5011BreakStatementsShouldBeFollowedByABlankLineCodeFixProvider : 
         }
 
         var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-        var breakLine = sourceText.Lines.GetLineFromPosition(diagnosticSpan.Start);
+        var breakLine = sourceText.Lines.GetLineFromPosition(breakStatement.SpanStart);
+        var nextToken = breakStatement.SemicolonToken.GetNextToken(includeZeroWidth: true, includeSkipped: true);
+
+        if (nextToken.IsKind(SyntaxKind.None) == false
+            && sourceText.Lines.GetLineFromPosition(nextToken.SpanStart).LineNumber == breakLine.LineNumber)
+        {
+            var nextStatement = nextToken.Parent?.FirstAncestorOrSelf<StatementSyntax>();
+
+            if (nextStatement == null)
+            {
+                return document;
+            }
+
+            var endOfLine = ReihitsuFormatterHelpers.DetectEndOfLine(root);
+            var indentation = FormattingTextAnalysisUtilities.GetLeadingWhitespace(FormattingTextAnalysisUtilities.GetLineText(sourceText, breakLine));
+            var gap = TextSpan.FromBounds(breakStatement.SemicolonToken.Span.End, nextToken.SpanStart);
+
+            return document.WithText(sourceText.Replace(gap, $"{endOfLine}{endOfLine}{indentation}"));
+        }
+
         var lineBreak = breakLine.EndIncludingLineBreak > breakLine.End
                             ? sourceText.ToString(TextSpan.FromBounds(breakLine.End, breakLine.EndIncludingLineBreak))
                             : ReihitsuFormatterHelpers.DetectEndOfLine(root);
 
         return document.WithText(sourceText.Replace(new TextSpan(breakLine.EndIncludingLineBreak, 0), lineBreak));
+    }
+
+    /// <summary>
+    /// Determines whether the gap after a same-line break statement contains only formatting trivia
+    /// </summary>
+    /// <param name="root">Syntax root</param>
+    /// <param name="breakStatement">Break statement</param>
+    /// <returns><see langword="true"/> when the action can preserve every token and trivia item; otherwise, <see langword="false"/></returns>
+    private static bool CanRegisterCodeFix(SyntaxNode root, BreakStatementSyntax breakStatement)
+    {
+        var nextToken = breakStatement.SemicolonToken.GetNextToken(includeZeroWidth: true, includeSkipped: true);
+
+        if (nextToken.IsKind(SyntaxKind.None))
+        {
+            return true;
+        }
+
+        var lineSpan = root.SyntaxTree.GetLineSpan(TextSpan.FromBounds(breakStatement.SpanStart, nextToken.SpanStart));
+
+        if (lineSpan.StartLinePosition.Line != lineSpan.EndLinePosition.Line)
+        {
+            return true;
+        }
+
+        var gap = TextSpan.FromBounds(breakStatement.SemicolonToken.Span.End, nextToken.SpanStart);
+
+        return nextToken.Parent?.FirstAncestorOrSelf<StatementSyntax>() != null
+               && root.SyntaxTree.GetDiagnostics().Any(diagnostic => diagnostic.Location.SourceSpan.IntersectsWith(gap)) == false
+               && root.SyntaxTree.GetText()
+                                 .ToString(gap)
+                                 .All(static character => character is ' ' or '\t');
     }
 
     #endregion // Methods
@@ -61,17 +114,27 @@ public class RH5011BreakStatementsShouldBeFollowedByABlankLineCodeFixProvider : 
     }
 
     /// <inheritdoc/>
-    public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        foreach (var diagnostic in context.Diagnostics)
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+        if (root == null)
         {
-            context.RegisterCodeFix(CodeAction.Create(CodeFixResources.RH5011Title,
-                                                      token => ApplyCodeFixAsync(context.Document, diagnostic.Location.SourceSpan, token),
-                                                      nameof(RH5011BreakStatementsShouldBeFollowedByABlankLineCodeFixProvider)),
-                                    diagnostic);
+            return;
         }
 
-        return Task.CompletedTask;
+        foreach (var diagnostic in context.Diagnostics)
+        {
+            var breakStatement = root.FindNode(diagnostic.Location.SourceSpan).FirstAncestorOrSelf<BreakStatementSyntax>();
+
+            if (breakStatement != null && CanRegisterCodeFix(root, breakStatement))
+            {
+                context.RegisterCodeFix(CodeAction.Create(CodeFixResources.RH5011Title,
+                                                          token => ApplyCodeFixAsync(context.Document, breakStatement, token),
+                                                          nameof(RH5011BreakStatementsShouldBeFollowedByABlankLineCodeFixProvider)),
+                                        diagnostic);
+            }
+        }
     }
 
     #endregion // CodeFixProvider

--- a/Reihitsu.Analyzer.CodeFixes/Rules/Layout/RH5103CodeMustNotContainMultipleStatementsOnOneLineCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Layout/RH5103CodeMustNotContainMultipleStatementsOnOneLineCodeFixProvider.cs
@@ -29,10 +29,9 @@ public class RH5103CodeMustNotContainMultipleStatementsOnOneLineCodeFixProvider 
     /// </summary>
     /// <param name="document">Document</param>
     /// <param name="statement">Statement to move</param>
-    /// <param name="previousStatement">Previous statement</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>The updated document</returns>
-    private static async Task<Document> ApplyCodeFixAsync(Document document, StatementSyntax statement, StatementSyntax previousStatement, CancellationToken cancellationToken)
+    private static async Task<Document> ApplyCodeFixAsync(Document document, StatementSyntax statement, CancellationToken cancellationToken)
     {
         var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
@@ -42,11 +41,41 @@ public class RH5103CodeMustNotContainMultipleStatementsOnOneLineCodeFixProvider 
         }
 
         var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-        var indentationColumn = previousStatement.GetLocation().GetLineSpan().StartLinePosition.Character;
-        var replacementText = ReihitsuFormatterHelpers.DetectEndOfLine(root) + new string(' ', indentationColumn);
-        var replacementSpan = TextSpan.FromBounds(previousStatement.Span.End, statement.Span.Start);
+        var previousToken = statement.GetFirstToken().GetPreviousToken();
+        var previousStatement = GetPreviousStatement(statement);
+
+        if (previousStatement == null)
+        {
+            return document;
+        }
+
+        var replacementText = ReihitsuFormatterHelpers.DetectEndOfLine(root) + GetIndentation(sourceText, statement, previousStatement);
+        var replacementSpan = TextSpan.FromBounds(previousToken.Span.End, statement.Span.Start);
 
         return document.WithText(sourceText.Replace(replacementSpan, replacementText));
+    }
+
+    /// <summary>
+    /// Gets the exact indentation from the containing statement list when it is available
+    /// </summary>
+    /// <param name="sourceText">Source text</param>
+    /// <param name="statement">Statement to move</param>
+    /// <param name="previousStatement">Previous statement in the containing list</param>
+    /// <returns>The indentation to place before the moved statement</returns>
+    private static string GetIndentation(SourceText sourceText, StatementSyntax statement, StatementSyntax previousStatement)
+    {
+        var previousLine = sourceText.Lines.GetLineFromPosition(previousStatement.SpanStart);
+        var indentation = FormattingTextAnalysisUtilities.GetLeadingWhitespace(FormattingTextAnalysisUtilities.GetLineText(sourceText, previousLine));
+
+        if (statement.Parent is BlockSyntax
+            || previousLine.Start + indentation.Length == previousStatement.SpanStart)
+        {
+            return indentation;
+        }
+
+        var indentationColumn = SyntaxIndentationUtilities.ComputeStatementIndentLevel(statement) * SyntaxIndentationUtilities.IndentSize;
+
+        return new string(' ', indentationColumn);
     }
 
     /// <summary>
@@ -69,6 +98,30 @@ public class RH5103CodeMustNotContainMultipleStatementsOnOneLineCodeFixProvider 
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Determines whether the selected statement has a directly editable leading gap
+    /// </summary>
+    /// <param name="root">Syntax root</param>
+    /// <param name="statement">Selected statement</param>
+    /// <param name="previousStatement">Previous analyzed non-empty statement</param>
+    /// <returns><see langword="true"/> if only formatting trivia separates the statements; otherwise, <see langword="false"/></returns>
+    private static bool HasEditableLeadingGap(SyntaxNode root, StatementSyntax statement, StatementSyntax previousStatement)
+    {
+        var previousToken = statement.GetFirstToken().GetPreviousToken(includeZeroWidth: true, includeSkipped: true);
+
+        if (previousToken.Parent?.FirstAncestorOrSelf<StatementSyntax>() != previousStatement)
+        {
+            return false;
+        }
+
+        var gap = TextSpan.FromBounds(previousStatement.Span.End, statement.Span.Start);
+
+        return root.SyntaxTree.GetDiagnostics().Any(diagnostic => diagnostic.Location.SourceSpan.IntersectsWith(gap)) == false
+               && root.SyntaxTree.GetText()
+                                 .ToString(gap)
+                                 .All(static character => character is ' ' or '\t');
     }
 
     #endregion // Methods
@@ -105,14 +158,13 @@ public class RH5103CodeMustNotContainMultipleStatementsOnOneLineCodeFixProvider 
 
             var previousStatement = GetPreviousStatement(statement);
 
-            if (previousStatement == null
-                || SyntaxNodeUtilities.SpanContainsComment(root, TextSpan.FromBounds(previousStatement.Span.End, statement.Span.Start)))
+            if (previousStatement == null || HasEditableLeadingGap(root, statement, previousStatement) == false)
             {
                 continue;
             }
 
             context.RegisterCodeFix(CodeAction.Create(CodeFixResources.RH5103Title,
-                                                      token => ApplyCodeFixAsync(context.Document, statement, previousStatement, token),
+                                                      token => ApplyCodeFixAsync(context.Document, statement, token),
                                                       nameof(RH5103CodeMustNotContainMultipleStatementsOnOneLineCodeFixProvider)),
                                     diagnostic);
         }

--- a/Reihitsu.Analyzer.Test/Clarity/RH3001NotOperatorShouldNotBeUsedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Clarity/RH3001NotOperatorShouldNotBeUsedAnalyzerTests.cs
@@ -236,5 +236,38 @@ public class RH3001NotOperatorShouldNotBeUsedAnalyzerTests : AnalyzerTestsBase<R
         await Verify(testCode, fixedCode, Diagnostics(RH3001NotOperatorShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH3001MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies a comment between a not operator and its operand survives the code fix
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task Issue469CommentBetweenNotOperatorAndOperandIsPreserved()
+    {
+        const string testCode = """
+                                public class Test
+                                {
+                                    private bool _field;
+
+                                    public bool GetField()
+                                    {
+                                        return {|#0:!|} /* Keep. */ _field;
+                                    }
+                                }
+                                """;
+        const string fixedCode = """
+                                 public class Test
+                                 {
+                                     private bool _field;
+
+                                     public bool GetField()
+                                     {
+                                         return /* Keep. */ _field == false;
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH3001NotOperatorShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH3001MessageFormat));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Clarity/RH3001NotOperatorShouldNotBeUsedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Clarity/RH3001NotOperatorShouldNotBeUsedAnalyzerTests.cs
@@ -318,7 +318,7 @@ public class RH3001NotOperatorShouldNotBeUsedAnalyzerTests : AnalyzerTestsBase<R
                                 {
                                     public bool GetField()
                                     {
-                                        return !(
+                                        return {|#0:!|}(
                                 #if FEATURE
                                             true /* enabled branch */
                                 #else
@@ -329,21 +329,33 @@ public class RH3001NotOperatorShouldNotBeUsedAnalyzerTests : AnalyzerTestsBase<R
                                 }
                                 """;
 
-        var actions = await GetCodeFixActionsAsync(testCode,
-                                                   RH3001NotOperatorShouldNotBeUsedAnalyzer.DiagnosticId,
-                                                   root => root.DescendantNodes().OfType<PrefixUnaryExpressionSyntax>().Single().OperatorToken.GetLocation(),
-                                                   "FEATURE");
+        const string fixedCode = """
+                                 public class Test
+                                 {
+                                     public bool GetField()
+                                     {
+                                         return (
+                                 #if FEATURE
+                                             true /* enabled branch */
+                                 #else
+                                             false /* disabled branch */
+                                 #endif
+                                         ) == false;
+                                     }
+                                 }
+                                 """;
 
-        Assert.HasCount(1, actions);
+        await Verify(testCode,
+                     fixedCode,
+                     static test => test.SolutionTransforms.Add(static (solution, projectId) =>
+                                                                       {
+                                                                           var project = solution.GetProject(projectId);
 
-        var fixedCode = await ApplyCodeFixAsync(testCode, "FEATURE");
-
-        Assert.Contains("== false", fixedCode);
-        Assert.AreEqual(1, fixedCode.Split("#if FEATURE").Length - 1);
-        Assert.AreEqual(1, fixedCode.Split("#else").Length - 1);
-        Assert.AreEqual(1, fixedCode.Split("#endif").Length - 1);
-        Assert.AreEqual(1, fixedCode.Split("true /* enabled branch */").Length - 1);
-        Assert.AreEqual(1, fixedCode.Split("false /* disabled branch */").Length - 1);
+                                                                           return project?.ParseOptions is Microsoft.CodeAnalysis.CSharp.CSharpParseOptions parseOptions
+                                                                                      ? solution.WithProjectParseOptions(projectId, parseOptions.WithPreprocessorSymbols("FEATURE"))
+                                                                                      : solution;
+                                                                       }),
+                     Diagnostics(RH3001NotOperatorShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH3001MessageFormat));
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer.Test/Clarity/RH3001NotOperatorShouldNotBeUsedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Clarity/RH3001NotOperatorShouldNotBeUsedAnalyzerTests.cs
@@ -1,5 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
 
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Reihitsu.Analyzer.CodeFixes.Rules.Clarity;
@@ -267,6 +269,136 @@ public class RH3001NotOperatorShouldNotBeUsedAnalyzerTests : AnalyzerTestsBase<R
                                  """;
 
         await Verify(testCode, fixedCode, Diagnostics(RH3001NotOperatorShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH3001MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies an end-of-line comment between a not operator and its operand survives the code fix
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task EndOfLineCommentBetweenNotOperatorAndOperandIsPreserved()
+    {
+        const string testCode = """
+                                public class Test
+                                {
+                                    private bool _field;
+
+                                    public bool GetField()
+                                    {
+                                        return {|#0:!|} // Keep.
+                                               _field;
+                                    }
+                                }
+                                """;
+        const string fixedCode = """
+                                 public class Test
+                                 {
+                                     private bool _field;
+
+                                     public bool GetField()
+                                     {
+                                         return // Keep.
+                                                _field == false;
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testCode, fixedCode, Diagnostics(RH3001NotOperatorShouldNotBeUsedAnalyzer.DiagnosticId, AnalyzerResources.RH3001MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies directives and disabled text nested inside an operand do not suppress a fix for a clean operator gap
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task NestedOperandDirectivesRemainAvailableAndArePreserved()
+    {
+        const string testCode = """
+                                public class Test
+                                {
+                                    public bool GetField()
+                                    {
+                                        return !(
+                                #if FEATURE
+                                            true /* enabled branch */
+                                #else
+                                            false /* disabled branch */
+                                #endif
+                                        );
+                                    }
+                                }
+                                """;
+
+        var actions = await GetCodeFixActionsAsync(testCode,
+                                                   RH3001NotOperatorShouldNotBeUsedAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes().OfType<PrefixUnaryExpressionSyntax>().Single().OperatorToken.GetLocation(),
+                                                   "FEATURE");
+
+        Assert.HasCount(1, actions);
+
+        var fixedCode = await ApplyCodeFixAsync(testCode, "FEATURE");
+
+        Assert.Contains("== false", fixedCode);
+        Assert.AreEqual(1, fixedCode.Split("#if FEATURE").Length - 1);
+        Assert.AreEqual(1, fixedCode.Split("#else").Length - 1);
+        Assert.AreEqual(1, fixedCode.Split("#endif").Length - 1);
+        Assert.AreEqual(1, fixedCode.Split("true /* enabled branch */").Length - 1);
+        Assert.AreEqual(1, fixedCode.Split("false /* disabled branch */").Length - 1);
+    }
+
+    /// <summary>
+    /// Verifies no fix is offered when conditional-compilation trivia separates the not operator and operand
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task FixIsNotOfferedAcrossDirectiveAndDisabledText()
+    {
+        const string testCode = """
+                                public class Test
+                                {
+                                    public bool GetField()
+                                    {
+                                        return !
+                                #if FEATURE
+                                               true
+                                #else
+                                               false
+                                #endif
+                                               ;
+                                    }
+                                }
+                                """;
+
+        var actions = await GetCodeFixActionsAsync(testCode,
+                                                   RH3001NotOperatorShouldNotBeUsedAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes().OfType<PrefixUnaryExpressionSyntax>().Single().OperatorToken.GetLocation(),
+                                                   "FEATURE");
+
+        Assert.IsEmpty(actions);
+    }
+
+    /// <summary>
+    /// Verifies no fix is offered when skipped syntax separates the not operator and operand
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task FixIsNotOfferedAcrossSkippedSyntax()
+    {
+        const string testCode = """
+                                public class Test
+                                {
+                                    public bool GetField(bool value)
+                                    {
+                                        return ! @ value;
+                                    }
+                                }
+                                """;
+
+        var actions = await GetCodeFixActionsAsync(testCode,
+                                                   RH3001NotOperatorShouldNotBeUsedAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes().OfType<PrefixUnaryExpressionSyntax>().Single().OperatorToken.GetLocation());
+
+        Assert.IsEmpty(actions);
     }
 
     #endregion // Tests

--- a/Reihitsu.Analyzer.Test/Formatting/RH5011BreakStatementsShouldBeFollowedByABlankLineAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH5011BreakStatementsShouldBeFollowedByABlankLineAnalyzerTests.cs
@@ -199,5 +199,35 @@ public class RH5011BreakStatementsShouldBeFollowedByABlankLineAnalyzerTests : An
         await Verify(testCode);
     }
 
+    /// <summary>
+    /// Verifies a same-line following statement is split before a blank line is added after a break statement
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task Issue469SameLineBreakFixSeparatesAndConverges()
+    {
+        const string testCode = """
+                                internal class RH5011
+                                {
+                                    public void Execute()
+                                    {
+                                        while (true)
+                                        {
+                                            break; Consume();
+                                        }
+                                    }
+
+                                    private void Consume()
+                                    {
+                                    }
+                                }
+                                """;
+
+        var onceFixed = await ApplyCodeFixAsync(testCode);
+        var twiceFixed = await ApplyCodeFixAsync(onceFixed);
+
+        Assert.AreEqual(onceFixed, twiceFixed);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatting/RH5011BreakStatementsShouldBeFollowedByABlankLineAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH5011BreakStatementsShouldBeFollowedByABlankLineAnalyzerTests.cs
@@ -1,5 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
 
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Reihitsu.Analyzer.CodeFixes.Rules.Layout;
@@ -213,7 +215,7 @@ public class RH5011BreakStatementsShouldBeFollowedByABlankLineAnalyzerTests : An
                                     {
                                         while (true)
                                         {
-                                            break; Consume();
+                                            {|#0:break|}; Consume();
                                         }
                                     }
 
@@ -223,10 +225,144 @@ public class RH5011BreakStatementsShouldBeFollowedByABlankLineAnalyzerTests : An
                                 }
                                 """;
 
-        var onceFixed = await ApplyCodeFixAsync(testCode);
-        var twiceFixed = await ApplyCodeFixAsync(onceFixed);
+        const string fixedCode = """
+                                 internal class RH5011
+                                 {
+                                     public void Execute()
+                                     {
+                                         while (true)
+                                         {
+                                             break;
 
-        Assert.AreEqual(onceFixed, twiceFixed);
+                                             Consume();
+                                         }
+                                     }
+
+                                     private void Consume()
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testCode,
+                     fixedCode,
+                     Diagnostics(RH5011BreakStatementsShouldBeFollowedByABlankLineAnalyzer.DiagnosticId, AnalyzerResources.RH5011MessageFormat));
+
+        var crlfFixed = await ApplyCodeFixAsync(NormalizeToCarriageReturnLineFeed(testCode.Replace("{|#0:", string.Empty).Replace("|}", string.Empty)));
+
+        Assert.Contains("break;\r\n\r\n            Consume();", crlfFixed);
+        Assert.DoesNotContain("\n", crlfFixed.Replace("\r\n", string.Empty));
+    }
+
+    /// <summary>
+    /// Verifies a same-line split preserves the break line's exact tab indentation and converges
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task SameLineFixPreservesExactTabIndentationAndConverges()
+    {
+        const string testCode = "internal class RH5011\n{\n\tpublic void Execute()\n\t{\n\t\twhile (true)\n\t\t{\n\t\t\t{|#0:break|}; Consume();\n\t\t}\n\t}\n\n\tprivate void Consume()\n\t{\n\t}\n}";
+        const string fixedCode = "internal class RH5011\n{\n\tpublic void Execute()\n\t{\n\t\twhile (true)\n\t\t{\n\t\t\tbreak;\n\n\t\t\tConsume();\n\t\t}\n\t}\n\n\tprivate void Consume()\n\t{\n\t}\n}";
+
+        await Verify(testCode,
+                     fixedCode,
+                     Diagnostics(RH5011BreakStatementsShouldBeFollowedByABlankLineAnalyzer.DiagnosticId, AnalyzerResources.RH5011MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies separate-line insertion preserves CRLF and converges after one application
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task SeparateLineFixPreservesCarriageReturnLineFeedAndConverges()
+    {
+        const string testCode = """
+                                internal class RH5011
+                                {
+                                    public void Execute()
+                                    {
+                                        while (true)
+                                        {
+                                            break;
+                                            Consume();
+                                        }
+                                    }
+
+                                    private void Consume()
+                                    {
+                                    }
+                                }
+                                """;
+
+        var onceFixed = await ApplyCodeFixAsync(NormalizeToCarriageReturnLineFeed(testCode));
+
+        Assert.Contains("break;\r\n\r\n", onceFixed);
+        Assert.DoesNotContain("\n", onceFixed.Replace("\r\n", string.Empty));
+    }
+
+    /// <summary>
+    /// Verifies a same-line fix is withheld when the inter-statement gap contains a comment
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task SameLineFixIsNotOfferedAcrossComment()
+    {
+        const string testCode = """
+                                internal class RH5011
+                                {
+                                    public void Execute()
+                                    {
+                                        while (true)
+                                        {
+                                            break; /* Keep. */ Consume();
+                                        }
+                                    }
+
+                                    private void Consume()
+                                    {
+                                    }
+                                }
+                                """;
+
+        var actions = await GetCodeFixActionsAsync(testCode,
+                                                   RH5011BreakStatementsShouldBeFollowedByABlankLineAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes().OfType<BreakStatementSyntax>().Single().BreakKeyword.GetLocation());
+
+        Assert.IsEmpty(actions);
+    }
+
+    /// <summary>
+    /// Verifies a same-line fix is withheld when the gap contains directive or skipped syntax
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task SameLineFixIsNotOfferedAcrossDirectiveAndSkippedSyntax()
+    {
+        const string testCode = """
+                                internal class RH5011
+                                {
+                                    public void Execute()
+                                    {
+                                        while (true)
+                                        {
+                                            break; #if FEATURE
+                                            Consume();
+                                            #endif
+                                        }
+                                    }
+
+                                    private void Consume()
+                                    {
+                                    }
+                                }
+                                """;
+
+        var actions = await GetCodeFixActionsAsync(testCode,
+                                                   RH5011BreakStatementsShouldBeFollowedByABlankLineAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes().OfType<BreakStatementSyntax>().Single().BreakKeyword.GetLocation(),
+                                                   "FEATURE");
+
+        Assert.IsEmpty(actions);
     }
 
     #endregion // Tests

--- a/Reihitsu.Analyzer.Test/Formatting/RH5011BreakStatementsShouldBeFollowedByABlankLineAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH5011BreakStatementsShouldBeFollowedByABlankLineAnalyzerTests.cs
@@ -293,6 +293,45 @@ public class RH5011BreakStatementsShouldBeFollowedByABlankLineAnalyzerTests : An
                                     }
                                 }
                                 """;
+        const string markedTestCode = """
+                                      internal class RH5011
+                                      {
+                                          public void Execute()
+                                          {
+                                              while (true)
+                                              {
+                                                  {|#0:break|};
+                                                  Consume();
+                                              }
+                                          }
+
+                                          private void Consume()
+                                          {
+                                          }
+                                      }
+                                      """;
+        const string fixedCode = """
+                                 internal class RH5011
+                                 {
+                                     public void Execute()
+                                     {
+                                         while (true)
+                                         {
+                                             break;
+
+                                             Consume();
+                                         }
+                                     }
+
+                                     private void Consume()
+                                     {
+                                     }
+                                 }
+                                 """;
+
+        await Verify(NormalizeToCarriageReturnLineFeed(markedTestCode),
+                     NormalizeToCarriageReturnLineFeed(fixedCode),
+                     Diagnostics(RH5011BreakStatementsShouldBeFollowedByABlankLineAnalyzer.DiagnosticId, AnalyzerResources.RH5011MessageFormat));
 
         var onceFixed = await ApplyCodeFixAsync(NormalizeToCarriageReturnLineFeed(testCode));
 

--- a/Reihitsu.Analyzer.Test/Formatting/RH5103CodeMustNotContainMultipleStatementsOnOneLineAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH5103CodeMustNotContainMultipleStatementsOnOneLineAnalyzerTests.cs
@@ -121,5 +121,39 @@ public class RH5103CodeMustNotContainMultipleStatementsOnOneLineAnalyzerTests : 
         Assert.DoesNotContain("\n", fixedSource.Replace("\r\n", string.Empty));
     }
 
+    /// <summary>
+    /// Verifies a three-statement same-line chain is rewritten with block indentation
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task Issue469ThreeStatementChainFixAllKeepsBlockIndentation()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method()
+                                    {
+                                        int first = 1; {|#0:int second = 2;|} {|#1:int third = 3;|}
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     void Method()
+                                     {
+                                         int first = 1;
+                                         int second = 2;
+                                         int third = 3;
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData,
+                     fixedData,
+                     static config => config.NumberOfFixAllIterations = 1,
+                     Diagnostics(RH5103CodeMustNotContainMultipleStatementsOnOneLineAnalyzer.DiagnosticId, AnalyzerResources.RH5103MessageFormat, 2));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatting/RH5103CodeMustNotContainMultipleStatementsOnOneLineAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH5103CodeMustNotContainMultipleStatementsOnOneLineAnalyzerTests.cs
@@ -155,5 +155,118 @@ public class RH5103CodeMustNotContainMultipleStatementsOnOneLineAnalyzerTests : 
                      Diagnostics(RH5103CodeMustNotContainMultipleStatementsOnOneLineAnalyzer.DiagnosticId, AnalyzerResources.RH5103MessageFormat, 2));
     }
 
+    /// <summary>
+    /// Verifies a block statement chain preserves the source line's exact tab indentation
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task TabIndentedBlockChainFixAllPreservesExactIndentation()
+    {
+        const string testData = "internal class TestClass\n{\n\tvoid Method()\n\t{\n\t\tint first = 1; {|#0:int second = 2;|} {|#1:int third = 3;|}\n\t}\n}";
+        const string fixedData = "internal class TestClass\n{\n\tvoid Method()\n\t{\n\t\tint first = 1;\n\t\tint second = 2;\n\t\tint third = 3;\n\t}\n}";
+
+        await Verify(testData,
+                     fixedData,
+                     static config => config.NumberOfFixAllIterations = 1,
+                     Diagnostics(RH5103CodeMustNotContainMultipleStatementsOnOneLineAnalyzer.DiagnosticId, AnalyzerResources.RH5103MessageFormat, 2));
+    }
+
+    /// <summary>
+    /// Verifies a switch-section statement chain is rewritten with the section statement indentation
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task ThreeStatementSwitchSectionFixAllKeepsSectionIndentation()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method(int value)
+                                    {
+                                        switch (value)
+                                        {
+                                            case 0: Method(1); {|#0:Method(2);|} {|#1:break;|}
+                                        }
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     void Method(int value)
+                                     {
+                                         switch (value)
+                                         {
+                                             case 0: Method(1);
+                                                 Method(2);
+                                                 break;
+                                         }
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData,
+                     fixedData,
+                     static config => config.NumberOfFixAllIterations = 1,
+                     Diagnostics(RH5103CodeMustNotContainMultipleStatementsOnOneLineAnalyzer.DiagnosticId, AnalyzerResources.RH5103MessageFormat, 2));
+    }
+
+    /// <summary>
+    /// Verifies a fix is withheld when an empty statement lies between the analyzed non-empty siblings
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task FixIsNotOfferedAcrossEmptyStatementSyntax()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method()
+                                    {
+                                        Method(); ; Method();
+                                    }
+                                }
+                                """;
+
+        var actions = await GetCodeFixActionsAsync(testData,
+                                                   RH5103CodeMustNotContainMultipleStatementsOnOneLineAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<ExpressionStatementSyntax>()
+                                                               .Last()
+                                                               .GetLocation());
+
+        Assert.IsEmpty(actions);
+    }
+
+    /// <summary>
+    /// Verifies a fix is withheld when a directive and skipped syntax occupy the selected statement's leading gap
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task FixIsNotOfferedAcrossDirectiveAndSkippedSyntax()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method()
+                                    {
+                                        Method(); #if FEATURE
+                                        Method();
+                                        #endif
+                                    }
+                                }
+                                """;
+
+        var actions = await GetCodeFixActionsAsync(testData,
+                                                   RH5103CodeMustNotContainMultipleStatementsOnOneLineAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<ExpressionStatementSyntax>()
+                                                               .Last()
+                                                               .GetLocation(),
+                                                   "FEATURE");
+
+        Assert.IsEmpty(actions);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Naming/RH4115LocalVariableCasingAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Naming/RH4115LocalVariableCasingAnalyzerTests.cs
@@ -588,9 +588,81 @@ public class RH4115LocalVariableCasingAnalyzerTests : AnalyzerTestsBase<RH4115Lo
                                 }
                                 """;
 
-        var fixedSource = await ApplyCodeFixAsync(testCode);
+        var actions = await GetCodeFixActionsAsync(testCode,
+                                                   RH4115LocalVariableCasingAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<VariableDeclaratorSyntax>()
+                                                               .Single(declarator => declarator.Identifier.ValueText == "BadName")
+                                                               .Identifier
+                                                               .GetLocation());
 
-        Assert.DoesNotContain("int badName = 1;", fixedSource);
+        Assert.IsEmpty(actions);
+    }
+
+    /// <summary>
+    /// Verifies collisions are refused for each declaration-node form supported by RH4115
+    /// </summary>
+    /// <param name="declaration">Declaration that would collide with the enclosing local</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    [DataRow("foreach (var BadName in new int[0]) { }")]
+    [DataRow("if (new object() is int BadName) { }")]
+    [DataRow("try { } catch (System.Exception BadName) { }")]
+    public async Task CollisionIsRefusedForSupportedLocalDeclarationForms(string declaration)
+    {
+        var testCode = $$"""
+                         internal class TestClass
+                         {
+                             void Method()
+                             {
+                                 int badName = 0;
+                                 {{declaration}}
+                             }
+                         }
+                         """;
+
+        var actions = await GetCodeFixActionsAsync(testCode,
+                                                   RH4115LocalVariableCasingAnalyzer.DiagnosticId,
+                                                   root => root.DescendantTokens()
+                                                               .Single(token => token.ValueText == "BadName")
+                                                               .GetLocation());
+
+        Assert.IsEmpty(actions);
+    }
+
+    /// <summary>
+    /// Verifies multiple colliding diagnostics are refused independently
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task MultipleCollidingDiagnosticsAreRefusedIndependently()
+    {
+        const string testCode = """
+                                internal class TestClass
+                                {
+                                    void Method()
+                                    {
+                                        int firstName = 0;
+                                        int secondName = 0;
+
+                                        {
+                                            int FirstName = 1;
+                                            int SecondName = 2;
+                                        }
+                                    }
+                                }
+                                """;
+
+        foreach (var identifier in new[] { "FirstName", "SecondName" })
+        {
+            var actions = await GetCodeFixActionsAsync(testCode,
+                                                       RH4115LocalVariableCasingAnalyzer.DiagnosticId,
+                                                       root => root.DescendantTokens()
+                                                                   .Single(token => token.ValueText == identifier)
+                                                                   .GetLocation());
+
+            Assert.IsEmpty(actions);
+        }
     }
 
     #endregion // Tests

--- a/Reihitsu.Analyzer.Test/Naming/RH4115LocalVariableCasingAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Naming/RH4115LocalVariableCasingAnalyzerTests.cs
@@ -800,6 +800,133 @@ public class RH4115LocalVariableCasingAnalyzerTests : AnalyzerTestsBase<RH4115Lo
     }
 
     /// <summary>
+    /// Verifies a top-level type rename is refused when the normalized target exists in another document
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task TopLevelTypeCollisionAcrossDocumentsIsRefused()
+    {
+        const string source = "internal class badName { }";
+        const string conflictingSource = "internal class BadName { }";
+
+        var (actionCount, fixedSources, postFixAnalyzerDiagnostics, compilerErrors) = await ApplyOrdinaryFixAcrossDocumentsAsync(new RH4002ClassNameCasingAnalyzer(),
+                                                                                                                                 new RH4002ClassNameCasingCodeFixProvider(),
+                                                                                                                                 source,
+                                                                                                                                 conflictingSource);
+
+        Assert.AreEqual(0, actionCount);
+        Assert.AreSequenceEqual(new[] { source, conflictingSource }, fixedSources);
+        Assert.HasCount(1, postFixAnalyzerDiagnostics);
+        Assert.IsEmpty(compilerErrors);
+    }
+
+    /// <summary>
+    /// Verifies an unrelated compiler error in another document does not suppress a safe top-level type rename
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task TopLevelTypeRenameIgnoresUnrelatedDocumentError()
+    {
+        const string source = "internal class badName { }";
+        const string unrelatedErrorSource = "internal class Broken { MissingType Value; }";
+
+        var (actionCount, fixedSources, postFixAnalyzerDiagnostics, compilerErrors) = await ApplyOrdinaryFixAcrossDocumentsAsync(new RH4002ClassNameCasingAnalyzer(),
+                                                                                                                                 new RH4002ClassNameCasingCodeFixProvider(),
+                                                                                                                                 source,
+                                                                                                                                 unrelatedErrorSource);
+
+        Assert.AreEqual(1, actionCount);
+        Assert.AreSequenceEqual(new[] { "internal class BadName { }", unrelatedErrorSource }, fixedSources);
+        Assert.IsEmpty(postFixAnalyzerDiagnostics);
+        Assert.HasCount(1, compilerErrors);
+        Assert.AreEqual("CS0246", compilerErrors[0].Id);
+    }
+
+    /// <summary>
+    /// Verifies top-level types with the same normalized name but different arity can coexist
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task TopLevelTypeRenameAllowsDifferentArity()
+    {
+        const string source = "internal class badName<T> { }";
+        const string differentAritySource = "internal class BadName<TFirst, TSecond> { }";
+
+        var (actionCount, fixedSources, postFixAnalyzerDiagnostics, compilerErrors) = await ApplyOrdinaryFixAcrossDocumentsAsync(new RH4002ClassNameCasingAnalyzer(),
+                                                                                                                                 new RH4002ClassNameCasingCodeFixProvider(),
+                                                                                                                                 source,
+                                                                                                                                 differentAritySource);
+
+        Assert.AreEqual(1, actionCount);
+        Assert.AreSequenceEqual(new[] { "internal class BadName<T> { }", differentAritySource }, fixedSources);
+        Assert.IsEmpty(postFixAnalyzerDiagnostics);
+        Assert.IsEmpty(compilerErrors);
+    }
+
+    /// <summary>
+    /// Verifies a file-local type with the normalized target in another document does not create a collision
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task TopLevelTypeRenameAllowsFileLocalTargetInAnotherDocument()
+    {
+        const string source = "internal class badName { }";
+        const string fileLocalSource = "file class BadName { }";
+
+        var (actionCount, fixedSources, postFixAnalyzerDiagnostics, compilerErrors) = await ApplyOrdinaryFixAcrossDocumentsAsync(new RH4002ClassNameCasingAnalyzer(),
+                                                                                                                                 new RH4002ClassNameCasingCodeFixProvider(),
+                                                                                                                                 source,
+                                                                                                                                 fileLocalSource);
+
+        Assert.AreEqual(1, actionCount);
+        Assert.AreSequenceEqual(new[] { "internal class BadName { }", fileLocalSource }, fixedSources);
+        Assert.IsEmpty(postFixAnalyzerDiagnostics);
+        Assert.IsEmpty(compilerErrors);
+    }
+
+    /// <summary>
+    /// Verifies a top-level type rename is refused when its normalized target is an existing namespace
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task TopLevelTypeRenameToNamespaceAcrossDocumentsIsRefused()
+    {
+        const string source = "internal class badName { }";
+        const string conflictingSource = "namespace BadName { internal class SecondClass { } }";
+
+        var (actionCount, fixedSources, postFixAnalyzerDiagnostics, compilerErrors) = await ApplyOrdinaryFixAcrossDocumentsAsync(new RH4002ClassNameCasingAnalyzer(),
+                                                                                                                                 new RH4002ClassNameCasingCodeFixProvider(),
+                                                                                                                                 source,
+                                                                                                                                 conflictingSource);
+
+        Assert.AreEqual(0, actionCount);
+        Assert.AreSequenceEqual(new[] { source, conflictingSource }, fixedSources);
+        Assert.HasCount(1, postFixAnalyzerDiagnostics);
+        Assert.IsEmpty(compilerErrors);
+    }
+
+    /// <summary>
+    /// Verifies Project Fix All refuses a cross-document top-level type collision
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task TopLevelTypeCollisionAcrossDocumentsIsRefusedByProjectFixAll()
+    {
+        const string source = "internal class badName { }";
+        const string conflictingSource = "internal class BadName { }";
+
+        var (fixedSources, initialAnalyzerDiagnostics, postFixAnalyzerDiagnostics, compilerErrors) = await ApplyFixAllAcrossDocumentsAsync(new RH4002ClassNameCasingAnalyzer(),
+                                                                                                                                           new RH4002ClassNameCasingCodeFixProvider(),
+                                                                                                                                           source,
+                                                                                                                                           conflictingSource);
+
+        Assert.HasCount(1, initialAnalyzerDiagnostics);
+        Assert.AreSequenceEqual(new[] { source, conflictingSource }, fixedSources);
+        Assert.HasCount(1, postFixAnalyzerDiagnostics);
+        Assert.IsEmpty(compilerErrors);
+    }
+
+    /// <summary>
     /// Verifies a local-variable casing fix does not introduce a duplicate declaration in a nested block
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
@@ -1226,6 +1353,169 @@ public class RH4115LocalVariableCasingAnalyzerTests : AnalyzerTestsBase<RH4115Lo
                     initialAnalyzerDiagnostics.ToImmutable(),
                     postFixAnalyzerDiagnostics.ToImmutable(),
                     compilerErrors.ToImmutable());
+        }
+    }
+
+    /// <summary>
+    /// Applies an ordinary code fix to the first diagnostic in a multi-document project
+    /// </summary>
+    /// <param name="analyzer">Analyzer that reports the target diagnostic</param>
+    /// <param name="provider">Code fix provider</param>
+    /// <param name="sources">Project source documents</param>
+    /// <returns>The action count, resulting sources, post-fix analyzer diagnostics, and compiler errors</returns>
+    private static async Task<(int ActionCount,
+    ImmutableArray<string> FixedSources,
+    ImmutableArray<Diagnostic> PostFixAnalyzerDiagnostics,
+    ImmutableArray<Diagnostic> CompilerErrors)> ApplyOrdinaryFixAcrossDocumentsAsync(DiagnosticAnalyzer analyzer,
+                                                                                     CodeFixProvider provider,
+                                                                                     params string[] sources)
+    {
+        using (var workspace = new AdhocWorkspace())
+        {
+            var projectId = ProjectId.CreateNewId();
+            var documentIds = ImmutableArray.CreateBuilder<DocumentId>();
+            var solution = workspace.CurrentSolution
+                                    .AddProject(projectId, "TestProject", "TestProject", LanguageNames.CSharp)
+                                    .WithProjectCompilationOptions(projectId, new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+                                    .AddMetadataReferences(projectId, GetMetadataReferences());
+
+            for (var index = 0; index < sources.Length; index++)
+            {
+                var documentId = DocumentId.CreateNewId(projectId);
+
+                documentIds.Add(documentId);
+                solution = solution.AddDocument(documentId, $"Test{index}.cs", SourceText.From(sources[index]));
+            }
+
+            var project = solution.GetProject(projectId)
+                              ?? throw new InvalidOperationException("Failed to create test project.");
+            var compilation = await project.GetCompilationAsync(CancellationToken.None).ConfigureAwait(false)
+                                  ?? throw new InvalidOperationException("Failed to compile test project.");
+            var analyzerDiagnostics = await compilation.WithAnalyzers(ImmutableArray.Create(analyzer))
+                                                       .GetAnalyzerDiagnosticsAsync(CancellationToken.None)
+                                                       .ConfigureAwait(false);
+            var diagnostic = analyzerDiagnostics.Single(item => item.Location.SourceTree != null
+                                                                && solution.GetDocument(item.Location.SourceTree)?.Id == documentIds[0]);
+            var initiatingDocument = solution.GetDocument(documentIds[0])
+                                         ?? throw new InvalidOperationException("Failed to get initiating document.");
+            var actions = new List<CodeAction>();
+            var context = new CodeFixContext(initiatingDocument,
+                                             diagnostic,
+                                             (action, _) => actions.Add(action),
+                                             CancellationToken.None);
+
+            await provider.RegisterCodeFixesAsync(context).ConfigureAwait(false);
+
+            var fixedSolution = solution;
+
+            if (actions.Count > 0)
+            {
+                var operation = (await actions[0].GetOperationsAsync(CancellationToken.None).ConfigureAwait(false)).OfType<ApplyChangesOperation>()
+                                                                                                                   .Single();
+
+                fixedSolution = operation.ChangedSolution;
+            }
+
+            var fixedProject = fixedSolution.GetProject(projectId)
+                                   ?? throw new InvalidOperationException("Failed to get fixed project.");
+            var fixedCompilation = await fixedProject.GetCompilationAsync(CancellationToken.None).ConfigureAwait(false)
+                                       ?? throw new InvalidOperationException("Failed to compile fixed project.");
+            var fixedSources = ImmutableArray.CreateBuilder<string>();
+
+            foreach (var documentId in documentIds)
+            {
+                var fixedDocument = fixedSolution.GetDocument(documentId)
+                                        ?? throw new InvalidOperationException("Failed to get fixed document.");
+
+                fixedSources.Add((await fixedDocument.GetTextAsync(CancellationToken.None).ConfigureAwait(false)).ToString());
+            }
+
+            var postFixAnalyzerDiagnostics = await fixedCompilation.WithAnalyzers(ImmutableArray.Create(analyzer))
+                                                                   .GetAnalyzerDiagnosticsAsync(CancellationToken.None)
+                                                                   .ConfigureAwait(false);
+            var compilerErrors = fixedCompilation.GetDiagnostics(CancellationToken.None)
+                                                 .Where(static item => item.Severity == DiagnosticSeverity.Error)
+                                                 .ToImmutableArray();
+
+            return (actions.Count, fixedSources.ToImmutable(), postFixAnalyzerDiagnostics, compilerErrors);
+        }
+    }
+
+    /// <summary>
+    /// Applies Project Fix All to every diagnostic in a multi-document project
+    /// </summary>
+    /// <param name="analyzer">Analyzer that reports the target diagnostics</param>
+    /// <param name="provider">Code fix provider</param>
+    /// <param name="sources">Project source documents</param>
+    /// <returns>The resulting sources plus initial/post-fix analyzer diagnostics and compiler errors</returns>
+    private static async Task<(ImmutableArray<string> FixedSources,
+    ImmutableArray<Diagnostic> InitialAnalyzerDiagnostics,
+    ImmutableArray<Diagnostic> PostFixAnalyzerDiagnostics,
+    ImmutableArray<Diagnostic> CompilerErrors)> ApplyFixAllAcrossDocumentsAsync(DiagnosticAnalyzer analyzer,
+                                                                                CodeFixProvider provider,
+                                                                                params string[] sources)
+    {
+        using (var workspace = new AdhocWorkspace())
+        {
+            var projectId = ProjectId.CreateNewId();
+            var documentIds = ImmutableArray.CreateBuilder<DocumentId>();
+            var solution = workspace.CurrentSolution
+                                    .AddProject(projectId, "TestProject", "TestProject", LanguageNames.CSharp)
+                                    .WithProjectCompilationOptions(projectId, new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+                                    .AddMetadataReferences(projectId, GetMetadataReferences());
+
+            for (var index = 0; index < sources.Length; index++)
+            {
+                var documentId = DocumentId.CreateNewId(projectId);
+
+                documentIds.Add(documentId);
+                solution = solution.AddDocument(documentId, $"Test{index}.cs", SourceText.From(sources[index]));
+            }
+
+            var project = solution.GetProject(projectId)
+                              ?? throw new InvalidOperationException("Failed to create test project.");
+            var compilation = await project.GetCompilationAsync(CancellationToken.None).ConfigureAwait(false)
+                                  ?? throw new InvalidOperationException("Failed to compile test project.");
+            var initialAnalyzerDiagnostics = await compilation.WithAnalyzers(ImmutableArray.Create(analyzer))
+                                                              .GetAnalyzerDiagnosticsAsync(CancellationToken.None)
+                                                              .ConfigureAwait(false);
+            var initiatingDocument = solution.GetDocument(documentIds[0])
+                                         ?? throw new InvalidOperationException("Failed to get initiating document.");
+            var context = new FixAllContext(initiatingDocument,
+                                            provider,
+                                            FixAllScope.Project,
+                                            provider.GetType().Name,
+                                            provider.FixableDiagnosticIds,
+                                            new TestFixAllDiagnosticProvider(solution, initialAnalyzerDiagnostics),
+                                            CancellationToken.None);
+            var action = await provider.GetFixAllProvider()
+                                       .GetFixAsync(context)
+                                       .ConfigureAwait(false)
+                             ?? throw new InvalidOperationException("Failed to create the Fix All action.");
+            var operation = (await action.GetOperationsAsync(CancellationToken.None).ConfigureAwait(false)).OfType<ApplyChangesOperation>()
+                                                                                                           .Single();
+            var fixedProject = operation.ChangedSolution.GetProject(projectId)
+                                   ?? throw new InvalidOperationException("Failed to get fixed project.");
+            var fixedCompilation = await fixedProject.GetCompilationAsync(CancellationToken.None).ConfigureAwait(false)
+                                       ?? throw new InvalidOperationException("Failed to compile fixed project.");
+            var fixedSources = ImmutableArray.CreateBuilder<string>();
+
+            foreach (var documentId in documentIds)
+            {
+                var fixedDocument = operation.ChangedSolution.GetDocument(documentId)
+                                        ?? throw new InvalidOperationException("Failed to get fixed document.");
+
+                fixedSources.Add((await fixedDocument.GetTextAsync(CancellationToken.None).ConfigureAwait(false)).ToString());
+            }
+
+            var postFixAnalyzerDiagnostics = await fixedCompilation.WithAnalyzers(ImmutableArray.Create(analyzer))
+                                                                   .GetAnalyzerDiagnosticsAsync(CancellationToken.None)
+                                                                   .ConfigureAwait(false);
+            var compilerErrors = fixedCompilation.GetDiagnostics(CancellationToken.None)
+                                                 .Where(static item => item.Severity == DiagnosticSeverity.Error)
+                                                 .ToImmutableArray();
+
+            return (fixedSources.ToImmutable(), initialAnalyzerDiagnostics, postFixAnalyzerDiagnostics, compilerErrors);
         }
     }
 

--- a/Reihitsu.Analyzer.Test/Naming/RH4115LocalVariableCasingAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Naming/RH4115LocalVariableCasingAnalyzerTests.cs
@@ -564,6 +564,35 @@ public class RH4115LocalVariableCasingAnalyzerTests : AnalyzerTestsBase<RH4115Lo
         Assert.IsEmpty(actions);
     }
 
+    /// <summary>
+    /// Verifies a local-variable casing fix does not introduce a duplicate declaration in a nested block
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task Issue469LocalRenameDoesNotProduceDuplicateDeclaration()
+    {
+        const string testCode = """
+                                namespace Reihitsu.Analyzer.Test.Naming.Resources
+                                {
+                                    public class DataLoader
+                                    {
+                                        public void Load()
+                                        {
+                                            int badName = 0;
+
+                                            {
+                                                int BadName = 1;
+                                            }
+                                        }
+                                    }
+                                }
+                                """;
+
+        var fixedSource = await ApplyCodeFixAsync(testCode);
+
+        Assert.DoesNotContain("int badName = 1;", fixedSource);
+    }
+
     #endregion // Tests
 
     #region Methods

--- a/Reihitsu.Analyzer.Test/Naming/RH4115LocalVariableCasingAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Naming/RH4115LocalVariableCasingAnalyzerTests.cs
@@ -1,7 +1,18 @@
-﻿using System.Linq;
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Reihitsu.Analyzer.CodeFixes.Rules.Naming;
@@ -565,6 +576,89 @@ public class RH4115LocalVariableCasingAnalyzerTests : AnalyzerTestsBase<RH4115Lo
     }
 
     /// <summary>
+    /// Verifies an unrelated compiler error elsewhere in the document does not suppress a safe rename
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task UnrelatedDocumentCompilerErrorDoesNotSuppressSafeRename()
+    {
+        const string testCode = """
+                                internal class TestClass
+                                {
+                                    MissingType ExistingError;
+
+                                    void Method()
+                                    {
+                                        int BadName = 1;
+                                    }
+                                }
+                                """;
+
+        var actions = await GetCodeFixActionsAsync(testCode,
+                                                   RH4115LocalVariableCasingAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<VariableDeclaratorSyntax>()
+                                                               .Single(declarator => declarator.Identifier.ValueText == "BadName")
+                                                               .Identifier
+                                                               .GetLocation());
+
+        Assert.HasCount(1, actions);
+    }
+
+    /// <summary>
+    /// Verifies the custom provider retains the three scopes supported by the prior batch provider
+    /// </summary>
+    [TestMethod]
+    public void FixAllProviderSupportsDocumentProjectAndSolutionScopes()
+    {
+        var provider = new RH4115LocalVariableCasingCodeFixProvider();
+        var scopes = provider.GetFixAllProvider().GetSupportedFixAllScopes().ToArray();
+
+        Assert.AreSequenceEqual(new[] { FixAllScope.Document, FixAllScope.Project, FixAllScope.Solution }, scopes);
+    }
+
+    /// <summary>
+    /// Verifies broader Fix All scopes retrieve and apply their aggregate diagnostics
+    /// </summary>
+    /// <param name="scope">Fix All scope</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    [DataRow(FixAllScope.Project)]
+    [DataRow(FixAllScope.Solution)]
+    public async Task BroaderFixAllScopesApplyUniqueRename(FixAllScope scope)
+    {
+        const string testCode = """
+                                internal class TestClass
+                                {
+                                    int Method()
+                                    {
+                                        int BadName = 1;
+
+                                        return BadName;
+                                    }
+                                }
+                                """;
+        const string fixedCode = """
+                                 internal class TestClass
+                                 {
+                                     int Method()
+                                     {
+                                         int badName = 1;
+
+                                         return badName;
+                                     }
+                                 }
+                                 """;
+
+        var (fixedSource, initialAnalyzerDiagnostics, postFixAnalyzerDiagnostics, compilerErrors) = await ApplyFixAllAsync(testCode, scope);
+
+        Assert.HasCount(1, initialAnalyzerDiagnostics);
+        Assert.IsEmpty(postFixAnalyzerDiagnostics);
+        Assert.AreEqual(fixedCode, fixedSource);
+        Assert.IsEmpty(compilerErrors);
+    }
+
+    /// <summary>
     /// Verifies a local-variable casing fix does not introduce a duplicate declaration in a nested block
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
@@ -665,6 +759,130 @@ public class RH4115LocalVariableCasingAnalyzerTests : AnalyzerTestsBase<RH4115Lo
         }
     }
 
+    /// <summary>
+    /// Verifies diagnostics that normalize to one shared target are refused as a group by Fix All
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task DuplicateNormalizedTargetGroupIsRefusedBeforeFixAll()
+    {
+        const string testCode = """
+                                internal class TestClass
+                                {
+                                    void Method()
+                                    {
+                                        int BadName = 1;
+                                        int BAD_NAME = 2;
+                                    }
+                                }
+                                """;
+
+        var (fixedSource, initialAnalyzerDiagnostics, postFixAnalyzerDiagnostics, compilerErrors) = await ApplyFixAllAsync(testCode);
+
+        Assert.HasCount(2, initialAnalyzerDiagnostics);
+        Assert.AreEqual(testCode, fixedSource);
+        Assert.HasCount(2, postFixAnalyzerDiagnostics);
+        Assert.IsEmpty(compilerErrors);
+    }
+
+    /// <summary>
+    /// Verifies equal normalized targets in independent sibling declaration spaces remain fixable together
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task DuplicateNormalizedTargetsInSiblingScopesRemainFixableTogether()
+    {
+        const string testCode = """
+                                internal class TestClass
+                                {
+                                    void Method(bool condition)
+                                    {
+                                        if (condition)
+                                        {
+                                            int BadName = 1;
+                                        }
+
+                                        if (!condition)
+                                        {
+                                            int BAD_NAME = 2;
+                                        }
+                                    }
+                                }
+                                """;
+        const string fixedCode = """
+                                 internal class TestClass
+                                 {
+                                     void Method(bool condition)
+                                     {
+                                         if (condition)
+                                         {
+                                             int badName = 1;
+                                         }
+
+                                         if (!condition)
+                                         {
+                                             int badName = 2;
+                                         }
+                                     }
+                                 }
+                                 """;
+
+        var (fixedSource, initialAnalyzerDiagnostics, postFixAnalyzerDiagnostics, compilerErrors) = await ApplyFixAllAsync(testCode);
+
+        Assert.HasCount(2, initialAnalyzerDiagnostics);
+        Assert.IsEmpty(postFixAnalyzerDiagnostics);
+        Assert.AreEqual(fixedCode, fixedSource);
+        Assert.IsEmpty(compilerErrors);
+    }
+
+    /// <summary>
+    /// Verifies distinct normalized targets remain fixable together in one Fix All iteration
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task UniqueNormalizedTargetsRemainFixableTogether()
+    {
+        const string testCode = """
+                                internal class TestClass
+                                {
+                                    int Method()
+                                    {
+                                        int {|#0:BadName|} = 1;
+                                        int {|#1:OTHER_NAME|} = 2;
+
+                                        return BadName + OTHER_NAME;
+                                    }
+                                }
+                                """;
+        const string fixedCode = """
+                                 internal class TestClass
+                                 {
+                                     int Method()
+                                     {
+                                         int badName = 1;
+                                         int otherName = 2;
+
+                                         return badName + otherName;
+                                     }
+                                 }
+                                 """;
+
+        var plainTestCode = testCode.Replace("{|#0:", string.Empty)
+                                    .Replace("{|#1:", string.Empty)
+                                    .Replace("|}", string.Empty);
+        var (fixedSource, initialAnalyzerDiagnostics, postFixAnalyzerDiagnostics, compilerErrors) = await ApplyFixAllAsync(plainTestCode);
+
+        Assert.HasCount(2, initialAnalyzerDiagnostics);
+        Assert.IsEmpty(postFixAnalyzerDiagnostics);
+        Assert.AreEqual(fixedCode, fixedSource);
+        Assert.IsEmpty(compilerErrors, string.Join(Environment.NewLine, compilerErrors));
+
+        await Verify(testCode,
+                     fixedCode,
+                     static config => config.NumberOfFixAllIterations = 1,
+                     Diagnostics(RH4115LocalVariableCasingAnalyzer.DiagnosticId, AnalyzerResources.RH4115MessageFormat, 2));
+    }
+
     #endregion // Tests
 
     #region Methods
@@ -678,5 +896,135 @@ public class RH4115LocalVariableCasingAnalyzerTests : AnalyzerTestsBase<RH4115Lo
         test.SolutionTransforms.Add(ApplyAllowUnsafeToTestProject);
     }
 
+    /// <summary>
+    /// Applies the provider's requested Fix All action to every supplied analyzer diagnostic
+    /// </summary>
+    /// <param name="source">Source text</param>
+    /// <param name="scope">Fix All scope</param>
+    /// <returns>The fixed source, initial and post-fix analyzer diagnostics, and compiler errors after Fix All</returns>
+    private static async Task<(string FixedSource,
+    ImmutableArray<Diagnostic> InitialAnalyzerDiagnostics,
+    ImmutableArray<Diagnostic> PostFixAnalyzerDiagnostics,
+    ImmutableArray<Diagnostic> CompilerErrors)> ApplyFixAllAsync(string source, FixAllScope scope = FixAllScope.Document)
+    {
+        using (var workspace = new AdhocWorkspace())
+        {
+            var projectId = ProjectId.CreateNewId();
+            var documentId = DocumentId.CreateNewId(projectId);
+            var solution = workspace.CurrentSolution
+                                    .AddProject(projectId, "TestProject", "TestProject", LanguageNames.CSharp)
+                                    .WithProjectCompilationOptions(projectId, new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+                                    .AddMetadataReferences(projectId, GetMetadataReferences())
+                                    .AddDocument(documentId, "Test.cs", SourceText.From(source));
+            var document = solution.GetDocument(documentId)
+                               ?? throw new InvalidOperationException("Failed to create test document.");
+            var compilation = await document.Project.GetCompilationAsync(CancellationToken.None).ConfigureAwait(false)
+                                  ?? throw new InvalidOperationException("Failed to compile test document.");
+            var analyzerDiagnostics = await compilation.WithAnalyzers(ImmutableArray.Create<DiagnosticAnalyzer>(new RH4115LocalVariableCasingAnalyzer()))
+                                                       .GetAnalyzerDiagnosticsAsync(CancellationToken.None)
+                                                       .ConfigureAwait(false);
+            var provider = new RH4115LocalVariableCasingCodeFixProvider();
+            var context = new FixAllContext(document,
+                                            provider,
+                                            scope,
+                                            provider.GetType().Name,
+                                            provider.FixableDiagnosticIds,
+                                            new TestFixAllDiagnosticProvider(analyzerDiagnostics),
+                                            CancellationToken.None);
+            var action = await provider.GetFixAllProvider()
+                                       .GetFixAsync(context)
+                                       .ConfigureAwait(false)
+                             ?? throw new InvalidOperationException("Failed to create the Fix All action.");
+
+            Assert.AreEqual(provider.GetType().Name, action.EquivalenceKey);
+
+            var operation = (await action.GetOperationsAsync(CancellationToken.None).ConfigureAwait(false)).OfType<ApplyChangesOperation>()
+                                                                                                           .Single();
+            var fixedDocument = operation.ChangedSolution.GetDocument(documentId)
+                                    ?? throw new InvalidOperationException("Failed to get the fixed document.");
+            var fixedCompilation = await fixedDocument.Project.GetCompilationAsync(CancellationToken.None).ConfigureAwait(false)
+                                       ?? throw new InvalidOperationException("Failed to compile the fixed document.");
+            var compilerErrors = fixedCompilation.GetDiagnostics(CancellationToken.None)
+                                                 .Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+                                                 .ToImmutableArray();
+            var postFixAnalyzerDiagnostics = await fixedCompilation.WithAnalyzers(ImmutableArray.Create<DiagnosticAnalyzer>(new RH4115LocalVariableCasingAnalyzer()))
+                                                                   .GetAnalyzerDiagnosticsAsync(CancellationToken.None)
+                                                                   .ConfigureAwait(false);
+            var fixedSource = await fixedDocument.GetTextAsync(CancellationToken.None).ConfigureAwait(false);
+
+            return (fixedSource.ToString(), analyzerDiagnostics, postFixAnalyzerDiagnostics, compilerErrors);
+        }
+    }
+
+    /// <summary>
+    /// Gets the platform references needed by the aggregate code-fix document
+    /// </summary>
+    /// <returns>Metadata references</returns>
+    private static IEnumerable<MetadataReference> GetMetadataReferences()
+    {
+        var trustedPlatformAssemblies = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        var referencePaths = trustedPlatformAssemblies?.Split(Path.PathSeparator)
+                                 ?? [];
+
+        return referencePaths.Select(static path => MetadataReference.CreateFromFile(path));
+    }
+
     #endregion // Methods
+
+    #region Types
+
+#pragma warning disable RH2101 // The provider is a focused test adapter owned by this fixture
+    /// <summary>
+    /// Supplies the document diagnostics used by the focused Fix All tests
+    /// </summary>
+    private sealed class TestFixAllDiagnosticProvider : FixAllContext.DiagnosticProvider
+    {
+        #region Fields
+
+        /// <summary>
+        /// Diagnostics
+        /// </summary>
+        private readonly ImmutableArray<Diagnostic> _diagnostics;
+
+        #endregion // Fields
+
+        #region Constructor
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="diagnostics">Diagnostics</param>
+        public TestFixAllDiagnosticProvider(ImmutableArray<Diagnostic> diagnostics)
+        {
+            _diagnostics = diagnostics;
+        }
+
+        #endregion // Constructor
+
+        #region DiagnosticProvider
+
+        /// <inheritdoc/>
+        public override Task<IEnumerable<Diagnostic>> GetDocumentDiagnosticsAsync(Document document, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<IEnumerable<Diagnostic>>(_diagnostics);
+        }
+
+        /// <inheritdoc/>
+        public override Task<IEnumerable<Diagnostic>> GetProjectDiagnosticsAsync(Project project, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<IEnumerable<Diagnostic>>([]);
+        }
+
+        /// <inheritdoc/>
+        public override Task<IEnumerable<Diagnostic>> GetAllDiagnosticsAsync(Project project, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<IEnumerable<Diagnostic>>(_diagnostics);
+        }
+
+        #endregion // DiagnosticProvider
+    }
+
+#pragma warning restore RH2101
+
+    #endregion // Types
 }

--- a/Reihitsu.Analyzer.Test/Naming/RH4115LocalVariableCasingAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Naming/RH4115LocalVariableCasingAnalyzerTests.cs
@@ -606,6 +606,65 @@ public class RH4115LocalVariableCasingAnalyzerTests : AnalyzerTestsBase<RH4115Lo
     }
 
     /// <summary>
+    /// Verifies an existing target in the same declaration space refuses an ordinary action regardless of source order or line ending
+    /// </summary>
+    /// <param name="targetBefore">Whether the existing target precedes the diagnosed declaration</param>
+    /// <param name="carriageReturnLineFeed">Whether the source uses carriage-return/line-feed endings</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    [DataRow(false, false)]
+    [DataRow(false, true)]
+    [DataRow(true, false)]
+    [DataRow(true, true)]
+    public async Task SameScopeExistingTargetRefusesOrdinaryActionInEitherOrder(bool targetBefore, bool carriageReturnLineFeed)
+    {
+        var testCode = CreateSameScopeExistingTargetSource(targetBefore);
+
+        if (carriageReturnLineFeed)
+        {
+            testCode = NormalizeToCarriageReturnLineFeed(testCode);
+        }
+
+        var actions = await GetCodeFixActionsAsync(testCode,
+                                                   RH4115LocalVariableCasingAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<VariableDeclaratorSyntax>()
+                                                               .Single(declarator => declarator.Identifier.ValueText == "BadName")
+                                                               .Identifier
+                                                               .GetLocation());
+
+        Assert.IsEmpty(actions);
+    }
+
+    /// <summary>
+    /// Verifies an existing target in the same declaration space remains unchanged under Fix All regardless of source order or line ending
+    /// </summary>
+    /// <param name="targetBefore">Whether the existing target precedes the diagnosed declaration</param>
+    /// <param name="carriageReturnLineFeed">Whether the source uses carriage-return/line-feed endings</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    [DataRow(false, false)]
+    [DataRow(false, true)]
+    [DataRow(true, false)]
+    [DataRow(true, true)]
+    public async Task SameScopeExistingTargetRemainsUnchangedUnderFixAll(bool targetBefore, bool carriageReturnLineFeed)
+    {
+        var testCode = CreateSameScopeExistingTargetSource(targetBefore);
+
+        if (carriageReturnLineFeed)
+        {
+            testCode = NormalizeToCarriageReturnLineFeed(testCode);
+        }
+
+        var (fixedSource, initialAnalyzerDiagnostics, postFixAnalyzerDiagnostics, compilerErrors) = await ApplyFixAllAsync(testCode);
+
+        Assert.HasCount(1, initialAnalyzerDiagnostics);
+        Assert.AreEqual(testCode, fixedSource);
+        Assert.HasCount(1, postFixAnalyzerDiagnostics);
+        Assert.IsEmpty(compilerErrors);
+    }
+
+    /// <summary>
     /// Verifies the custom provider retains the three scopes supported by the prior batch provider
     /// </summary>
     [TestMethod]
@@ -618,43 +677,125 @@ public class RH4115LocalVariableCasingAnalyzerTests : AnalyzerTestsBase<RH4115Lo
     }
 
     /// <summary>
-    /// Verifies broader Fix All scopes retrieve and apply their aggregate diagnostics
+    /// Verifies Project Fix All retrieves and applies diagnostics from every document in the project
     /// </summary>
-    /// <param name="scope">Fix All scope</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
     [TestMethod]
-    [DataRow(FixAllScope.Project)]
-    [DataRow(FixAllScope.Solution)]
-    public async Task BroaderFixAllScopesApplyUniqueRename(FixAllScope scope)
+    public async Task ProjectFixAllAppliesUniqueRenamesAcrossDocuments()
     {
-        const string testCode = """
-                                internal class TestClass
-                                {
-                                    int Method()
+        const string firstSource = """
+                                   internal class FirstClass
+                                   {
+                                       int Method()
+                                       {
+                                           int BadName = 1;
+
+                                           return BadName;
+                                       }
+                                   }
+                                   """;
+        const string secondSource = """
+                                    internal class SecondClass
                                     {
-                                        int BadName = 1;
+                                        int Method()
+                                        {
+                                            int OTHER_NAME = 2;
 
-                                        return BadName;
+                                            return OTHER_NAME;
+                                        }
                                     }
-                                }
-                                """;
-        const string fixedCode = """
-                                 internal class TestClass
-                                 {
-                                     int Method()
-                                     {
-                                         int badName = 1;
+                                    """;
+        const string firstFixedSource = """
+                                        internal class FirstClass
+                                        {
+                                            int Method()
+                                            {
+                                                int badName = 1;
 
-                                         return badName;
-                                     }
-                                 }
-                                 """;
+                                                return badName;
+                                            }
+                                        }
+                                        """;
+        const string secondFixedSource = """
+                                         internal class SecondClass
+                                         {
+                                             int Method()
+                                             {
+                                                 int otherName = 2;
 
-        var (fixedSource, initialAnalyzerDiagnostics, postFixAnalyzerDiagnostics, compilerErrors) = await ApplyFixAllAsync(testCode, scope);
+                                                 return otherName;
+                                             }
+                                         }
+                                         """;
 
-        Assert.HasCount(1, initialAnalyzerDiagnostics);
+        var (fixedSources, initialAnalyzerDiagnostics, postFixAnalyzerDiagnostics, compilerErrors) = await ApplyFixAllAcrossSolutionAsync(FixAllScope.Project,
+                                                                                                                                          [firstSource, secondSource]);
+
+        Assert.HasCount(2, initialAnalyzerDiagnostics);
+        Assert.AreSequenceEqual(new[] { firstFixedSource, secondFixedSource }, fixedSources);
         Assert.IsEmpty(postFixAnalyzerDiagnostics);
-        Assert.AreEqual(fixedCode, fixedSource);
+        Assert.IsEmpty(compilerErrors);
+    }
+
+    /// <summary>
+    /// Verifies Solution Fix All retrieves and applies diagnostics from every project in the solution
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task SolutionFixAllAppliesUniqueRenamesAcrossProjects()
+    {
+        const string firstSource = """
+                                   internal class FirstClass
+                                   {
+                                       int Method()
+                                       {
+                                           int BadName = 1;
+
+                                           return BadName;
+                                       }
+                                   }
+                                   """;
+        const string secondSource = """
+                                    internal class SecondClass
+                                    {
+                                        int Method()
+                                        {
+                                            int OTHER_NAME = 2;
+
+                                            return OTHER_NAME;
+                                        }
+                                    }
+                                    """;
+        const string firstFixedSource = """
+                                        internal class FirstClass
+                                        {
+                                            int Method()
+                                            {
+                                                int badName = 1;
+
+                                                return badName;
+                                            }
+                                        }
+                                        """;
+        const string secondFixedSource = """
+                                         internal class SecondClass
+                                         {
+                                             int Method()
+                                             {
+                                                 int otherName = 2;
+
+                                                 return otherName;
+                                             }
+                                         }
+                                         """;
+
+        var (fixedSources, initialAnalyzerDiagnostics, postFixAnalyzerDiagnostics, compilerErrors) = await ApplyFixAllAcrossSolutionAsync(FixAllScope.Solution,
+                                                                                                                                          [firstSource],
+                                                                                                                                          [secondSource]);
+
+        Assert.HasCount(2, initialAnalyzerDiagnostics);
+        Assert.AreSequenceEqual(new[] { firstFixedSource, secondFixedSource }, fixedSources);
+        Assert.IsEmpty(postFixAnalyzerDiagnostics);
         Assert.IsEmpty(compilerErrors);
     }
 
@@ -897,6 +1038,34 @@ public class RH4115LocalVariableCasingAnalyzerTests : AnalyzerTestsBase<RH4115Lo
     }
 
     /// <summary>
+    /// Creates a same-scope local declaration pair whose diagnosed name normalizes to the existing target
+    /// </summary>
+    /// <param name="targetBefore">Whether the existing target precedes the diagnosed declaration</param>
+    /// <returns>Source containing the declaration pair</returns>
+    private static string CreateSameScopeExistingTargetSource(bool targetBefore)
+    {
+        var declarations = targetBefore
+                               ? """
+                                     int badName = 2;
+                                     int BadName = 1;
+                                 """
+                               : """
+                                     int BadName = 1;
+                                     int badName = 2;
+                                 """;
+
+        return $$"""
+                 internal class TestClass
+                 {
+                     void Method()
+                     {
+                 {{declarations}}
+                     }
+                 }
+                 """;
+    }
+
+    /// <summary>
     /// Applies the provider's requested Fix All action to every supplied analyzer diagnostic
     /// </summary>
     /// <param name="source">Source text</param>
@@ -929,7 +1098,7 @@ public class RH4115LocalVariableCasingAnalyzerTests : AnalyzerTestsBase<RH4115Lo
                                             scope,
                                             provider.GetType().Name,
                                             provider.FixableDiagnosticIds,
-                                            new TestFixAllDiagnosticProvider(analyzerDiagnostics),
+                                            new TestFixAllDiagnosticProvider(solution, analyzerDiagnostics),
                                             CancellationToken.None);
             var action = await provider.GetFixAllProvider()
                                        .GetFixAsync(context)
@@ -953,6 +1122,110 @@ public class RH4115LocalVariableCasingAnalyzerTests : AnalyzerTestsBase<RH4115Lo
             var fixedSource = await fixedDocument.GetTextAsync(CancellationToken.None).ConfigureAwait(false);
 
             return (fixedSource.ToString(), analyzerDiagnostics, postFixAnalyzerDiagnostics, compilerErrors);
+        }
+    }
+
+    /// <summary>
+    /// Applies Project or Solution Fix All to a solution containing the supplied project/document matrix
+    /// </summary>
+    /// <param name="scope">Fix All scope</param>
+    /// <param name="projectSources">Source documents grouped by project</param>
+    /// <returns>Fixed sources plus initial/post-fix analyzer diagnostics and post-fix compiler errors</returns>
+    private static async Task<(ImmutableArray<string> FixedSources,
+    ImmutableArray<Diagnostic> InitialAnalyzerDiagnostics,
+    ImmutableArray<Diagnostic> PostFixAnalyzerDiagnostics,
+    ImmutableArray<Diagnostic> CompilerErrors)> ApplyFixAllAcrossSolutionAsync(FixAllScope scope, params string[][] projectSources)
+    {
+        using (var workspace = new AdhocWorkspace())
+        {
+            var solution = workspace.CurrentSolution;
+            var projectIds = ImmutableArray.CreateBuilder<ProjectId>();
+            var documentIds = ImmutableArray.CreateBuilder<DocumentId>();
+
+            for (var projectIndex = 0; projectIndex < projectSources.Length; projectIndex++)
+            {
+                var projectId = ProjectId.CreateNewId();
+
+                projectIds.Add(projectId);
+                solution = solution.AddProject(projectId, $"TestProject{projectIndex}", $"TestProject{projectIndex}", LanguageNames.CSharp)
+                                   .WithProjectCompilationOptions(projectId, new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+                                   .AddMetadataReferences(projectId, GetMetadataReferences());
+
+                for (var documentIndex = 0; documentIndex < projectSources[projectIndex].Length; documentIndex++)
+                {
+                    var documentId = DocumentId.CreateNewId(projectId);
+
+                    documentIds.Add(documentId);
+                    solution = solution.AddDocument(documentId,
+                                                    $"Test{projectIndex}_{documentIndex}.cs",
+                                                    SourceText.From(projectSources[projectIndex][documentIndex]));
+                }
+            }
+
+            var initialAnalyzerDiagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
+
+            foreach (var projectId in projectIds)
+            {
+                var project = solution.GetProject(projectId)
+                                  ?? throw new InvalidOperationException("Failed to create test project.");
+                var compilation = await project.GetCompilationAsync(CancellationToken.None).ConfigureAwait(false)
+                                      ?? throw new InvalidOperationException("Failed to compile test project.");
+
+                initialAnalyzerDiagnostics.AddRange(await compilation.WithAnalyzers(ImmutableArray.Create<DiagnosticAnalyzer>(new RH4115LocalVariableCasingAnalyzer()))
+                                                                     .GetAnalyzerDiagnosticsAsync(CancellationToken.None)
+                                                                     .ConfigureAwait(false));
+            }
+
+            var initiatingDocument = solution.GetDocument(documentIds[0])
+                                         ?? throw new InvalidOperationException("Failed to get initiating document.");
+            var provider = new RH4115LocalVariableCasingCodeFixProvider();
+            var context = new FixAllContext(initiatingDocument,
+                                            provider,
+                                            scope,
+                                            provider.GetType().Name,
+                                            provider.FixableDiagnosticIds,
+                                            new TestFixAllDiagnosticProvider(solution, initialAnalyzerDiagnostics.ToImmutable()),
+                                            CancellationToken.None);
+            var action = await provider.GetFixAllProvider()
+                                       .GetFixAsync(context)
+                                       .ConfigureAwait(false)
+                             ?? throw new InvalidOperationException("Failed to create the Fix All action.");
+
+            Assert.AreEqual(provider.GetType().Name, action.EquivalenceKey);
+
+            var operation = (await action.GetOperationsAsync(CancellationToken.None).ConfigureAwait(false)).OfType<ApplyChangesOperation>()
+                                                                                                           .Single();
+            var fixedSources = ImmutableArray.CreateBuilder<string>();
+
+            foreach (var documentId in documentIds)
+            {
+                var fixedDocument = operation.ChangedSolution.GetDocument(documentId)
+                                        ?? throw new InvalidOperationException("Failed to get fixed document.");
+
+                fixedSources.Add((await fixedDocument.GetTextAsync(CancellationToken.None).ConfigureAwait(false)).ToString());
+            }
+
+            var postFixAnalyzerDiagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
+            var compilerErrors = ImmutableArray.CreateBuilder<Diagnostic>();
+
+            foreach (var projectId in projectIds)
+            {
+                var fixedProject = operation.ChangedSolution.GetProject(projectId)
+                                       ?? throw new InvalidOperationException("Failed to get fixed project.");
+                var fixedCompilation = await fixedProject.GetCompilationAsync(CancellationToken.None).ConfigureAwait(false)
+                                           ?? throw new InvalidOperationException("Failed to compile fixed project.");
+
+                compilerErrors.AddRange(fixedCompilation.GetDiagnostics(CancellationToken.None)
+                                                        .Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
+                postFixAnalyzerDiagnostics.AddRange(await fixedCompilation.WithAnalyzers(ImmutableArray.Create<DiagnosticAnalyzer>(new RH4115LocalVariableCasingAnalyzer()))
+                                                                          .GetAnalyzerDiagnosticsAsync(CancellationToken.None)
+                                                                          .ConfigureAwait(false));
+            }
+
+            return (fixedSources.ToImmutable(),
+                    initialAnalyzerDiagnostics.ToImmutable(),
+                    postFixAnalyzerDiagnostics.ToImmutable(),
+                    compilerErrors.ToImmutable());
         }
     }
 
@@ -986,6 +1259,11 @@ public class RH4115LocalVariableCasingAnalyzerTests : AnalyzerTestsBase<RH4115Lo
         /// </summary>
         private readonly ImmutableArray<Diagnostic> _diagnostics;
 
+        /// <summary>
+        /// Solution containing the diagnostics
+        /// </summary>
+        private readonly Solution _solution;
+
         #endregion // Fields
 
         #region Constructor
@@ -993,9 +1271,11 @@ public class RH4115LocalVariableCasingAnalyzerTests : AnalyzerTestsBase<RH4115Lo
         /// <summary>
         /// Constructor
         /// </summary>
+        /// <param name="solution">Solution containing the diagnostics</param>
         /// <param name="diagnostics">Diagnostics</param>
-        public TestFixAllDiagnosticProvider(ImmutableArray<Diagnostic> diagnostics)
+        public TestFixAllDiagnosticProvider(Solution solution, ImmutableArray<Diagnostic> diagnostics)
         {
+            _solution = solution;
             _diagnostics = diagnostics;
         }
 
@@ -1006,7 +1286,10 @@ public class RH4115LocalVariableCasingAnalyzerTests : AnalyzerTestsBase<RH4115Lo
         /// <inheritdoc/>
         public override Task<IEnumerable<Diagnostic>> GetDocumentDiagnosticsAsync(Document document, CancellationToken cancellationToken)
         {
-            return Task.FromResult<IEnumerable<Diagnostic>>(_diagnostics);
+            var diagnostics = _diagnostics.Where(diagnostic => diagnostic.Location.SourceTree != null
+                                                               && _solution.GetDocument(diagnostic.Location.SourceTree)?.Id == document.Id);
+
+            return Task.FromResult<IEnumerable<Diagnostic>>(diagnostics);
         }
 
         /// <inheritdoc/>
@@ -1018,7 +1301,10 @@ public class RH4115LocalVariableCasingAnalyzerTests : AnalyzerTestsBase<RH4115Lo
         /// <inheritdoc/>
         public override Task<IEnumerable<Diagnostic>> GetAllDiagnosticsAsync(Project project, CancellationToken cancellationToken)
         {
-            return Task.FromResult<IEnumerable<Diagnostic>>(_diagnostics);
+            var diagnostics = _diagnostics.Where(diagnostic => diagnostic.Location.SourceTree != null
+                                                               && _solution.GetDocument(diagnostic.Location.SourceTree)?.Project.Id == project.Id);
+
+            return Task.FromResult<IEnumerable<Diagnostic>>(diagnostics);
         }
 
         #endregion // DiagnosticProvider

--- a/Reihitsu.Analyzer.Test/Naming/RH4115LocalVariableCasingAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Naming/RH4115LocalVariableCasingAnalyzerTests.cs
@@ -927,6 +927,133 @@ public class RH4115LocalVariableCasingAnalyzerTests : AnalyzerTestsBase<RH4115Lo
     }
 
     /// <summary>
+    /// Verifies a named-namespace type rename is refused when the normalized target exists in another document
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task NamedNamespaceTypeCollisionAcrossDocumentsIsRefused()
+    {
+        const string source = "namespace Common;\ninternal class badName { }";
+        const string conflictingSource = "namespace Common;\ninternal class BadName { }";
+
+        var (actionCount, fixedSources, postFixAnalyzerDiagnostics, compilerErrors) = await ApplyOrdinaryFixAcrossDocumentsAsync(new RH4002ClassNameCasingAnalyzer(),
+                                                                                                                                 new RH4002ClassNameCasingCodeFixProvider(),
+                                                                                                                                 source,
+                                                                                                                                 conflictingSource);
+
+        Assert.AreEqual(0, actionCount);
+        Assert.AreSequenceEqual(new[] { source, conflictingSource }, fixedSources);
+        Assert.HasCount(1, postFixAnalyzerDiagnostics);
+        Assert.IsEmpty(compilerErrors);
+    }
+
+    /// <summary>
+    /// Verifies Project Fix All refuses a cross-document type collision within a named namespace
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task NamedNamespaceTypeCollisionAcrossDocumentsIsRefusedByProjectFixAll()
+    {
+        const string source = "namespace Common;\ninternal class badName { }";
+        const string conflictingSource = "namespace Common;\ninternal class BadName { }";
+
+        var (fixedSources, initialAnalyzerDiagnostics, postFixAnalyzerDiagnostics, compilerErrors) = await ApplyFixAllAcrossDocumentsAsync(new RH4002ClassNameCasingAnalyzer(),
+                                                                                                                                           new RH4002ClassNameCasingCodeFixProvider(),
+                                                                                                                                           source,
+                                                                                                                                           conflictingSource);
+
+        Assert.HasCount(1, initialAnalyzerDiagnostics);
+        Assert.AreSequenceEqual(new[] { source, conflictingSource }, fixedSources);
+        Assert.HasCount(1, postFixAnalyzerDiagnostics);
+        Assert.IsEmpty(compilerErrors);
+    }
+
+    /// <summary>
+    /// Verifies an error in another declaration of the same namespace does not suppress a safe type rename
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task NamedNamespaceTypeRenameIgnoresUnrelatedDocumentError()
+    {
+        const string source = "namespace Common;\ninternal class badName { }";
+        const string unrelatedErrorSource = "namespace Common;\ninternal class Broken { MissingType Value; }";
+
+        var (actionCount, fixedSources, postFixAnalyzerDiagnostics, compilerErrors) = await ApplyOrdinaryFixAcrossDocumentsAsync(new RH4002ClassNameCasingAnalyzer(),
+                                                                                                                                 new RH4002ClassNameCasingCodeFixProvider(),
+                                                                                                                                 source,
+                                                                                                                                 unrelatedErrorSource);
+
+        Assert.AreEqual(1, actionCount);
+        Assert.AreSequenceEqual(new[] { "namespace Common;\ninternal class BadName { }", unrelatedErrorSource }, fixedSources);
+        Assert.IsEmpty(postFixAnalyzerDiagnostics);
+        Assert.HasCount(1, compilerErrors);
+        Assert.AreEqual("CS0246", compilerErrors[0].Id);
+    }
+
+    /// <summary>
+    /// Verifies named-namespace types with the same normalized name but different arity can coexist
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task NamedNamespaceTypeRenameAllowsDifferentArity()
+    {
+        const string source = "namespace Common;\ninternal class badName<T> { }";
+        const string differentAritySource = "namespace Common;\ninternal class BadName<TFirst, TSecond> { }";
+
+        var (actionCount, fixedSources, postFixAnalyzerDiagnostics, compilerErrors) = await ApplyOrdinaryFixAcrossDocumentsAsync(new RH4002ClassNameCasingAnalyzer(),
+                                                                                                                                 new RH4002ClassNameCasingCodeFixProvider(),
+                                                                                                                                 source,
+                                                                                                                                 differentAritySource);
+
+        Assert.AreEqual(1, actionCount);
+        Assert.AreSequenceEqual(new[] { "namespace Common;\ninternal class BadName<T> { }", differentAritySource }, fixedSources);
+        Assert.IsEmpty(postFixAnalyzerDiagnostics);
+        Assert.IsEmpty(compilerErrors);
+    }
+
+    /// <summary>
+    /// Verifies a file-local normalized target in another declaration of a named namespace does not collide
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task NamedNamespaceTypeRenameAllowsFileLocalTargetInAnotherDocument()
+    {
+        const string source = "namespace Common;\ninternal class badName { }";
+        const string fileLocalSource = "namespace Common;\nfile class BadName { }";
+
+        var (actionCount, fixedSources, postFixAnalyzerDiagnostics, compilerErrors) = await ApplyOrdinaryFixAcrossDocumentsAsync(new RH4002ClassNameCasingAnalyzer(),
+                                                                                                                                 new RH4002ClassNameCasingCodeFixProvider(),
+                                                                                                                                 source,
+                                                                                                                                 fileLocalSource);
+
+        Assert.AreEqual(1, actionCount);
+        Assert.AreSequenceEqual(new[] { "namespace Common;\ninternal class BadName { }", fileLocalSource }, fixedSources);
+        Assert.IsEmpty(postFixAnalyzerDiagnostics);
+        Assert.IsEmpty(compilerErrors);
+    }
+
+    /// <summary>
+    /// Verifies a named-namespace type rename is refused when its normalized target is a nested source namespace
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task NamedNamespaceTypeRenameToNamespaceAcrossDocumentsIsRefused()
+    {
+        const string source = "namespace Common;\ninternal class badName { }";
+        const string conflictingSource = "namespace Common.BadName { internal class SecondClass { } }";
+
+        var (actionCount, fixedSources, postFixAnalyzerDiagnostics, compilerErrors) = await ApplyOrdinaryFixAcrossDocumentsAsync(new RH4002ClassNameCasingAnalyzer(),
+                                                                                                                                 new RH4002ClassNameCasingCodeFixProvider(),
+                                                                                                                                 source,
+                                                                                                                                 conflictingSource);
+
+        Assert.AreEqual(0, actionCount);
+        Assert.AreSequenceEqual(new[] { source, conflictingSource }, fixedSources);
+        Assert.HasCount(1, postFixAnalyzerDiagnostics);
+        Assert.IsEmpty(compilerErrors);
+    }
+
+    /// <summary>
     /// Verifies a local-variable casing fix does not introduce a duplicate declaration in a nested block
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>

--- a/documentation/rules/RH3001.md
+++ b/documentation/rules/RH3001.md
@@ -19,6 +19,8 @@ The `!` operator is easy to overlook, especially in complex conditional expressi
 
 Replace `!condition` with `condition == false`.
 
+When the operator-to-operand gap contains a directive, disabled text, or skipped syntax, the automatic fix is unavailable and the expression must be corrected manually.
+
 ## Exclusions
 
 Only operands of type `bool` are reported. Operands of type `bool?` are skipped because `!x` propagates `null` while `x == false` does not, and operands with a user-defined `operator !` are skipped because the rewrite is not equivalent (and `== false` may not compile).

--- a/documentation/rules/RH4002.md
+++ b/documentation/rules/RH4002.md
@@ -19,6 +19,8 @@ PascalCase for type names is a fundamental C# naming convention. Inconsistent ca
 
 Rename the class to use PascalCase.
 
+If the required casing target conflicts with an existing identifier, the automatic fix is unavailable and the name must be corrected manually.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH4003.md
+++ b/documentation/rules/RH4003.md
@@ -19,6 +19,8 @@ PascalCase for type names is a fundamental C# naming convention. Inconsistent ca
 
 Rename the struct to use PascalCase.
 
+If the required casing target conflicts with an existing identifier, the automatic fix is unavailable and the name must be corrected manually.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH4004.md
+++ b/documentation/rules/RH4004.md
@@ -19,6 +19,8 @@ PascalCase for type names is a fundamental C# naming convention. Inconsistent ca
 
 Rename the enum to use PascalCase.
 
+If the required casing target conflicts with an existing identifier, the automatic fix is unavailable and the name must be corrected manually.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH4005.md
+++ b/documentation/rules/RH4005.md
@@ -19,6 +19,8 @@ PascalCase with an `I` prefix for interface names is a fundamental C# naming con
 
 Rename the interface to use PascalCase with an `I` prefix.
 
+If the required casing target conflicts with an existing identifier, the automatic fix is unavailable and the name must be corrected manually.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH4006.md
+++ b/documentation/rules/RH4006.md
@@ -19,6 +19,8 @@ PascalCase for type names is a fundamental C# naming convention. Inconsistent ca
 
 Rename the delegate to use PascalCase.
 
+If the required casing target conflicts with an existing identifier, the automatic fix is unavailable and the name must be corrected manually.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH4010.md
+++ b/documentation/rules/RH4010.md
@@ -19,6 +19,8 @@ Type names are central API surface. Using inconsistent casing for record types m
 
 Rename the record so each word starts with an uppercase letter.
 
+If the required casing target conflicts with an existing identifier, the automatic fix is unavailable and the name must be corrected manually.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH4011.md
+++ b/documentation/rules/RH4011.md
@@ -19,6 +19,8 @@ Record structs are types and should follow the same naming style as other types.
 
 Rename the record struct so each word starts with an uppercase letter.
 
+If the required casing target conflicts with an existing identifier, the automatic fix is unavailable and the name must be corrected manually.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH4101.md
+++ b/documentation/rules/RH4101.md
@@ -19,6 +19,8 @@ PascalCase for enum members is a standard C# naming convention. Inconsistent cas
 
 Rename the enum members to use PascalCase.
 
+If the required casing target conflicts with an existing identifier, the automatic fix is unavailable and the name must be corrected manually.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH4102.md
+++ b/documentation/rules/RH4102.md
@@ -19,6 +19,8 @@ PascalCase for public members is a fundamental C# naming convention. Inconsisten
 
 Rename the event to use PascalCase.
 
+If the required casing target conflicts with an existing identifier, the automatic fix is unavailable and the name must be corrected manually.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH4103.md
+++ b/documentation/rules/RH4103.md
@@ -19,6 +19,8 @@ PascalCase for method names is a fundamental C# naming convention. Inconsistent 
 
 Rename the method to use PascalCase.
 
+If the required casing target conflicts with an existing identifier, the automatic fix is unavailable and the name must be corrected manually.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH4104.md
+++ b/documentation/rules/RH4104.md
@@ -19,6 +19,8 @@ PascalCase for function names is a standard C# naming convention that applies to
 
 Rename the local function to use PascalCase.
 
+If the required casing target conflicts with an existing identifier, the automatic fix is unavailable and the name must be corrected manually.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH4105.md
+++ b/documentation/rules/RH4105.md
@@ -19,6 +19,8 @@ camelCase for parameters is a fundamental C# naming convention. Inconsistent par
 
 Rename the parameter to use camelCase.
 
+If the required casing target conflicts with an existing identifier, the automatic fix is unavailable and the name must be corrected manually.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH4106.md
+++ b/documentation/rules/RH4106.md
@@ -21,6 +21,8 @@ The underscore prefix convention for private fields clearly distinguishes them f
 
 Rename the private field to use _camelCase with an underscore prefix, including `private static readonly` fields.
 
+If the required casing target conflicts with an existing identifier, the automatic fix is unavailable and the name must be corrected manually.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH4107.md
+++ b/documentation/rules/RH4107.md
@@ -21,6 +21,8 @@ The underscore prefix convention for protected fields clearly distinguishes them
 
 Rename the protected field to use _camelCase with an underscore prefix.
 
+If the required casing target conflicts with an existing identifier, the automatic fix is unavailable and the name must be corrected manually.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH4108.md
+++ b/documentation/rules/RH4108.md
@@ -21,6 +21,8 @@ PascalCase for internal fields maintains consistency with other non-private memb
 
 Rename the internal field to use PascalCase.
 
+If the required casing target conflicts with an existing identifier, the automatic fix is unavailable and the name must be corrected manually.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH4109.md
+++ b/documentation/rules/RH4109.md
@@ -19,6 +19,8 @@ PascalCase for public members is a fundamental C# naming convention. Inconsisten
 
 Rename the public field to use PascalCase.
 
+If the required casing target conflicts with an existing identifier, the automatic fix is unavailable and the name must be corrected manually.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH4110.md
+++ b/documentation/rules/RH4110.md
@@ -19,6 +19,8 @@ PascalCase for constants is the standard C# naming convention. Using other conve
 
 Rename the const field to use PascalCase.
 
+If the required casing target conflicts with an existing identifier, the automatic fix is unavailable and the name must be corrected manually.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH4111.md
+++ b/documentation/rules/RH4111.md
@@ -21,6 +21,8 @@ PascalCase for properties is a fundamental C# naming convention that applies reg
 
 Rename the private property to use PascalCase.
 
+If the required casing target conflicts with an existing identifier, the automatic fix is unavailable and the name must be corrected manually.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH4112.md
+++ b/documentation/rules/RH4112.md
@@ -21,6 +21,8 @@ This rule also covers `private protected` properties. `protected internal` prope
 
 Rename the protected property to use PascalCase.
 
+If the required casing target conflicts with an existing identifier, the automatic fix is unavailable and the name must be corrected manually.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH4113.md
+++ b/documentation/rules/RH4113.md
@@ -21,6 +21,8 @@ This rule also covers `protected internal` properties. `private protected` prope
 
 Rename the internal property to use PascalCase.
 
+If the required casing target conflicts with an existing identifier, the automatic fix is unavailable and the name must be corrected manually.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH4114.md
+++ b/documentation/rules/RH4114.md
@@ -19,6 +19,8 @@ PascalCase for public members is a fundamental C# naming convention. Inconsisten
 
 Rename the public property to use PascalCase.
 
+If the required casing target conflicts with an existing identifier, the automatic fix is unavailable and the name must be corrected manually.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH4115.md
+++ b/documentation/rules/RH4115.md
@@ -19,6 +19,8 @@ camelCase for local variables is a fundamental C# naming convention. Using Pasca
 
 Rename the local variable to use camelCase.
 
+If the required casing target conflicts with an existing identifier, the automatic fix is unavailable and the name must be corrected manually.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH4117.md
+++ b/documentation/rules/RH4117.md
@@ -19,6 +19,8 @@ camelCase for local variables is a fundamental C# naming convention. Deconstruct
 
 Rename the deconstruction variables to use camelCase.
 
+If the required casing target conflicts with an existing identifier, the automatic fix is unavailable and the name must be corrected manually.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH4120.md
+++ b/documentation/rules/RH4120.md
@@ -19,6 +19,8 @@ This rule enforces a consistent style for record primary-constructor parameters.
 
 Rename each primary-constructor parameter so each word starts with an uppercase letter.
 
+If the required casing target conflicts with an existing identifier, the automatic fix is unavailable and the name must be corrected manually.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH4121.md
+++ b/documentation/rules/RH4121.md
@@ -19,6 +19,8 @@ A type parameter named `Key` or `Value` is indistinguishable from a regular type
 
 Rename the type parameter so it starts with an uppercase `T` followed by a PascalCase name, or use a single `T` when the declaration has only one type parameter.
 
+If the required casing target conflicts with an existing identifier, the automatic fix is unavailable and the name must be corrected manually.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH5011.md
+++ b/documentation/rules/RH5011.md
@@ -19,6 +19,8 @@ Without a blank line after a `break` statement, consecutive switch cases appear 
 
 Add a blank line after the `break` statement and before the next `case` or `default` label.
 
+When a statement shares the `break` line and the gap contains a comment, directive, disabled text, or skipped syntax, the automatic fix is unavailable and the layout must be corrected manually.
+
 ## Examples
 
 ### Violation

--- a/documentation/rules/RH5103.md
+++ b/documentation/rules/RH5103.md
@@ -19,6 +19,8 @@ Placing multiple statements on one line reduces readability and makes changes ha
 
 Move each statement to its own line.
 
+When the statement's leading gap cannot be edited independently without crossing empty-statement or non-formatting syntax, the automatic fix is unavailable and the statements must be separated manually.
+
 ## Examples
 
 ### Violation


### PR DESCRIPTION
## Summary
- make RH5103, RH5011, and RH3001 fixes preserve syntax/trivia boundaries and converge across line endings
- refuse unsafe naming collisions for ordinary actions and Document, Project, or Solution Fix All without project-wide diagnostic scans
- cover cross-document, cross-project, declaration-order, comment, directive, and line-ending boundaries
- document deliberate manual-fix cases across the affected rules and shared naming providers

## Review notes
- RH3004 and RH6011 reported scenarios were already safe and remain covered as characterization boundaries
- naming-collision refusal is shared by all casing code-fix providers

Closes #469