### PR TITLE
Resolve Sonar reliability findings

### DIFF
--- a/Reihitsu.Analyzer.CodeFixes/Rules/Layout/RH5103CodeMustNotContainMultipleStatementsOnOneLineCodeFixProvider.cs
+++ b/Reihitsu.Analyzer.CodeFixes/Rules/Layout/RH5103CodeMustNotContainMultipleStatementsOnOneLineCodeFixProvider.cs
@@ -105,10 +105,16 @@ public class RH5103CodeMustNotContainMultipleStatementsOnOneLineCodeFixProvider 
     /// </summary>
     /// <param name="root">Syntax root</param>
     /// <param name="statement">Selected statement</param>
-    /// <param name="previousStatement">Previous analyzed non-empty statement</param>
     /// <returns><see langword="true"/> if only formatting trivia separates the statements; otherwise, <see langword="false"/></returns>
-    private static bool HasEditableLeadingGap(SyntaxNode root, StatementSyntax statement, StatementSyntax previousStatement)
+    private static bool HasEditableLeadingGap(SyntaxNode root, StatementSyntax statement)
     {
+        var previousStatement = GetPreviousStatement(statement);
+
+        if (previousStatement == null)
+        {
+            return false;
+        }
+
         var previousToken = statement.GetFirstToken().GetPreviousToken(includeZeroWidth: true, includeSkipped: true);
 
         if (previousToken.Parent?.FirstAncestorOrSelf<StatementSyntax>() != previousStatement)
@@ -156,9 +162,7 @@ public class RH5103CodeMustNotContainMultipleStatementsOnOneLineCodeFixProvider 
                 continue;
             }
 
-            var previousStatement = GetPreviousStatement(statement);
-
-            if (previousStatement == null || HasEditableLeadingGap(root, statement, previousStatement) == false)
+            if (HasEditableLeadingGap(root, statement) == false)
             {
                 continue;
             }

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -15,7 +15,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/dotnet-env.sh
 . "$script_dir/lib/dotnet-env.sh"
 
-if [ "$#" -eq 0 ]; then
+if [[ "$#" -eq 0 ]]; then
     echo "format.sh: expected at least one path." >&2
     exit 2
 fi
@@ -33,7 +33,7 @@ for argument in "$@"; do
             ;;
         *)
             # Absolute paths survive the repository-root invocation below
-            if [ -e "$argument" ]; then
+            if [[ -e "$argument" ]]; then
                 formatter_arguments+=("$(cd "$(dirname "$argument")" && pwd)/$(basename "$argument")")
             else
                 formatter_arguments+=("$argument")
@@ -42,7 +42,7 @@ for argument in "$@"; do
     esac
 done
 
-if [ "${#formatter_arguments[@]}" -eq 0 ]; then
+if [[ "${#formatter_arguments[@]}" -eq 0 ]]; then
     echo "format.sh: expected at least one path." >&2
     exit 2
 fi

--- a/scripts/lib/dotnet-env.sh
+++ b/scripts/lib/dotnet-env.sh
@@ -33,7 +33,7 @@ reihitsu_has_required_sdk()
 # Adds a previously installed private SDK to PATH when one exists.
 reihitsu_use_private_sdk()
 {
-    if [ -x "$REIHITSU_DOTNET_ROOT/dotnet" ]; then
+    if [[ -x "$REIHITSU_DOTNET_ROOT/dotnet" ]]; then
         export PATH="$REIHITSU_DOTNET_ROOT:$PATH"
         export DOTNET_ROOT="$REIHITSU_DOTNET_ROOT"
 
@@ -62,18 +62,18 @@ reihitsu_ensure_dotnet()
     done
 
     if reihitsu_has_required_sdk; then
-        [ "$quiet" -eq 1 ] || echo "dotnet: using $(command -v dotnet) ($(dotnet --version))"
+        [[ "$quiet" -eq 1 ]] || echo "dotnet: using $(command -v dotnet) ($(dotnet --version))"
 
         return 0
     fi
 
     if reihitsu_use_private_sdk && reihitsu_has_required_sdk; then
-        [ "$quiet" -eq 1 ] || echo "dotnet: using $REIHITSU_DOTNET_ROOT/dotnet ($(dotnet --version))"
+        [[ "$quiet" -eq 1 ]] || echo "dotnet: using $REIHITSU_DOTNET_ROOT/dotnet ($(dotnet --version))"
 
         return 0
     fi
 
-    if [ "$allow_install" -eq 0 ]; then
+    if [[ "$allow_install" -eq 0 ]]; then
         echo "dotnet: no .NET ${REIHITSU_DOTNET_MAJOR} SDK found and --no-install was requested." >&2
 
         return 2
@@ -109,7 +109,7 @@ reihitsu_ensure_dotnet()
         return 2
     fi
 
-    [ "$quiet" -eq 1 ] || echo "dotnet: installed $(dotnet --version) in $REIHITSU_DOTNET_ROOT"
+    [[ "$quiet" -eq 1 ]] || echo "dotnet: installed $(dotnet --version) in $REIHITSU_DOTNET_ROOT"
 
     return 0
 }

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -19,7 +19,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 reihitsu_ensure_dotnet "$@"
 
-if [ -x "$REIHITSU_DOTNET_ROOT/dotnet" ]; then
+if [[ -x "$REIHITSU_DOTNET_ROOT/dotnet" ]]; then
     case ":$PATH:" in
         *":$REIHITSU_DOTNET_ROOT:"*)
             echo "hint: for direct dotnet calls in this shell, run: export PATH=\"$REIHITSU_DOTNET_ROOT:\$PATH\""

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -26,10 +26,10 @@ filter=""
 install_arguments=()
 test_arguments=()
 
-while [ "$#" -gt 0 ]; do
+while [[ "$#" -gt 0 ]]; do
     case "$1" in
         --project)
-            if [ "$#" -lt 2 ]; then
+            if [[ "$#" -lt 2 ]]; then
                 echo "test.sh: --project expects a value (analyzer, formatter, core, cli, architecture, tooling, or all)." >&2
                 exit 2
             fi
@@ -38,7 +38,7 @@ while [ "$#" -gt 0 ]; do
             shift 2
             ;;
         --filter)
-            if [ "$#" -lt 2 ]; then
+            if [[ "$#" -lt 2 ]]; then
                 echo "test.sh: --filter expects an expression." >&2
                 exit 2
             fi
@@ -87,7 +87,7 @@ repository_root="$(reihitsu_repo_root)"
 for test_project in "${projects[@]}"; do
     echo "==> $test_project"
 
-    if [ -n "$filter" ]; then
+    if [[ -n "$filter" ]]; then
         dotnet test "$repository_root/$test_project" -c Release --verbosity minimal --filter "$filter" "${test_arguments[@]+"${test_arguments[@]}"}"
     else
         dotnet test "$repository_root/$test_project" -c Release --verbosity minimal "${test_arguments[@]+"${test_arguments[@]}"}"


### PR DESCRIPTION
## Summary

- Make RH5103 leading-gap validation own its previous-statement null check.
- Replace legacy Bash conditional tests with `[[ ... ]]` across the affected repository scripts.

## Why

SonarCloud reports one potential null dereference and thirteen reliability findings for Bash conditional syntax. The C# null proof currently lives only at the caller, while the scripts already require Bash and can use its safer conditional construct directly.

## Impact

This clears the current Reliability findings without changing public APIs, diagnostic behavior, dependencies, or supported script environments.