### PR TITLE
Complete the RH55xx scope descriptions and unify RH80xx XML tag spelling

### DIFF
--- a/documentation/rules/RH5505.md
+++ b/documentation/rules/RH5505.md
@@ -11,6 +11,9 @@
 
 Class attributes must be on their own line.
 
+This rule also reports on record classes, since a `record` (or `record class`) declaration resolves to the same
+attribute target as a `class` declaration.
+
 ## Why is this a problem?
 
 The declaration line is what a reader scans for when looking for a type: the accessibility, the `class` keyword and

--- a/documentation/rules/RH5506.md
+++ b/documentation/rules/RH5506.md
@@ -11,6 +11,9 @@
 
 Class attribute lists must contain exactly one attribute.
 
+This rule also reports on record classes, since a `record` (or `record class`) declaration resolves to the same
+attribute target as a `class` declaration.
+
 ## Why is this a problem?
 
 Attributes on a type are rarely related to each other — serialization, obsolescence and test categorization are

--- a/documentation/rules/RH5507.md
+++ b/documentation/rules/RH5507.md
@@ -11,6 +11,9 @@
 
 Struct attributes must be on their own line.
 
+This rule also reports on record structs, since a `record struct` declaration resolves to the same attribute target
+as a `struct` declaration.
+
 ## Why is this a problem?
 
 The declaration line is what a reader scans for when looking for a type: the accessibility, the `struct` keyword and

--- a/documentation/rules/RH5508.md
+++ b/documentation/rules/RH5508.md
@@ -11,6 +11,9 @@
 
 Struct attribute lists must contain exactly one attribute.
 
+This rule also reports on record structs, since a `record struct` declaration resolves to the same attribute target
+as a `struct` declaration.
+
 ## Why is this a problem?
 
 Attributes on a type are rarely related to each other, and `[First, Second]` is the syntax that says they are.

--- a/documentation/rules/RH5513.md
+++ b/documentation/rules/RH5513.md
@@ -11,6 +11,10 @@
 
 Method attributes must be on their own line.
 
+This rule also reports on operators, conversion operators, destructors, local functions, and lambdas, since they
+resolve to the same attribute target as a method. Accessor attributes are not covered here; RH5530 reports on those
+instead.
+
 ## Why is this a problem?
 
 A reader scanning a type for a method looks down a column of accessibility modifiers, return types and names. An

--- a/documentation/rules/RH5514.md
+++ b/documentation/rules/RH5514.md
@@ -11,6 +11,10 @@
 
 Method attribute lists must contain exactly one attribute.
 
+This rule also reports on operators, conversion operators, destructors, local functions, and lambdas, since they
+resolve to the same attribute target as a method. Accessor attribute lists are not covered here; RH5531 reports on
+those instead.
+
 ## Why is this a problem?
 
 Attributes on a method are independent decisions, and `[First, Second]` is the syntax that says they are not. Methods

--- a/documentation/rules/RH5515.md
+++ b/documentation/rules/RH5515.md
@@ -11,6 +11,9 @@
 
 Property attributes must be on their own line.
 
+This rule also reports on indexers, since an indexer declaration resolves to the same attribute target as a
+property.
+
 ## Why is this a problem?
 
 A reader scanning a type for a property looks down a column of accessibility modifiers, types and names. An attribute

--- a/documentation/rules/RH5516.md
+++ b/documentation/rules/RH5516.md
@@ -11,6 +11,9 @@
 
 Property attribute lists must contain exactly one attribute.
 
+This rule also reports on indexers, since an indexer declaration resolves to the same attribute target as a
+property.
+
 ## Why is this a problem?
 
 Properties attract independent attributes from several directions at once: serialization, validation, data binding,

--- a/documentation/rules/RH5517.md
+++ b/documentation/rules/RH5517.md
@@ -11,6 +11,9 @@
 
 Field attributes must be on their own line.
 
+This rule also reports on enum members, since an enum member declaration resolves to the same attribute target as a
+field.
+
 ## Why is this a problem?
 
 Fields are usually read as a block of declarations at the top of a type, one type-and-name pair per line. An attribute

--- a/documentation/rules/RH5518.md
+++ b/documentation/rules/RH5518.md
@@ -11,6 +11,9 @@
 
 Field attribute lists must contain exactly one attribute.
 
+This rule also reports on enum members, since an enum member declaration resolves to the same attribute target as a
+field.
+
 ## Why is this a problem?
 
 Attributes on a field are independent decisions, and `[First, Second]` is the syntax that says they are not. Because

--- a/documentation/rules/RH5519.md
+++ b/documentation/rules/RH5519.md
@@ -11,6 +11,8 @@
 
 Event attributes must be on their own line.
 
+This rule also reports on event field declarations, since they resolve to the same attribute target as an event.
+
 ## Why is this a problem?
 
 A reader scanning a type for an event looks down a column of accessibility modifiers, handler types and names. An

--- a/documentation/rules/RH5520.md
+++ b/documentation/rules/RH5520.md
@@ -11,6 +11,8 @@
 
 Event attribute lists must contain exactly one attribute.
 
+This rule also reports on event field declarations, since they resolve to the same attribute target as an event.
+
 ## Why is this a problem?
 
 Attributes on an event are independent decisions, and `[First, Second]` is the syntax that says they are not.

--- a/documentation/rules/RH8001.md
+++ b/documentation/rules/RH8001.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-This rule requires non-private class declarations to have XML documentation. A declaration counts as documented when it has a &lt;summary&gt; tag or uses &lt;inheritdoc/&gt;.
+This rule requires non-private class declarations to have XML documentation. A declaration counts as documented when it has a `<summary>` tag or uses `<inheritdoc/>`.
 
 ## Why is this a problem?
 
@@ -17,7 +17,7 @@ Undocumented non-private class declarations make the code harder to understand b
 
 ## How to fix it
 
-Add a meaningful XML comment above the declaration. In most cases a short &lt;summary&gt; is the best fix.
+Add a meaningful XML comment above the declaration. In most cases a short `<summary>` is the best fix.
 
 ## Examples
 

--- a/documentation/rules/RH8002.md
+++ b/documentation/rules/RH8002.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-This rule requires private class declarations to have XML documentation. A declaration counts as documented when it has a &lt;summary&gt; tag or uses &lt;inheritdoc/&gt;.
+This rule requires private class declarations to have XML documentation. A declaration counts as documented when it has a `<summary>` tag or uses `<inheritdoc/>`.
 
 ## Why is this a problem?
 
@@ -17,7 +17,7 @@ A private class is visible only inside the type that declares it, so nothing out
 
 ## How to fix it
 
-Add a meaningful XML comment above the declaration. In most cases a short &lt;summary&gt; is the best fix.
+Add a meaningful XML comment above the declaration. In most cases a short `<summary>` is the best fix.
 
 ## Examples
 

--- a/documentation/rules/RH8003.md
+++ b/documentation/rules/RH8003.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-This rule requires non-private struct declarations to have XML documentation. A declaration counts as documented when it has a &lt;summary&gt; tag or uses &lt;inheritdoc/&gt;.
+This rule requires non-private struct declarations to have XML documentation. A declaration counts as documented when it has a `<summary>` tag or uses `<inheritdoc/>`.
 
 ## Why is this a problem?
 
@@ -17,7 +17,7 @@ Undocumented non-private struct declarations make the code harder to understand 
 
 ## How to fix it
 
-Add a meaningful XML comment above the declaration. In most cases a short &lt;summary&gt; is the best fix.
+Add a meaningful XML comment above the declaration. In most cases a short `<summary>` is the best fix.
 
 ## Examples
 

--- a/documentation/rules/RH8004.md
+++ b/documentation/rules/RH8004.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-This rule requires private struct declarations to have XML documentation. A declaration counts as documented when it has a &lt;summary&gt; tag or uses &lt;inheritdoc/&gt;.
+This rule requires private struct declarations to have XML documentation. A declaration counts as documented when it has a `<summary>` tag or uses `<inheritdoc/>`.
 
 ## Why is this a problem?
 
@@ -17,7 +17,7 @@ A private struct is visible only inside the type that declares it, so nothing ou
 
 ## How to fix it
 
-Add a meaningful XML comment above the declaration. In most cases a short &lt;summary&gt; is the best fix.
+Add a meaningful XML comment above the declaration. In most cases a short `<summary>` is the best fix.
 
 ## Examples
 

--- a/documentation/rules/RH8005.md
+++ b/documentation/rules/RH8005.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-This rule requires non-private interface declarations to have XML documentation. A declaration counts as documented when it has a &lt;summary&gt; tag or uses &lt;inheritdoc/&gt;.
+This rule requires non-private interface declarations to have XML documentation. A declaration counts as documented when it has a `<summary>` tag or uses `<inheritdoc/>`.
 
 ## Why is this a problem?
 
@@ -17,7 +17,7 @@ Undocumented non-private interface declarations make the code harder to understa
 
 ## How to fix it
 
-Add a meaningful XML comment above the declaration. In most cases a short &lt;summary&gt; is the best fix.
+Add a meaningful XML comment above the declaration. In most cases a short `<summary>` is the best fix.
 
 ## Examples
 

--- a/documentation/rules/RH8006.md
+++ b/documentation/rules/RH8006.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-This rule requires private interface declarations to have XML documentation. A declaration counts as documented when it has a &lt;summary&gt; tag or uses &lt;inheritdoc/&gt;.
+This rule requires private interface declarations to have XML documentation. A declaration counts as documented when it has a `<summary>` tag or uses `<inheritdoc/>`.
 
 ## Why is this a problem?
 
@@ -17,7 +17,7 @@ A private interface is visible only inside the type that declares it, so nothing
 
 ## How to fix it
 
-Add a meaningful XML comment above the declaration. In most cases a short &lt;summary&gt; is the best fix.
+Add a meaningful XML comment above the declaration. In most cases a short `<summary>` is the best fix.
 
 ## Examples
 

--- a/documentation/rules/RH8007.md
+++ b/documentation/rules/RH8007.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-This rule requires non-private record declarations to have XML documentation. A declaration counts as documented when it has a &lt;summary&gt; tag or uses &lt;inheritdoc/&gt;.
+This rule requires non-private record declarations to have XML documentation. A declaration counts as documented when it has a `<summary>` tag or uses `<inheritdoc/>`.
 
 ## Why is this a problem?
 
@@ -17,7 +17,7 @@ Undocumented non-private record declarations make the code harder to understand 
 
 ## How to fix it
 
-Add a meaningful XML comment above the declaration. In most cases a short &lt;summary&gt; is the best fix.
+Add a meaningful XML comment above the declaration. In most cases a short `<summary>` is the best fix.
 
 ## Examples
 

--- a/documentation/rules/RH8008.md
+++ b/documentation/rules/RH8008.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-This rule requires private record declarations to have XML documentation. A declaration counts as documented when it has a &lt;summary&gt; tag or uses &lt;inheritdoc/&gt;.
+This rule requires private record declarations to have XML documentation. A declaration counts as documented when it has a `<summary>` tag or uses `<inheritdoc/>`.
 
 ## Why is this a problem?
 
@@ -17,7 +17,7 @@ A private record is visible only inside the type that declares it, so nothing ou
 
 ## How to fix it
 
-Add a meaningful XML comment above the declaration. In most cases a short &lt;summary&gt; is the best fix.
+Add a meaningful XML comment above the declaration. In most cases a short `<summary>` is the best fix.
 
 ## Examples
 

--- a/documentation/rules/RH8009.md
+++ b/documentation/rules/RH8009.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-This rule requires non-private record struct declarations to have XML documentation. A declaration counts as documented when it has a &lt;summary&gt; tag or uses &lt;inheritdoc/&gt;.
+This rule requires non-private record struct declarations to have XML documentation. A declaration counts as documented when it has a `<summary>` tag or uses `<inheritdoc/>`.
 
 ## Why is this a problem?
 
@@ -17,7 +17,7 @@ Undocumented non-private record struct declarations make the code harder to unde
 
 ## How to fix it
 
-Add a meaningful XML comment above the declaration. In most cases a short &lt;summary&gt; is the best fix.
+Add a meaningful XML comment above the declaration. In most cases a short `<summary>` is the best fix.
 
 ## Examples
 

--- a/documentation/rules/RH8010.md
+++ b/documentation/rules/RH8010.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-This rule requires private record struct declarations to have XML documentation. A declaration counts as documented when it has a &lt;summary&gt; tag or uses &lt;inheritdoc/&gt;.
+This rule requires private record struct declarations to have XML documentation. A declaration counts as documented when it has a `<summary>` tag or uses `<inheritdoc/>`.
 
 ## Why is this a problem?
 
@@ -17,7 +17,7 @@ A private record struct is visible only inside the type that declares it, so not
 
 ## How to fix it
 
-Add a meaningful XML comment above the declaration. In most cases a short &lt;summary&gt; is the best fix.
+Add a meaningful XML comment above the declaration. In most cases a short `<summary>` is the best fix.
 
 ## Examples
 

--- a/documentation/rules/RH8011.md
+++ b/documentation/rules/RH8011.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-This rule requires non-private enum declarations to have XML documentation. A declaration counts as documented when it has a &lt;summary&gt; tag or uses &lt;inheritdoc/&gt;.
+This rule requires non-private enum declarations to have XML documentation. A declaration counts as documented when it has a `<summary>` tag or uses `<inheritdoc/>`.
 
 ## Why is this a problem?
 
@@ -17,7 +17,7 @@ Undocumented non-private enum declarations make the code harder to understand be
 
 ## How to fix it
 
-Add a meaningful XML comment above the declaration. In most cases a short &lt;summary&gt; is the best fix.
+Add a meaningful XML comment above the declaration. In most cases a short `<summary>` is the best fix.
 
 ## Examples
 

--- a/documentation/rules/RH8012.md
+++ b/documentation/rules/RH8012.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-This rule requires private enum declarations to have XML documentation. A declaration counts as documented when it has a &lt;summary&gt; tag or uses &lt;inheritdoc/&gt;.
+This rule requires private enum declarations to have XML documentation. A declaration counts as documented when it has a `<summary>` tag or uses `<inheritdoc/>`.
 
 ## Why is this a problem?
 
@@ -17,7 +17,7 @@ A private enum is visible only inside the type that declares it, so nothing outs
 
 ## How to fix it
 
-Add a meaningful XML comment above the declaration. In most cases a short &lt;summary&gt; is the best fix.
+Add a meaningful XML comment above the declaration. In most cases a short `<summary>` is the best fix.
 
 ## Examples
 

--- a/documentation/rules/RH8015.md
+++ b/documentation/rules/RH8015.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-This rule requires non-private delegate declarations to have XML documentation. A declaration counts as documented when it has a &lt;summary&gt; tag or uses &lt;inheritdoc/&gt;.
+This rule requires non-private delegate declarations to have XML documentation. A declaration counts as documented when it has a `<summary>` tag or uses `<inheritdoc/>`.
 
 ## Why is this a problem?
 
@@ -17,7 +17,7 @@ Undocumented non-private delegate declarations make the code harder to understan
 
 ## How to fix it
 
-Add a meaningful XML comment above the declaration. In most cases a short &lt;summary&gt; is the best fix.
+Add a meaningful XML comment above the declaration. In most cases a short `<summary>` is the best fix.
 
 ## Examples
 

--- a/documentation/rules/RH8016.md
+++ b/documentation/rules/RH8016.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-This rule requires private delegate declarations to have XML documentation. A declaration counts as documented when it has a &lt;summary&gt; tag or uses &lt;inheritdoc/&gt;.
+This rule requires private delegate declarations to have XML documentation. A declaration counts as documented when it has a `<summary>` tag or uses `<inheritdoc/>`.
 
 ## Why is this a problem?
 
@@ -17,7 +17,7 @@ A private delegate is visible only inside the type that declares it, so nothing 
 
 ## How to fix it
 
-Add a meaningful XML comment above the declaration. In most cases a short &lt;summary&gt; is the best fix.
+Add a meaningful XML comment above the declaration. In most cases a short `<summary>` is the best fix.
 
 ## Examples
 

--- a/documentation/rules/RH8017.md
+++ b/documentation/rules/RH8017.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-This rule requires non-private constructor declarations to have XML documentation. A declaration counts as documented when it has a &lt;summary&gt; tag or uses &lt;inheritdoc/&gt;.
+This rule requires non-private constructor declarations to have XML documentation. A declaration counts as documented when it has a `<summary>` tag or uses `<inheritdoc/>`.
 
 ## Why is this a problem?
 
@@ -17,7 +17,7 @@ Undocumented non-private constructor declarations make the code harder to unders
 
 ## How to fix it
 
-Add a meaningful XML comment above the declaration. In most cases a short &lt;summary&gt; is the best fix.
+Add a meaningful XML comment above the declaration. In most cases a short `<summary>` is the best fix.
 
 ## Examples
 

--- a/documentation/rules/RH8018.md
+++ b/documentation/rules/RH8018.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-This rule requires private constructor declarations to have XML documentation. A declaration counts as documented when it has a &lt;summary&gt; tag or uses &lt;inheritdoc/&gt;.
+This rule requires private constructor declarations to have XML documentation. A declaration counts as documented when it has a `<summary>` tag or uses `<inheritdoc/>`.
 
 ## Why is this a problem?
 
@@ -17,7 +17,7 @@ A constructor is made private on purpose, and the reason is never visible from t
 
 ## How to fix it
 
-Add a meaningful XML comment above the declaration. In most cases a short &lt;summary&gt; is the best fix.
+Add a meaningful XML comment above the declaration. In most cases a short `<summary>` is the best fix.
 
 ## Examples
 

--- a/documentation/rules/RH8019.md
+++ b/documentation/rules/RH8019.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-This rule requires destructor declarations to have XML documentation. A declaration counts as documented when it has a &lt;summary&gt; tag or uses &lt;inheritdoc/&gt;. Unlike the paired rules for the other member kinds, this one does not distinguish accessibility, because a destructor has none.
+This rule requires destructor declarations to have XML documentation. A declaration counts as documented when it has a `<summary>` tag or uses `<inheritdoc/>`. Unlike the paired rules for the other member kinds, this one does not distinguish accessibility, because a destructor has none.
 
 ## Why is this a problem?
 
@@ -17,7 +17,7 @@ Destructors are uncommon and usually indicate important cleanup behavior. Withou
 
 ## How to fix it
 
-Add a meaningful XML comment above the declaration. In most cases a short &lt;summary&gt; is the best fix.
+Add a meaningful XML comment above the declaration. In most cases a short `<summary>` is the best fix.
 
 ## Examples
 

--- a/documentation/rules/RH8020.md
+++ b/documentation/rules/RH8020.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-This rule requires non-private method declarations to have XML documentation. A declaration counts as documented when it has a &lt;summary&gt; tag or uses &lt;inheritdoc/&gt;.
+This rule requires non-private method declarations to have XML documentation. A declaration counts as documented when it has a `<summary>` tag or uses `<inheritdoc/>`.
 
 ## Why is this a problem?
 
@@ -17,13 +17,13 @@ Undocumented non-private method declarations make the code harder to understand 
 
 ## How to fix it
 
-Add a meaningful XML comment above the declaration. In most cases a short &lt;summary&gt; is the best fix.
+Add a meaningful XML comment above the declaration. In most cases a short `<summary>` is the best fix.
 
 ## Exceptions
 
 A method that explicitly implements an interface member, such as `void IDisposable.Dispose()`, is not reported. Its description belongs to the interface member it implements, which is where readers and the editor already look for it.
 
-A method that overrides a base method is reported like any other. Writing &lt;inheritdoc/&gt; on it satisfies the rule and keeps the two descriptions from drifting apart.
+A method that overrides a base method is reported like any other. Writing `<inheritdoc/>` on it satisfies the rule and keeps the two descriptions from drifting apart.
 
 ## Examples
 

--- a/documentation/rules/RH8021.md
+++ b/documentation/rules/RH8021.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-This rule requires private method declarations to have XML documentation. A declaration counts as documented when it has a &lt;summary&gt; tag or uses &lt;inheritdoc/&gt;.
+This rule requires private method declarations to have XML documentation. A declaration counts as documented when it has a `<summary>` tag or uses `<inheritdoc/>`.
 
 ## Why is this a problem?
 
@@ -17,7 +17,7 @@ A private method is callable only from inside the type that declares it, so noth
 
 ## How to fix it
 
-Add a meaningful XML comment above the declaration. In most cases a short &lt;summary&gt; is the best fix.
+Add a meaningful XML comment above the declaration. In most cases a short `<summary>` is the best fix.
 
 ## Exceptions
 

--- a/documentation/rules/RH8022.md
+++ b/documentation/rules/RH8022.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-This rule requires non-private property declarations to have XML documentation. A declaration counts as documented when it has a &lt;summary&gt; tag or uses &lt;inheritdoc/&gt;.
+This rule requires non-private property declarations to have XML documentation. A declaration counts as documented when it has a `<summary>` tag or uses `<inheritdoc/>`.
 
 ## Why is this a problem?
 
@@ -17,13 +17,13 @@ Undocumented non-private property declarations make the code harder to understan
 
 ## How to fix it
 
-Add a meaningful XML comment above the declaration. In most cases a short &lt;summary&gt; is the best fix.
+Add a meaningful XML comment above the declaration. In most cases a short `<summary>` is the best fix.
 
 ## Exceptions
 
 A property that explicitly implements an interface member, such as `string IEntity.Name { get; }`, is not reported. Its description belongs to the interface member it implements, which is where readers and the editor already look for it.
 
-A property that overrides a base property is reported like any other. Writing &lt;inheritdoc/&gt; on it satisfies the rule and keeps the two descriptions from drifting apart.
+A property that overrides a base property is reported like any other. Writing `<inheritdoc/>` on it satisfies the rule and keeps the two descriptions from drifting apart.
 
 ## Examples
 

--- a/documentation/rules/RH8023.md
+++ b/documentation/rules/RH8023.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-This rule requires private property declarations to have XML documentation. A declaration counts as documented when it has a &lt;summary&gt; tag or uses &lt;inheritdoc/&gt;.
+This rule requires private property declarations to have XML documentation. A declaration counts as documented when it has a `<summary>` tag or uses `<inheritdoc/>`.
 
 ## Why is this a problem?
 
@@ -17,7 +17,7 @@ A private property is visible only inside the type that declares it, so nothing 
 
 ## How to fix it
 
-Add a meaningful XML comment above the declaration. In most cases a short &lt;summary&gt; is the best fix.
+Add a meaningful XML comment above the declaration. In most cases a short `<summary>` is the best fix.
 
 ## Exceptions
 

--- a/documentation/rules/RH8024.md
+++ b/documentation/rules/RH8024.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-This rule requires non-private indexer declarations to have XML documentation. A declaration counts as documented when it has a &lt;summary&gt; tag or uses &lt;inheritdoc/&gt;.
+This rule requires non-private indexer declarations to have XML documentation. A declaration counts as documented when it has a `<summary>` tag or uses `<inheritdoc/>`.
 
 ## Why is this a problem?
 
@@ -17,13 +17,13 @@ Undocumented non-private indexer declarations make the code harder to understand
 
 ## How to fix it
 
-Add a meaningful XML comment above the declaration. In most cases a short &lt;summary&gt; is the best fix.
+Add a meaningful XML comment above the declaration. In most cases a short `<summary>` is the best fix.
 
 ## Exceptions
 
 An indexer that explicitly implements an interface member, such as `int IBuffer.this[int index]`, is not reported. Its description belongs to the interface member it implements, which is where readers and the editor already look for it.
 
-An indexer that overrides a base indexer is reported like any other. Writing &lt;inheritdoc/&gt; on it satisfies the rule and keeps the two descriptions from drifting apart.
+An indexer that overrides a base indexer is reported like any other. Writing `<inheritdoc/>` on it satisfies the rule and keeps the two descriptions from drifting apart.
 
 ## Examples
 

--- a/documentation/rules/RH8025.md
+++ b/documentation/rules/RH8025.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-This rule requires private indexer declarations to have XML documentation. A declaration counts as documented when it has a &lt;summary&gt; tag or uses &lt;inheritdoc/&gt;.
+This rule requires private indexer declarations to have XML documentation. A declaration counts as documented when it has a `<summary>` tag or uses `<inheritdoc/>`.
 
 ## Why is this a problem?
 
@@ -17,7 +17,7 @@ A private indexer is usable only inside the type that declares it, and its signa
 
 ## How to fix it
 
-Add a meaningful XML comment above the declaration. In most cases a short &lt;summary&gt; is the best fix.
+Add a meaningful XML comment above the declaration. In most cases a short `<summary>` is the best fix.
 
 ## Exceptions
 

--- a/documentation/rules/RH8026.md
+++ b/documentation/rules/RH8026.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-This rule requires non-private field declarations to have XML documentation. A declaration counts as documented when it has a &lt;summary&gt; tag or uses &lt;inheritdoc/&gt;.
+This rule requires non-private field declarations to have XML documentation. A declaration counts as documented when it has a `<summary>` tag or uses `<inheritdoc/>`.
 
 ## Why is this a problem?
 
@@ -17,7 +17,7 @@ Undocumented non-private field declarations make the code harder to understand b
 
 ## How to fix it
 
-Add a meaningful XML comment above the declaration. In most cases a short &lt;summary&gt; is the best fix.
+Add a meaningful XML comment above the declaration. In most cases a short `<summary>` is the best fix.
 
 ## Examples
 

--- a/documentation/rules/RH8027.md
+++ b/documentation/rules/RH8027.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-This rule requires private field declarations to have XML documentation. A declaration counts as documented when it has a &lt;summary&gt; tag or uses &lt;inheritdoc/&gt;.
+This rule requires private field declarations to have XML documentation. A declaration counts as documented when it has a `<summary>` tag or uses `<inheritdoc/>`.
 
 ## Why is this a problem?
 
@@ -17,7 +17,7 @@ A private field is state that outlives every call, and its type and name rarely 
 
 ## How to fix it
 
-Add a meaningful XML comment above the declaration. In most cases a short &lt;summary&gt; is the best fix.
+Add a meaningful XML comment above the declaration. In most cases a short `<summary>` is the best fix.
 
 ## Examples
 

--- a/documentation/rules/RH8028.md
+++ b/documentation/rules/RH8028.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-This rule requires non-private event declarations to have XML documentation. A declaration counts as documented when it has a &lt;summary&gt; tag or uses &lt;inheritdoc/&gt;.
+This rule requires non-private event declarations to have XML documentation. A declaration counts as documented when it has a `<summary>` tag or uses `<inheritdoc/>`.
 
 ## Why is this a problem?
 
@@ -17,13 +17,13 @@ Undocumented non-private event declarations make the code harder to understand b
 
 ## How to fix it
 
-Add a meaningful XML comment above the declaration. In most cases a short &lt;summary&gt; is the best fix.
+Add a meaningful XML comment above the declaration. In most cases a short `<summary>` is the best fix.
 
 ## Exceptions
 
 An event that explicitly implements an interface member, such as `event System.Action IPublisher.Changed`, is not reported. Its description belongs to the interface member it implements, which is where readers and the editor already look for it.
 
-An event that overrides a base event is reported like any other. Writing &lt;inheritdoc/&gt; on it satisfies the rule and keeps the two descriptions from drifting apart.
+An event that overrides a base event is reported like any other. Writing `<inheritdoc/>` on it satisfies the rule and keeps the two descriptions from drifting apart.
 
 ## Examples
 

--- a/documentation/rules/RH8029.md
+++ b/documentation/rules/RH8029.md
@@ -9,7 +9,7 @@
 
 ## Description
 
-This rule requires private event declarations to have XML documentation. A declaration counts as documented when it has a &lt;summary&gt; tag or uses &lt;inheritdoc/&gt;.
+This rule requires private event declarations to have XML documentation. A declaration counts as documented when it has a `<summary>` tag or uses `<inheritdoc/>`.
 
 ## Why is this a problem?
 
@@ -17,7 +17,7 @@ An event says nothing about when it is raised, and a private one is raised only 
 
 ## How to fix it
 
-Add a meaningful XML comment above the declaration. In most cases a short &lt;summary&gt; is the best fix.
+Add a meaningful XML comment above the declaration. In most cases a short `<summary>` is the best fix.
 
 ## Exceptions
 

--- a/documentation/rules/RH8030.md
+++ b/documentation/rules/RH8030.md
@@ -9,9 +9,9 @@
 
 ## Description
 
-This rule requires every &lt;summary&gt; tag to contain meaningful text.
+This rule requires every `<summary>` tag to contain meaningful text.
 
-The rules that require a declaration to be documented at all — RH8001 to RH8029 — are satisfied as soon as a &lt;summary&gt; tag is present. This rule is the one that requires the tag to actually say something, so an empty summary added only to silence those rules is still reported.
+The rules that require a declaration to be documented at all — RH8001 to RH8029 — are satisfied as soon as a `<summary>` tag is present. This rule is the one that requires the tag to actually say something, so an empty summary added only to silence those rules is still reported.
 
 ## Why is this a problem?
 
@@ -19,7 +19,7 @@ An empty summary is worse than no summary at all. A reader who opens the declara
 
 ## How to fix it
 
-Write a short, useful description inside the &lt;summary&gt; tag.
+Write a short, useful description inside the `<summary>` tag.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

Adds a scope paragraph to the `## Description` section of the twelve RH55xx attribute-placement/shape rule pairs (RH5505/5506, RH5507/5508, RH5513/5514, RH5515/5516, RH5517/5518, RH5519/5520), naming the additional declaration kinds each one also reports on. Also replaces the entity-escaped `&lt;summary&gt;`/`&lt;inheritdoc/&gt;` XML tag spelling with code spans in the 28 RH80xx documentation-coverage rule docs (RH8001–RH8012, RH8015–RH8030), matching the style RH8013/RH8014 already use.

## Why

Each RH55xx rule is titled after a single declaration kind but is driven by an `AttributeTargets` value that covers several (`Reihitsu.Core/AttributeTargetUtilities.cs`, `TryResolveImplicitTarget`), so a reader whose lambda or record struct is reported had no way to learn from the page that this is intended behavior rather than a bug. Verified against source for all twelve rules:

- RH5505/5506 (Class) also report on record classes.
- RH5507/5508 (Struct) also report on record structs.
- RH5513/5514 (Method) also report on operators, conversion operators, destructors, local functions, and lambdas — but explicitly exclude accessors (`attributeList.Parent is not AccessorDeclarationSyntax`), so their added paragraph points to RH5530/RH5531 instead of claiming accessor coverage.
- RH5515/5516 (Property) also report on indexers.
- RH5517/5518 (Field) also report on enum members.
- RH5519/5520 (Event) also report on event field declarations.

The RH80xx tag spelling was inconsistent across the folder (entity escapes vs. code spans) for no reason a reader could detect; a repo-wide check now shows zero `&lt;`/`&gt;` occurrences left under `documentation/rules/`.

## Linked issues

Closes #670

## Review notes

No analyzer, code-fix, formatter, or `Reihitsu.Core` behavior changed — pure documentation, confirmed by `git status` showing exactly the 40 intended `documentation/rules/RH####.md` files. Full validation (`scripts/build.sh` + `scripts/test.sh`) is green: 0 build warnings/errors, 4632 tests passed across all 6 test projects, including `AnalyzerPackageMetadataTests`.

## Follow-up work

None.