### PR TITLE
Cover RH5103 missing-previous-statement guard

### DIFF
--- a/Reihitsu.Analyzer.Test/Formatting/RH5103CodeMustNotContainMultipleStatementsOnOneLineAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH5103CodeMustNotContainMultipleStatementsOnOneLineAnalyzerTests.cs
@@ -268,5 +268,32 @@ public class RH5103CodeMustNotContainMultipleStatementsOnOneLineAnalyzerTests : 
         Assert.IsEmpty(actions);
     }
 
+    /// <summary>
+    /// Verifies that a stale diagnostic targeting the first statement does not offer a fix
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task FixIsNotOfferedWhenDiagnosticTargetsFirstStatement()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    void Method()
+                                    {
+                                        Method();
+                                    }
+                                }
+                                """;
+
+        var actions = await GetCodeFixActionsAsync(testData,
+                                                   RH5103CodeMustNotContainMultipleStatementsOnOneLineAnalyzer.DiagnosticId,
+                                                   root => root.DescendantNodes()
+                                                               .OfType<ExpressionStatementSyntax>()
+                                                               .Single()
+                                                               .GetLocation());
+
+        Assert.IsEmpty(actions);
+    }
+
     #endregion // Tests
 }


### PR DESCRIPTION
## Summary

- Cover the RH5103 code-fix path where a diagnostic targets a statement without a previous sibling.
- Verify that the provider safely withholds the code fix for that stale diagnostic.

## Why

The Reliability fix merged in #667 cleared all Sonar findings, but its defensive null branch left new-code coverage at 75%. This focused regression test exercises the missing path so the quality gate can return to green.

## Impact

No production behavior or public API changes. The test documents and protects the existing defensive behavior.