### PR TITLE
Test the analyzer title/message-format resources against the rule docs

### DIFF
--- a/Reihitsu.Analyzer.Test/Clarity/RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Clarity/RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzerTests.cs
@@ -45,7 +45,7 @@ public class RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzerTests : Anal
                                  }
                                  """;
 
-        await Verify(testCode, fixedCode, Diagnostics(RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzer.DiagnosticId, "Statements must not use unnecessary parentheses."));
+        await Verify(testCode, fixedCode, Diagnostics(RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzer.DiagnosticId, "Statement must not use unnecessary parentheses"));
     }
 
     /// <summary>
@@ -79,7 +79,7 @@ public class RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzerTests : Anal
                                  }
                                  """;
 
-        await Verify(testCode, fixedCode, Diagnostics(RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzer.DiagnosticId, "Statements must not use unnecessary parentheses."));
+        await Verify(testCode, fixedCode, Diagnostics(RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzer.DiagnosticId, "Statement must not use unnecessary parentheses"));
     }
 
     /// <summary>
@@ -109,7 +109,7 @@ public class RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzerTests : Anal
                                  }
                                  """;
 
-        await Verify(testCode, fixedCode, Diagnostics(RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzer.DiagnosticId, "Statements must not use unnecessary parentheses."));
+        await Verify(testCode, fixedCode, Diagnostics(RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzer.DiagnosticId, "Statement must not use unnecessary parentheses"));
     }
 
     /// <summary>
@@ -147,7 +147,7 @@ public class RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzerTests : Anal
                                  }
                                  """;
 
-        await Verify(testCode, fixedCode, Diagnostics(RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzer.DiagnosticId, "Statements must not use unnecessary parentheses."));
+        await Verify(testCode, fixedCode, Diagnostics(RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzer.DiagnosticId, "Statement must not use unnecessary parentheses"));
     }
 
     /// <summary>
@@ -171,7 +171,7 @@ public class RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzerTests : Anal
                                  }
                                  """;
 
-        await Verify(testCode, fixedCode, Diagnostics(RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzer.DiagnosticId, "Statements must not use unnecessary parentheses."));
+        await Verify(testCode, fixedCode, Diagnostics(RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzer.DiagnosticId, "Statement must not use unnecessary parentheses"));
     }
 
     /// <summary>
@@ -204,7 +204,7 @@ public class RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzerTests : Anal
         await Verify(testCode,
                      fixedCode,
                      onConfigure: config => config.NumberOfFixAllIterations = 2,
-                     Diagnostics(RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzer.DiagnosticId, "Statements must not use unnecessary parentheses.", 2));
+                     Diagnostics(RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzer.DiagnosticId, "Statement must not use unnecessary parentheses", 2));
     }
 
     /// <summary>
@@ -276,7 +276,7 @@ public class RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzerTests : Anal
                                  }
                                  """;
 
-        await Verify(testCode, fixedCode, Diagnostics(RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzer.DiagnosticId, "Statements must not use unnecessary parentheses."));
+        await Verify(testCode, fixedCode, Diagnostics(RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzer.DiagnosticId, "Statement must not use unnecessary parentheses"));
     }
 
     /// <summary>
@@ -316,7 +316,7 @@ public class RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzerTests : Anal
                                  }
                                  """;
 
-        await Verify(testCode, fixedCode, Diagnostics(RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzer.DiagnosticId, "Statements must not use unnecessary parentheses."));
+        await Verify(testCode, fixedCode, Diagnostics(RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzer.DiagnosticId, "Statement must not use unnecessary parentheses"));
     }
 
     /// <summary>
@@ -348,7 +348,7 @@ public class RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzerTests : Anal
                                  }
                                  """;
 
-        await Verify(testCode, fixedCode, Diagnostics(RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzer.DiagnosticId, "Statements must not use unnecessary parentheses."));
+        await Verify(testCode, fixedCode, Diagnostics(RH3002StatementMustNotUseUnnecessaryParenthesesAnalyzer.DiagnosticId, "Statement must not use unnecessary parentheses"));
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer.Test/SelfHosting/AnalyzerMetadataDiscovery.cs
+++ b/Reihitsu.Analyzer.Test/SelfHosting/AnalyzerMetadataDiscovery.cs
@@ -45,6 +45,11 @@ internal static class AnalyzerMetadataDiscovery
     /// <returns>The formatter test class diagnostic ID regex</returns>
     private static readonly Regex _formatterTestClassDiagnosticIdRegex = new(@"^(RH\d{4}(?:[A-Z](?=[A-Z]))?)", RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100));
 
+    /// <summary>
+    /// Regex that detects numbered message-format placeholders such as <c>{0}</c>
+    /// </summary>
+    private static readonly Regex _messageFormatPlaceholderRegex = new(@"\{\d+\}", RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(100));
+
     #endregion // Fields
 
     #region Methods
@@ -170,6 +175,18 @@ internal static class AnalyzerMetadataDiscovery
         return _whitespaceCollapseRegex.Replace(normalizedValue, " ")
                                        .Trim()
                                        .TrimEnd('.');
+    }
+
+    /// <summary>
+    /// Determines whether a message format string contains a numbered placeholder
+    /// </summary>
+    /// <param name="messageFormat">Message format to inspect</param>
+    /// <returns><see langword="true"/> when the message format contains a placeholder such as <c>{0}</c>; otherwise, <see langword="false"/></returns>
+    internal static bool ContainsPlaceholder(string messageFormat)
+    {
+        ArgumentNullException.ThrowIfNull(messageFormat);
+
+        return _messageFormatPlaceholderRegex.IsMatch(messageFormat);
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer.Test/SelfHosting/AnalyzerPackageMetadataTests.cs
+++ b/Reihitsu.Analyzer.Test/SelfHosting/AnalyzerPackageMetadataTests.cs
@@ -1,7 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Analyzer;
 
 namespace Reihitsu.Analyzer.Test.SelfHosting;
 
@@ -11,6 +14,98 @@ namespace Reihitsu.Analyzer.Test.SelfHosting;
 [TestClass]
 public class AnalyzerPackageMetadataTests
 {
+    #region Fields
+
+    /// <summary>
+    /// Diagnostic IDs whose message format is intentionally more specific than their title - naming a concrete
+    /// remediation step, XML tag, disambiguating direction, or the singular subject a diagnostic instance
+    /// actually points at - so equalizing it with the title would remove information rather than redundancy
+    /// </summary>
+    private static readonly HashSet<string> _messageFormatIntentionallyDiffersFromTitle = new(StringComparer.Ordinal)
+                                                                                          {
+                                                                                              // Message states a concrete remediation step or configuration pointer the title omits
+                                                                                              "RH0002",
+                                                                                              "RH2109",
+                                                                                              "RH4009",
+                                                                                              "RH7004",
+                                                                                              "RH7501",
+
+                                                                                              // Message disambiguates an order or scope the title leaves ambiguous or under-specifies
+                                                                                              "RH5111",
+                                                                                              "RH5113",
+                                                                                              "RH5205",
+                                                                                              "RH7110",
+                                                                                              "RH7205",
+                                                                                              "RH7207",
+
+                                                                                              // Title states the general plural rule; message names the singular element a diagnostic instance
+                                                                                              // actually points at (documentation-coverage rule family)
+                                                                                              "RH8001",
+                                                                                              "RH8002",
+                                                                                              "RH8003",
+                                                                                              "RH8004",
+                                                                                              "RH8005",
+                                                                                              "RH8006",
+                                                                                              "RH8007",
+                                                                                              "RH8008",
+                                                                                              "RH8009",
+                                                                                              "RH8010",
+                                                                                              "RH8011",
+                                                                                              "RH8012",
+                                                                                              "RH8013",
+                                                                                              "RH8014",
+                                                                                              "RH8015",
+                                                                                              "RH8016",
+                                                                                              "RH8017",
+                                                                                              "RH8018",
+                                                                                              "RH8019",
+                                                                                              "RH8020",
+                                                                                              "RH8021",
+                                                                                              "RH8022",
+                                                                                              "RH8023",
+                                                                                              "RH8024",
+                                                                                              "RH8025",
+                                                                                              "RH8026",
+                                                                                              "RH8027",
+                                                                                              "RH8028",
+                                                                                              "RH8029",
+                                                                                              "RH8402",
+
+                                                                                              // Message names the concrete XML documentation tag the title only describes generically
+                                                                                              "RH8030",
+                                                                                              "RH8031",
+                                                                                              "RH8032",
+                                                                                              "RH8033",
+                                                                                              "RH8101",
+                                                                                              "RH8102",
+                                                                                              "RH8103",
+                                                                                              "RH8104",
+                                                                                              "RH8105",
+                                                                                              "RH8106",
+                                                                                              "RH8107",
+                                                                                              "RH8108",
+                                                                                              "RH8109",
+                                                                                              "RH8110",
+                                                                                              "RH8111",
+                                                                                              "RH8204",
+
+                                                                                              // Title carries a markdown code span copied from the rule document; the message is plain runtime text
+                                                                                              "RH3003",
+                                                                                              "RH3101",
+                                                                                              "RH3105",
+                                                                                              "RH8202",
+                                                                                              "RH8203",
+
+                                                                                              // Message covers a second, independently checked modifier pair the title's single example does not name
+                                                                                              "RH7106",
+
+                                                                                              // Message names the actual, narrower element kind the analyzer checks; the title matches the rule
+                                                                                              // document's own heading, which is outside the scope of this test to rewrite
+                                                                                              "RH7109"
+                                                                                          };
+
+    #endregion // Fields
+
     #region Tests
 
     /// <summary>
@@ -146,6 +241,62 @@ public class AnalyzerPackageMetadataTests
                                   .ToArray();
 
         Assert.IsEmpty(mismatches, $"The analyzer package README descriptions must match the rule documentation titles.{Environment.NewLine}{string.Join(Environment.NewLine, mismatches)}");
+    }
+
+    /// <summary>
+    /// Verifies every analyzer's title resource matches its rule documentation title
+    /// </summary>
+    [TestMethod]
+    public void AnalyzerTitleResourcesMatchRuleDocumentationTitles()
+    {
+        var analyzers = AnalyzerMetadataDiscovery.DiscoverAnalyzers();
+        var documentedRules = AnalyzerMetadataDiscovery.ParseRuleDocumentationTitles();
+
+        var mismatches = analyzers.Select(analyzer => new
+                                                      {
+                                                          Analyzer = analyzer,
+                                                          TitleResource = AnalyzerResources.ResourceManager.GetString($"{analyzer.DiagnosticId}Title"),
+                                                          DocumentedRule = documentedRules.SingleOrDefault(rule => rule.DiagnosticId == analyzer.DiagnosticId)
+                                                      })
+                                  .Where(entry => entry.TitleResource == null
+                                                  || entry.DocumentedRule == null
+                                                  || string.Equals(AnalyzerMetadataDiscovery.NormalizeRuleTitle(entry.TitleResource),
+                                                                   AnalyzerMetadataDiscovery.NormalizeRuleTitle(entry.DocumentedRule.Title),
+                                                                   StringComparison.OrdinalIgnoreCase) is false)
+                                  .Select(entry => entry.TitleResource == null
+                                                       ? $"{entry.Analyzer.DiagnosticId} ({entry.Analyzer.AnalyzerType.Name}) has no '{entry.Analyzer.DiagnosticId}Title' resource string."
+                                                       : entry.DocumentedRule == null
+                                                           ? $"{entry.Analyzer.DiagnosticId} ({entry.Analyzer.AnalyzerType.Name}) is missing rule documentation."
+                                                           : $"{entry.Analyzer.DiagnosticId} ({entry.Analyzer.AnalyzerType.Name}) title resource '{entry.TitleResource}' does not match rule title '{entry.DocumentedRule.Title}'.")
+                                  .ToArray();
+
+        Assert.IsEmpty(mismatches, $"Every analyzer title resource must match its rule documentation title.{Environment.NewLine}{string.Join(Environment.NewLine, mismatches)}");
+    }
+
+    /// <summary>
+    /// Verifies every analyzer's message format resource matches its title resource when the message format
+    /// contains no placeholders, except for the documented cases where the divergence is intentional
+    /// </summary>
+    [TestMethod]
+    public void MessageFormatResourcesMatchTitleWhenNoPlaceholders()
+    {
+        var analyzers = AnalyzerMetadataDiscovery.DiscoverAnalyzers();
+
+        var mismatches = analyzers.Select(analyzer => new
+                                                      {
+                                                          Analyzer = analyzer,
+                                                          TitleResource = AnalyzerResources.ResourceManager.GetString($"{analyzer.DiagnosticId}Title"),
+                                                          MessageFormatResource = AnalyzerResources.ResourceManager.GetString($"{analyzer.DiagnosticId}MessageFormat")
+                                                      })
+                                  .Where(entry => entry.TitleResource != null
+                                                  && entry.MessageFormatResource != null
+                                                  && AnalyzerMetadataDiscovery.ContainsPlaceholder(entry.MessageFormatResource) is false
+                                                  && _messageFormatIntentionallyDiffersFromTitle.Contains(entry.Analyzer.DiagnosticId) is false
+                                                  && string.Equals(entry.MessageFormatResource, entry.TitleResource, StringComparison.Ordinal) is false)
+                                  .Select(entry => $"{entry.Analyzer.DiagnosticId} ({entry.Analyzer.AnalyzerType.Name}) message format '{entry.MessageFormatResource}' does not match title '{entry.TitleResource}'.")
+                                  .ToArray();
+
+        Assert.IsEmpty(mismatches, $"Every analyzer message format without placeholders must match its title resource, unless listed in {nameof(_messageFormatIntentionallyDiffersFromTitle)}.{Environment.NewLine}{string.Join(Environment.NewLine, mismatches)}");
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer/AnalyzerResources.resx
+++ b/Reihitsu.Analyzer/AnalyzerResources.resx
@@ -118,16 +118,16 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="RH3001MessageFormat" xml:space="preserve">
-    <value>The logical operator ! should not be used for clarity.</value>
+    <value>Not operator should not be used</value>
   </data>
   <data name="RH3001Title" xml:space="preserve">
-    <value>The logical operator ! should not be used for clarity.</value>
+    <value>Not operator should not be used</value>
   </data>
   <data name="RH3101MessageFormat" xml:space="preserve">
     <value>Do not prefix calls with base. Unless a local implementation exists.</value>
   </data>
   <data name="RH3101Title" xml:space="preserve">
-    <value>Do not prefix calls with base. Unless a local implementation exists.</value>
+    <value>Do not prefix calls with `base.` unless a local implementation exists</value>
   </data>
   <data name="RH3102MessageFormat" xml:space="preserve">
     <value>Code must not contain empty statements.</value>
@@ -136,10 +136,10 @@
     <value>Code must not contain empty statements.</value>
   </data>
   <data name="RH3002MessageFormat" xml:space="preserve">
-    <value>Statements must not use unnecessary parentheses.</value>
+    <value>Statement must not use unnecessary parentheses</value>
   </data>
   <data name="RH3002Title" xml:space="preserve">
-    <value>Statements must not use unnecessary parentheses.</value>
+    <value>Statement must not use unnecessary parentheses</value>
   </data>
   <data name="RH3201MessageFormat" xml:space="preserve">
     <value>Comments must contain text.</value>
@@ -151,7 +151,7 @@
     <value>Use string.Empty for empty strings.</value>
   </data>
   <data name="RH3003Title" xml:space="preserve">
-    <value>Use string.Empty for empty strings.</value>
+    <value>Use `string.Empty` for empty strings</value>
   </data>
   <data name="RH3103MessageFormat" xml:space="preserve">
     <value>Use shorthand for nullable types.</value>
@@ -187,7 +187,7 @@
     <value>Do not prefix local members with this.</value>
   </data>
   <data name="RH3105Title" xml:space="preserve">
-    <value>Do not prefix local members with this.</value>
+    <value>Do not prefix local members with `this.`</value>
   </data>
   <data name="RH3007MessageFormat" xml:space="preserve">
     <value>Do not use query syntax.</value>
@@ -322,10 +322,10 @@
     <value>Razor @code blocks should not be used.</value>
   </data>
   <data name="RH4001MessageFormat" xml:space="preserve">
-    <value>The name of the class/struct/enum should match the filename.</value>
+    <value>The name of the type should match the filename</value>
   </data>
   <data name="RH4001Title" xml:space="preserve">
-    <value>The name of the class/struct/enum should match the filename.</value>
+    <value>The name of the type should match the filename</value>
   </data>
   <data name="RH4002MessageFormat" xml:space="preserve">
     <value>Class names should be in PascalCase</value>
@@ -340,16 +340,16 @@
     <value>Struct names should be in PascalCase</value>
   </data>
   <data name="RH4004Title" xml:space="preserve">
-    <value>Enumeration names should be in PascalCase</value>
+    <value>Enum names should be in PascalCase</value>
   </data>
   <data name="RH4004MessageFormat" xml:space="preserve">
-    <value>Enumeration names should be in PascalCase</value>
+    <value>Enum names should be in PascalCase</value>
   </data>
   <data name="RH4101Title" xml:space="preserve">
-    <value>Enumeration members names should be in PascalCase</value>
+    <value>Enum member names should be in PascalCase</value>
   </data>
   <data name="RH4101MessageFormat" xml:space="preserve">
-    <value>Enumeration members names should be in PascalCase</value>
+    <value>Enum member names should be in PascalCase</value>
   </data>
   <data name="RH4005Title" xml:space="preserve">
     <value>Interface names should use the I prefix and PascalCase</value>
@@ -370,10 +370,10 @@
     <value>Delegate names should be in PascalCase</value>
   </data>
   <data name="RH4103Title" xml:space="preserve">
-    <value>Method members names should be in PascalCase</value>
+    <value>Method names should be in PascalCase</value>
   </data>
   <data name="RH4103MessageFormat" xml:space="preserve">
-    <value>Method members names should be in PascalCase</value>
+    <value>Method names should be in PascalCase</value>
   </data>
   <data name="RH4104Title" xml:space="preserve">
     <value>Local function names should be in PascalCase</value>
@@ -445,7 +445,7 @@
     <value>Local variable names should be in camelCase</value>
   </data>
   <data name="RH4115MessageFormat" xml:space="preserve">
-    <value>Local variables should be in camelCase</value>
+    <value>Local variable names should be in camelCase</value>
   </data>
   <data name="RH4116Title" xml:space="preserve">
     <value>Named tuple elements should be in PascalCase</value>
@@ -457,7 +457,7 @@
     <value>Deconstruction variable names should be in camelCase</value>
   </data>
   <data name="RH4117MessageFormat" xml:space="preserve">
-    <value>Variables in deconstruction should be in camelCase</value>
+    <value>Deconstruction variable names should be in camelCase</value>
   </data>
   <data name="RH4118Title" xml:space="preserve">
     <value>Named tuple argument names should be in PascalCase</value>
@@ -466,19 +466,19 @@
     <value>Named tuple argument names should be in PascalCase</value>
   </data>
   <data name="RH4007Title" xml:space="preserve">
-    <value>Namespaces should be in PascalCase</value>
+    <value>File scoped namespace declarations should be in PascalCase</value>
   </data>
   <data name="RH4007MessageFormat" xml:space="preserve">
-    <value>Namespaces should be in PascalCase</value>
+    <value>File scoped namespace declarations should be in PascalCase</value>
   </data>
   <data name="RH4008Title" xml:space="preserve">
-    <value>Namespaces should be in PascalCase</value>
+    <value>Namespace declarations should be in PascalCase</value>
   </data>
   <data name="RH4008MessageFormat" xml:space="preserve">
-    <value>Namespaces should be in PascalCase</value>
+    <value>Namespace declarations should be in PascalCase</value>
   </data>
   <data name="RH4009Title" xml:space="preserve">
-    <value>The given namespace is not allowed (see reihitsu.json)</value>
+    <value>The given namespace is not allowed</value>
   </data>
   <data name="RH4009MessageFormat" xml:space="preserve">
     <value>The given namespace is not allowed (see reihitsu.json)</value>
@@ -544,130 +544,130 @@
     <value>Single-letter catch exception variable names should not be used</value>
   </data>
   <data name="RH7301MessageFormat" xml:space="preserve">
-    <value>The description of the #region and #endregion should match.</value>
+    <value>#region and #endregion descriptions should match</value>
   </data>
   <data name="RH7301Title" xml:space="preserve">
-    <value>The description of the #region and #endregion should match.</value>
+    <value>#region and #endregion descriptions should match</value>
   </data>
   <data name="RH5301MessageFormat" xml:space="preserve">
-    <value>The object initializer should be formatted correctly.</value>
+    <value>Object initializer should be formatted correctly</value>
   </data>
   <data name="RH5301Title" xml:space="preserve">
-    <value>The object initializer should be formatted correctly.</value>
+    <value>Object initializer should be formatted correctly</value>
   </data>
   <data name="RH5001MessageFormat" xml:space="preserve">
-    <value>The try-Statement should be preceded by a blank line.</value>
+    <value>try-Statement should be preceded by a blank line</value>
   </data>
   <data name="RH5001Title" xml:space="preserve">
-    <value>The try-Statement should be preceded by a blank line.</value>
+    <value>try-Statement should be preceded by a blank line</value>
   </data>
   <data name="RH5002MessageFormat" xml:space="preserve">
-    <value>The if-Statement should be preceded by a blank line.</value>
+    <value>if-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5002Title" xml:space="preserve">
-    <value>The if-Statement should be preceded by a blank line.</value>
+    <value>if-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5003MessageFormat" xml:space="preserve">
-    <value>The while-Statement should be preceded by a blank line.</value>
+    <value>while-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5003Title" xml:space="preserve">
-    <value>The while-Statement should be preceded by a blank line.</value>
+    <value>while-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5004MessageFormat" xml:space="preserve">
-    <value>The do-Statement should be preceded by a blank line.</value>
+    <value>do-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5004Title" xml:space="preserve">
-    <value>The do-Statement should be preceded by a blank line.</value>
+    <value>do-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5005MessageFormat" xml:space="preserve">
-    <value>The using-Statement should be preceded by a blank line.</value>
+    <value>using-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5005Title" xml:space="preserve">
-    <value>The using-Statement should be preceded by a blank line.</value>
+    <value>using-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5006MessageFormat" xml:space="preserve">
-    <value>The foreach-Statement should be preceded by a blank line.</value>
+    <value>foreach-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5006Title" xml:space="preserve">
-    <value>The foreach-Statement should be preceded by a blank line.</value>
+    <value>foreach-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5007MessageFormat" xml:space="preserve">
-    <value>The for-Statement should be preceded by a blank line.</value>
+    <value>for-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5007Title" xml:space="preserve">
-    <value>The for-Statement should be preceded by a blank line.</value>
+    <value>for-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5008MessageFormat" xml:space="preserve">
-    <value>The return-Statement should be preceded by a blank line.</value>
+    <value>return-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5008Title" xml:space="preserve">
-    <value>The return-Statement should be preceded by a blank line.</value>
+    <value>return-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5009MessageFormat" xml:space="preserve">
-    <value>The goto-Statement should be preceded by a blank line.</value>
+    <value>goto-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5009Title" xml:space="preserve">
-    <value>The goto-Statement should be preceded by a blank line.</value>
+    <value>goto-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5010MessageFormat" xml:space="preserve">
-    <value>The break-Statement should be preceded by a blank line.</value>
+    <value>break-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5010Title" xml:space="preserve">
-    <value>The break-Statement should be preceded by a blank line.</value>
+    <value>break-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5011MessageFormat" xml:space="preserve">
-    <value>The break-Statement should be followed by a blank line.</value>
+    <value>break-Statement should be followed by a blank line</value>
   </data>
    <data name="RH5011Title" xml:space="preserve">
-    <value>The break-Statement should be followed by a blank line.</value>
+    <value>break-Statement should be followed by a blank line</value>
   </data>
    <data name="RH5012MessageFormat" xml:space="preserve">
-    <value>The continue-Statement should be preceded by a blank line.</value>
+    <value>continue-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5012Title" xml:space="preserve">
-    <value>The continue-Statement should be preceded by a blank line.</value>
+    <value>continue-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5013MessageFormat" xml:space="preserve">
-    <value>The throw-Statement should be preceded by a blank line.</value>
+    <value>throw-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5013Title" xml:space="preserve">
-    <value>The throw-Statement should be preceded by a blank line.</value>
+    <value>throw-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5014MessageFormat" xml:space="preserve">
-    <value>The switch-Statement should be preceded by a blank line.</value>
+    <value>switch-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5014Title" xml:space="preserve">
-    <value>The switch-Statement should be preceded by a blank line.</value>
+    <value>switch-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5015MessageFormat" xml:space="preserve">
-    <value>The checked-Statement should be preceded by a blank line.</value>
+    <value>checked-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5015Title" xml:space="preserve">
-    <value>The checked-Statement should be preceded by a blank line.</value>
+    <value>checked-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5016MessageFormat" xml:space="preserve">
-    <value>The unchecked-Statement should be preceded by a blank line.</value>
+    <value>unchecked-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5016Title" xml:space="preserve">
-    <value>The unchecked-Statement should be preceded by a blank line.</value>
+    <value>unchecked-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5017MessageFormat" xml:space="preserve">
-    <value>The fixed-Statement should be preceded by a blank line.</value>
+    <value>fixed-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5017Title" xml:space="preserve">
-    <value>The fixed-Statement should be preceded by a blank line.</value>
+    <value>fixed-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5018MessageFormat" xml:space="preserve">
-    <value>The lock-Statement should be preceded by a blank line.</value>
+    <value>lock-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5018Title" xml:space="preserve">
-    <value>The lock-Statement should be preceded by a blank line.</value>
+    <value>lock-Statement should be preceded by a blank line</value>
   </data>
    <data name="RH5019MessageFormat" xml:space="preserve">
-    <value>The yield-Statement should be preceded by a blank line.</value>
+    <value>yield-Statement should be preceded by a blank line</value>
   </data>
   <data name="RH5019Title" xml:space="preserve">
-    <value>The yield-Statement should be preceded by a blank line.</value>
+    <value>yield-Statement should be preceded by a blank line</value>
   </data>
   <data name="RH5020MessageFormat" xml:space="preserve">
     <value>Comments should be preceded by a blank line.</value>
@@ -694,10 +694,10 @@
     <value>Wrapped fluent calls should keep the first call on the original line.</value>
   </data>
   <data name="RH5303MessageFormat" xml:space="preserve">
-    <value>The collection initializer should be formatted correctly.</value>
+    <value>Collection initializer should be formatted correctly</value>
   </data>
   <data name="RH5303Title" xml:space="preserve">
-    <value>The collection initializer should be formatted correctly.</value>
+    <value>Collection initializer should be formatted correctly</value>
   </data>
   <data name="RH5206MessageFormat" xml:space="preserve">
     <value>Switch expression braces should be anchored.</value>
@@ -838,7 +838,7 @@
     <value>Empty record structs should use semicolon declarations.</value>
   </data>
   <data name="RH5417MessageFormat" xml:space="preserve">
-    <value>Function and accessor body braces must not share a line.</value>
+    <value>Function and accessor body braces must not share a line</value>
   </data>
   <data name="RH5417Title" xml:space="preserve">
     <value>Function and accessor body braces must not share a line</value>
@@ -898,10 +898,10 @@
     <value>Expression style get-only properties should be single lined.</value>
   </data>
   <data name="RH7302MessageFormat" xml:space="preserve">
-    <value>The description of the #region should start with an uppercase letter.</value>
+    <value>#region description should start with an uppercase letter</value>
   </data>
   <data name="RH7302Title" xml:space="preserve">
-    <value>The description of the #region should start with an uppercase letter.</value>
+    <value>#region description should start with an uppercase letter</value>
   </data>
   <data name="RH5302MessageFormat" xml:space="preserve">
     <value>Logical expressions should be formatted correctly.</value>
@@ -958,367 +958,367 @@
     <value>Code must not contain multiple statements on one line.</value>
   </data>
   <data name="RH7101MessageFormat" xml:space="preserve">
-    <value>Field declarations must not combine multiple variables.</value>
+    <value>Do not combine fields</value>
   </data>
   <data name="RH7101Title" xml:space="preserve">
-    <value>Field declarations must not combine multiple variables.</value>
+    <value>Do not combine fields</value>
   </data>
   <data name="RH7303MessageFormat" xml:space="preserve">
-    <value>Regions must not be placed within elements.</value>
+    <value>Do not place regions within elements</value>
   </data>
   <data name="RH7303Title" xml:space="preserve">
-    <value>Regions must not be placed within elements.</value>
+    <value>Do not place regions within elements</value>
   </data>
   <data name="RH8304MessageFormat" xml:space="preserve">
-    <value>XML documentation elements must be on separate lines.</value>
+    <value>XML documentation elements must be on separate lines</value>
   </data>
   <data name="RH8304Title" xml:space="preserve">
     <value>XML documentation elements must be on separate lines</value>
   </data>
   <data name="RH8305MessageFormat" xml:space="preserve">
-    <value>Summary element must span at least three lines.</value>
+    <value>Summary element must span at least three lines</value>
   </data>
   <data name="RH8305Title" xml:space="preserve">
     <value>Summary element must span at least three lines</value>
   </data>
   <data name="RH8306MessageFormat" xml:space="preserve">
-    <value>Property summary must use a noun phrase instead of a sentence.</value>
+    <value>Property summary must use a noun phrase instead of a sentence</value>
   </data>
   <data name="RH8306Title" xml:space="preserve">
     <value>Property summary must use a noun phrase instead of a sentence</value>
   </data>
   <data name="RH8307MessageFormat" xml:space="preserve">
-    <value>Content after opening XML tag must be on same line as closing tag.</value>
+    <value>Content after opening XML tag must be on same line as closing tag</value>
   </data>
   <data name="RH8307Title" xml:space="preserve">
     <value>Content after opening XML tag must be on same line as closing tag</value>
   </data>
   <data name="RH8308MessageFormat" xml:space="preserve">
-    <value>No content should appear after closing XML tags.</value>
+    <value>No content should appear after closing XML tags</value>
   </data>
   <data name="RH8308Title" xml:space="preserve">
     <value>No content should appear after closing XML tags</value>
   </data>
   <data name="RH8309MessageFormat" xml:space="preserve">
-    <value>XML documentation elements must follow the prescribed order.</value>
+    <value>XML documentation elements must follow a prescribed order</value>
   </data>
   <data name="RH8309Title" xml:space="preserve">
     <value>XML documentation elements must follow a prescribed order</value>
   </data>
   <data name="RH6001MessageFormat" xml:space="preserve">
-    <value>Keywords must be spaced correctly.</value>
+    <value>Keywords must be spaced correctly</value>
   </data>
   <data name="RH6001Title" xml:space="preserve">
     <value>Keywords must be spaced correctly</value>
   </data>
   <data name="RH6002MessageFormat" xml:space="preserve">
-    <value>Commas must be spaced correctly.</value>
+    <value>Commas must be spaced correctly</value>
   </data>
   <data name="RH6002Title" xml:space="preserve">
     <value>Commas must be spaced correctly</value>
   </data>
   <data name="RH6003MessageFormat" xml:space="preserve">
-    <value>Semicolons must be spaced correctly.</value>
+    <value>Semicolons must be spaced correctly</value>
   </data>
   <data name="RH6003Title" xml:space="preserve">
     <value>Semicolons must be spaced correctly</value>
   </data>
   <data name="RH8301MessageFormat" xml:space="preserve">
-    <value>Documentation lines must begin with single space.</value>
+    <value>Documentation lines must begin with single space</value>
   </data>
   <data name="RH8301Title" xml:space="preserve">
     <value>Documentation lines must begin with single space</value>
   </data>
   <data name="RH6004MessageFormat" xml:space="preserve">
-    <value>Preprocessor keywords must not be preceded by space.</value>
+    <value>Preprocessor keywords must not be preceded by space</value>
   </data>
   <data name="RH6004Title" xml:space="preserve">
     <value>Preprocessor keywords must not be preceded by space</value>
   </data>
   <data name="RH6005MessageFormat" xml:space="preserve">
-    <value>Operator keyword must be followed by space.</value>
+    <value>Operator keyword must be followed by space</value>
   </data>
   <data name="RH6005Title" xml:space="preserve">
     <value>Operator keyword must be followed by space</value>
   </data>
   <data name="RH6006MessageFormat" xml:space="preserve">
-    <value>Opening parenthesis must be spaced correctly.</value>
+    <value>Opening parenthesis must be spaced correctly</value>
   </data>
   <data name="RH6006Title" xml:space="preserve">
     <value>Opening parenthesis must be spaced correctly</value>
   </data>
   <data name="RH6007MessageFormat" xml:space="preserve">
-    <value>Opening square brackets must be spaced correctly.</value>
+    <value>Opening square brackets must be spaced correctly</value>
   </data>
   <data name="RH6007Title" xml:space="preserve">
     <value>Opening square brackets must be spaced correctly</value>
   </data>
   <data name="RH6008MessageFormat" xml:space="preserve">
-    <value>Closing square brackets must be spaced correctly.</value>
+    <value>Closing square brackets must be spaced correctly</value>
   </data>
   <data name="RH6008Title" xml:space="preserve">
     <value>Closing square brackets must be spaced correctly</value>
   </data>
   <data name="RH6009MessageFormat" xml:space="preserve">
-    <value>Opening braces must be spaced correctly.</value>
+    <value>Opening braces must be spaced correctly</value>
   </data>
   <data name="RH6009Title" xml:space="preserve">
     <value>Opening braces must be spaced correctly</value>
   </data>
   <data name="RH6010MessageFormat" xml:space="preserve">
-    <value>Closing braces must be spaced correctly.</value>
+    <value>Closing braces must be spaced correctly</value>
   </data>
   <data name="RH6010Title" xml:space="preserve">
     <value>Closing braces must be spaced correctly</value>
   </data>
   <data name="RH6011MessageFormat" xml:space="preserve">
-    <value>Opening generic brackets must be spaced correctly.</value>
+    <value>Opening generic brackets must be spaced correctly</value>
   </data>
   <data name="RH6011Title" xml:space="preserve">
     <value>Opening generic brackets must be spaced correctly</value>
   </data>
   <data name="RH6012MessageFormat" xml:space="preserve">
-    <value>Closing generic brackets must be spaced correctly.</value>
+    <value>Closing generic brackets must be spaced correctly</value>
   </data>
   <data name="RH6012Title" xml:space="preserve">
     <value>Closing generic brackets must be spaced correctly</value>
   </data>
   <data name="RH6013MessageFormat" xml:space="preserve">
-    <value>Opening attribute brackets must be spaced correctly.</value>
+    <value>Opening attribute brackets must be spaced correctly</value>
   </data>
   <data name="RH6013Title" xml:space="preserve">
     <value>Opening attribute brackets must be spaced correctly</value>
   </data>
   <data name="RH6014MessageFormat" xml:space="preserve">
-    <value>Closing attribute brackets must be spaced correctly.</value>
+    <value>Closing attribute brackets must be spaced correctly</value>
   </data>
   <data name="RH6014Title" xml:space="preserve">
     <value>Closing attribute brackets must be spaced correctly</value>
   </data>
   <data name="RH6015MessageFormat" xml:space="preserve">
-    <value>Nullable type symbols must not be preceded by space.</value>
+    <value>Nullable type symbols must not be preceded by space</value>
   </data>
   <data name="RH6015Title" xml:space="preserve">
     <value>Nullable type symbols must not be preceded by space</value>
   </data>
   <data name="RH6016MessageFormat" xml:space="preserve">
-    <value>Member access symbols must be spaced correctly.</value>
+    <value>Member access symbols must be spaced correctly</value>
   </data>
   <data name="RH6016Title" xml:space="preserve">
     <value>Member access symbols must be spaced correctly</value>
   </data>
   <data name="RH6017MessageFormat" xml:space="preserve">
-    <value>Increment/decrement symbols must be spaced correctly.</value>
+    <value>Increment/decrement symbols must be spaced correctly</value>
   </data>
   <data name="RH6017Title" xml:space="preserve">
     <value>Increment/decrement symbols must be spaced correctly</value>
   </data>
   <data name="RH6018MessageFormat" xml:space="preserve">
-    <value>Negative signs must be spaced correctly.</value>
+    <value>Negative signs must be spaced correctly</value>
   </data>
   <data name="RH6018Title" xml:space="preserve">
     <value>Negative signs must be spaced correctly</value>
   </data>
   <data name="RH6019MessageFormat" xml:space="preserve">
-    <value>Positive signs must be spaced correctly.</value>
+    <value>Positive signs must be spaced correctly</value>
   </data>
   <data name="RH6019Title" xml:space="preserve">
     <value>Positive signs must be spaced correctly</value>
   </data>
   <data name="RH6020MessageFormat" xml:space="preserve">
-    <value>Dereference and access-of symbols must be spaced correctly.</value>
+    <value>Dereference and access-of symbols must be spaced correctly</value>
   </data>
   <data name="RH6020Title" xml:space="preserve">
     <value>Dereference and access-of symbols must be spaced correctly</value>
   </data>
   <data name="RH6021MessageFormat" xml:space="preserve">
-    <value>Colons must be spaced correctly.</value>
+    <value>Colons must be spaced correctly</value>
   </data>
   <data name="RH6021Title" xml:space="preserve">
     <value>Colons must be spaced correctly</value>
   </data>
   <data name="RH6022MessageFormat" xml:space="preserve">
-    <value>No space after new for implicitly typed arrays.</value>
+    <value>No space after new for implicitly typed arrays</value>
   </data>
   <data name="RH6022Title" xml:space="preserve">
     <value>No space after new for implicitly typed arrays</value>
   </data>
   <data name="RH6023MessageFormat" xml:space="preserve">
-    <value>Assignment operators must be spaced correctly.</value>
+    <value>Assignment operators must be spaced correctly</value>
   </data>
   <data name="RH6023Title" xml:space="preserve">
     <value>Assignment operators must be spaced correctly</value>
   </data>
   <data name="RH6024MessageFormat" xml:space="preserve">
-    <value>Binary operators must be spaced correctly.</value>
+    <value>Binary operators must be spaced correctly</value>
   </data>
   <data name="RH6024Title" xml:space="preserve">
     <value>Binary operators must be spaced correctly</value>
   </data>
   <data name="RH5601MessageFormat" xml:space="preserve">
-    <value>Use tabs correctly.</value>
+    <value>Tab characters must not be used</value>
   </data>
   <data name="RH5601Title" xml:space="preserve">
-    <value>Use tabs correctly</value>
+    <value>Tab characters must not be used</value>
   </data>
   <data name="RH5402MessageFormat" xml:space="preserve">
-    <value>Braces for multi-line statements must not share line.</value>
+    <value>Braces for multi-line statements must not share line</value>
   </data>
   <data name="RH5402Title" xml:space="preserve">
     <value>Braces for multi-line statements must not share line</value>
   </data>
   <data name="RH5403MessageFormat" xml:space="preserve">
-    <value>Statement must not be on a single line.</value>
+    <value>Statement must not be on a single line</value>
   </data>
   <data name="RH5403Title" xml:space="preserve">
     <value>Statement must not be on a single line</value>
   </data>
   <data name="RH5404MessageFormat" xml:space="preserve">
-    <value>Element must not be on a single line.</value>
+    <value>Element must not be on a single line</value>
   </data>
   <data name="RH5404Title" xml:space="preserve">
     <value>Element must not be on a single line</value>
   </data>
   <data name="RH5405MessageFormat" xml:space="preserve">
-    <value>Braces must not be omitted.</value>
+    <value>Braces must not be omitted</value>
   </data>
   <data name="RH5405Title" xml:space="preserve">
     <value>Braces must not be omitted</value>
   </data>
   <data name="RH5022MessageFormat" xml:space="preserve">
-    <value>Opening brace must not be followed by blank line.</value>
+    <value>Opening brace must not be followed by blank line</value>
   </data>
   <data name="RH5022Title" xml:space="preserve">
     <value>Opening brace must not be followed by blank line</value>
   </data>
   <data name="RH8302MessageFormat" xml:space="preserve">
-    <value>Element documentation headers must not be followed by blank line.</value>
+    <value>Element documentation headers must not be followed by blank line</value>
   </data>
   <data name="RH8302Title" xml:space="preserve">
     <value>Element documentation headers must not be followed by blank line</value>
   </data>
   <data name="RH5023MessageFormat" xml:space="preserve">
-    <value>Code must not contain multiple blank lines in a row.</value>
+    <value>Code must not contain multiple blank lines in a row</value>
   </data>
   <data name="RH5023Title" xml:space="preserve">
     <value>Code must not contain multiple blank lines in a row</value>
   </data>
   <data name="RH5024MessageFormat" xml:space="preserve">
-    <value>Closing brace must not be preceded by blank line.</value>
+    <value>Closing brace must not be preceded by blank line</value>
   </data>
   <data name="RH5024Title" xml:space="preserve">
     <value>Closing brace must not be preceded by blank line</value>
   </data>
   <data name="RH5025MessageFormat" xml:space="preserve">
-    <value>Opening brace must not be preceded by blank line.</value>
+    <value>Opening brace must not be preceded by blank line</value>
   </data>
   <data name="RH5025Title" xml:space="preserve">
     <value>Opening brace must not be preceded by blank line</value>
   </data>
   <data name="RH5026MessageFormat" xml:space="preserve">
-    <value>Chained statement blocks must not be preceded by blank line.</value>
+    <value>Chained statement blocks must not be preceded by blank line</value>
   </data>
   <data name="RH5026Title" xml:space="preserve">
     <value>Chained statement blocks must not be preceded by blank line</value>
   </data>
   <data name="RH5027MessageFormat" xml:space="preserve">
-    <value>While-do footer must not be preceded by blank line.</value>
+    <value>While-do footer must not be preceded by blank line</value>
   </data>
   <data name="RH5027Title" xml:space="preserve">
     <value>While-do footer must not be preceded by blank line</value>
   </data>
   <data name="RH8303MessageFormat" xml:space="preserve">
-    <value>Element documentation header must be preceded by blank line.</value>
+    <value>Element documentation header must be preceded by blank line</value>
   </data>
   <data name="RH8303Title" xml:space="preserve">
     <value>Element documentation header must be preceded by blank line</value>
   </data>
   <data name="RH5406MessageFormat" xml:space="preserve">
-    <value>Braces must not be omitted from multi-line child statements.</value>
+    <value>Braces must not be omitted from multi-line child statements</value>
   </data>
   <data name="RH5406Title" xml:space="preserve">
     <value>Braces must not be omitted from multi-line child statements</value>
   </data>
   <data name="RH5407MessageFormat" xml:space="preserve">
-    <value>Use braces consistently.</value>
+    <value>Use braces consistently</value>
   </data>
   <data name="RH5407Title" xml:space="preserve">
     <value>Use braces consistently</value>
   </data>
   <data name="RH5104MessageFormat" xml:space="preserve">
-    <value>Comments must be on their own line.</value>
+    <value>Comments must be on their own line</value>
   </data>
   <data name="RH5104Title" xml:space="preserve">
     <value>Comments must be on their own line</value>
   </data>
   <data name="RH5105MessageFormat" xml:space="preserve">
-    <value>Opening parenthesis for methods and constructors must be on declaration line.</value>
+    <value>Opening parenthesis must be on declaration line</value>
   </data>
   <data name="RH5105Title" xml:space="preserve">
-    <value>Opening parenthesis for methods and constructors must be on declaration line</value>
+    <value>Opening parenthesis must be on declaration line</value>
   </data>
   <data name="RH5106MessageFormat" xml:space="preserve">
-    <value>Closing parenthesis for methods and constructors must be on line of last argument.</value>
+    <value>Closing parenthesis must be on line of last argument</value>
   </data>
   <data name="RH5106Title" xml:space="preserve">
-    <value>Closing parenthesis for methods and constructors must be on line of last argument</value>
+    <value>Closing parenthesis must be on line of last argument</value>
   </data>
   <data name="RH5107MessageFormat" xml:space="preserve">
-    <value>Comma must be on same line as previous parameter.</value>
+    <value>Comma must be on same line as previous parameter</value>
   </data>
   <data name="RH5107Title" xml:space="preserve">
     <value>Comma must be on same line as previous parameter</value>
   </data>
   <data name="RH5108MessageFormat" xml:space="preserve">
-    <value>Parameter list must follow declaration.</value>
+    <value>Parameter list must follow declaration</value>
   </data>
   <data name="RH5108Title" xml:space="preserve">
     <value>Parameter list must follow declaration</value>
   </data>
   <data name="RH5109MessageFormat" xml:space="preserve">
-    <value>Parameters must be on same line or separate lines.</value>
+    <value>Parameters must be on same line or separate lines</value>
   </data>
   <data name="RH5109Title" xml:space="preserve">
     <value>Parameters must be on same line or separate lines</value>
   </data>
   <data name="RH5110MessageFormat" xml:space="preserve">
-    <value>Generic type constraints should be on their own line with proper indentation.</value>
+    <value>Generic type constraints should be on their own line with proper indentation</value>
   </data>
   <data name="RH5110Title" xml:space="preserve">
     <value>Generic type constraints should be on their own line with proper indentation</value>
   </data>
   <data name="RH5604MessageFormat" xml:space="preserve">
-    <value>Code must not contain mixed line endings.</value>
+    <value>Code must not contain mixed line endings</value>
   </data>
   <data name="RH5604Title" xml:space="preserve">
     <value>Code must not contain mixed line endings</value>
   </data>
   <data name="RH7304MessageFormat" xml:space="preserve">
-    <value>Region directives must use consistent indentation with containing code.</value>
+    <value>Region directives must use consistent indentation with containing code</value>
   </data>
   <data name="RH7304Title" xml:space="preserve">
     <value>Region directives must use consistent indentation with containing code</value>
   </data>
   <data name="RH7305AMessageFormat" xml:space="preserve">
-    <value>Types with multiple member kinds should be organized with regions.</value>
+    <value>Types with multiple member kinds should be organized with regions</value>
   </data>
   <data name="RH7305ATitle" xml:space="preserve">
     <value>Types with multiple member kinds should be organized with regions</value>
   </data>
   <data name="RH7305MessageFormat" xml:space="preserve">
-    <value>Types should be organized with regions.</value>
+    <value>Types should be organized with regions</value>
   </data>
   <data name="RH7305Title" xml:space="preserve">
     <value>Types should be organized with regions</value>
   </data>
   <data name="RH7306MessageFormat" xml:space="preserve">
-    <value>Region descriptions should not end with implementation.</value>
+    <value>Region descriptions should not end with implementation</value>
   </data>
   <data name="RH7306Title" xml:space="preserve">
     <value>Region descriptions should not end with implementation</value>
   </data>
   <data name="RH5204MessageFormat" xml:space="preserve">
-    <value>Indentation must use 4 spaces per scope level.</value>
+    <value>Indentation must use 4 spaces per scope level</value>
   </data>
   <data name="RH5204Title" xml:space="preserve">
     <value>Indentation must use 4 spaces per scope level</value>
@@ -1327,25 +1327,25 @@
     <value>Constants must appear before fields</value>
   </data>
   <data name="RH7102MessageFormat" xml:space="preserve">
-    <value>Constants must appear before fields.</value>
+    <value>Constants must appear before fields</value>
   </data>
   <data name="RH7103Title" xml:space="preserve">
     <value>Static elements must appear before instance elements</value>
   </data>
   <data name="RH7103MessageFormat" xml:space="preserve">
-    <value>Static elements must appear before instance elements.</value>
+    <value>Static elements must appear before instance elements</value>
   </data>
   <data name="RH7104Title" xml:space="preserve">
     <value>Partial elements must declare access modifier</value>
   </data>
   <data name="RH7104MessageFormat" xml:space="preserve">
-    <value>Partial elements must declare an access modifier.</value>
+    <value>Partial elements must declare access modifier</value>
   </data>
   <data name="RH7105Title" xml:space="preserve">
     <value>Declaration keywords must follow order</value>
   </data>
   <data name="RH7105MessageFormat" xml:space="preserve">
-    <value>Declaration keywords must follow the required order.</value>
+    <value>Declaration keywords must follow order</value>
   </data>
   <data name="RH7106Title" xml:space="preserve">
     <value>Protected must come before internal</value>
@@ -1357,37 +1357,37 @@
     <value>System using directives must be placed before other using directives</value>
   </data>
   <data name="RH7201MessageFormat" xml:space="preserve">
-    <value>System using directives must be placed before other using directives.</value>
+    <value>System using directives must be placed before other using directives</value>
   </data>
   <data name="RH7202Title" xml:space="preserve">
     <value>Using alias directives must be placed after other using directives</value>
   </data>
   <data name="RH7202MessageFormat" xml:space="preserve">
-    <value>Using alias directives must be placed after other using directives.</value>
+    <value>Using alias directives must be placed after other using directives</value>
   </data>
   <data name="RH7203Title" xml:space="preserve">
     <value>Using directives must be ordered alphabetically by namespace</value>
   </data>
   <data name="RH7203MessageFormat" xml:space="preserve">
-    <value>Using directives must be ordered alphabetically by namespace.</value>
+    <value>Using directives must be ordered alphabetically by namespace</value>
   </data>
   <data name="RH7204Title" xml:space="preserve">
     <value>Using alias directives must be ordered alphabetically by alias name</value>
   </data>
   <data name="RH7204MessageFormat" xml:space="preserve">
-    <value>Using alias directives must be ordered alphabetically by alias name.</value>
+    <value>Using alias directives must be ordered alphabetically by alias name</value>
   </data>
   <data name="RH7107Title" xml:space="preserve">
     <value>Property accessors must follow order</value>
   </data>
   <data name="RH7107MessageFormat" xml:space="preserve">
-    <value>Property accessors must appear in the correct order.</value>
+    <value>Property accessors must follow order</value>
   </data>
   <data name="RH7108Title" xml:space="preserve">
     <value>Event accessors must follow order</value>
   </data>
   <data name="RH7108MessageFormat" xml:space="preserve">
-    <value>Event accessors must appear in the correct order.</value>
+    <value>Event accessors must follow order</value>
   </data>
   <data name="RH7109Title" xml:space="preserve">
     <value>Readonly elements must appear before non-readonly elements</value>
@@ -1411,7 +1411,7 @@
     <value>Using static directives must be ordered alphabetically</value>
   </data>
   <data name="RH7206MessageFormat" xml:space="preserve">
-    <value>Using static directives must be ordered alphabetically.</value>
+    <value>Using static directives must be ordered alphabetically</value>
   </data>
   <data name="RH0001Title" xml:space="preserve">
     <value>reihitsu.json configuration must be valid</value>
@@ -1477,19 +1477,19 @@
     <value>Blank line after closing brace</value>
   </data>
   <data name="RH5030MessageFormat" xml:space="preserve">
-    <value>Add a blank line after the closing brace.</value>
+    <value>Blank line after closing brace</value>
   </data>
   <data name="RH5031Title" xml:space="preserve">
     <value>Region directives should be preceded by a blank line</value>
   </data>
   <data name="RH5031MessageFormat" xml:space="preserve">
-    <value>Region directives should be preceded by a blank line.</value>
+    <value>Region directives should be preceded by a blank line</value>
   </data>
   <data name="RH5032Title" xml:space="preserve">
     <value>Region directives should be followed by a blank line</value>
   </data>
   <data name="RH5032MessageFormat" xml:space="preserve">
-    <value>Region directives should be followed by a blank line.</value>
+    <value>Region directives should be followed by a blank line</value>
   </data>
   <data name="RH7501Title" xml:space="preserve">
     <value>Break statements should not be inside explicit switch case blocks.</value>
@@ -1507,7 +1507,7 @@
     <value>Region descriptions should not be Member or Members</value>
   </data>
   <data name="RH7307MessageFormat" xml:space="preserve">
-    <value>Use a more descriptive region description than 'Member' or 'Members'.</value>
+    <value>Region descriptions should not be Member or Members</value>
   </data>
   <data name="RH7308Title" xml:space="preserve">
     <value>Standard regions should contain only their matching member kind</value>
@@ -1525,7 +1525,7 @@
     <value>Empty regions should be removed</value>
   </data>
   <data name="RH7310MessageFormat" xml:space="preserve">
-    <value>The region is empty and should be removed.</value>
+    <value>Empty regions should be removed</value>
   </data>
   <data name="RH7311Title" xml:space="preserve">
     <value>Region descriptions must be unique within a type</value>
@@ -1534,10 +1534,10 @@
     <value>The region description '{0}' is already used by another region in this type. Give each region a distinct description or merge the blocks.</value>
   </data>
    <data name="RH8201MessageFormat" xml:space="preserve">
-    <value>The \&lt;inheritdoc/&gt; Tag should be used if possible.</value>
+    <value>The inheritdoc tag should be used if possible</value>
   </data>
   <data name="RH8201Title" xml:space="preserve">
-    <value>The \&lt;inheritdoc/&gt; Tag should be used if possible.</value>
+    <value>The inheritdoc tag should be used if possible</value>
   </data>
   <data name="RH8001MessageFormat" xml:space="preserve">
     <value>Non-private class must be documented.</value>
@@ -1723,7 +1723,7 @@
     <value>Do not use the &lt;value&gt; tag.</value>
   </data>
   <data name="RH8202Title" xml:space="preserve">
-    <value>&lt;value&gt; tag must not be used</value>
+    <value>`&lt;value&gt;` tag must not be used</value>
   </data>
   <data name="RH8101MessageFormat" xml:space="preserve">
     <value>Each parameter must have a corresponding &lt;param&gt; tag.</value>
@@ -1792,7 +1792,7 @@
     <value>Generic type parameter documentation must have text</value>
   </data>
   <data name="RH8401MessageFormat" xml:space="preserve">
-    <value>Single-line comments must not start with documentation comment slashes.</value>
+    <value>Single-line comments must not use documentation style slashes</value>
   </data>
   <data name="RH8401Title" xml:space="preserve">
     <value>Single-line comments must not use documentation style slashes</value>
@@ -1801,7 +1801,7 @@
     <value>&lt;inheritdoc&gt; may only be used on inheriting or implementing declarations.</value>
   </data>
   <data name="RH8203Title" xml:space="preserve">
-    <value>&lt;inheritdoc&gt; must be used with inheriting class</value>
+    <value>`&lt;inheritdoc&gt;` must be used with inheriting class</value>
   </data>
   <data name="RH8204MessageFormat" xml:space="preserve">
     <value>Documentation must not contain &lt;placeholder&gt; elements.</value>
@@ -1810,10 +1810,10 @@
     <value>Do not use placeholder elements</value>
   </data>
   <data name="RH1001MessageFormat" xml:space="preserve">
-    <value>Types used as keys must implement equality members.</value>
+    <value>Types used as dictionary keys or in hash sets must implement equality members</value>
   </data>
   <data name="RH1001Title" xml:space="preserve">
-    <value>Types used as keys must implement equality members.</value>
+    <value>Types used as dictionary keys or in hash sets must implement equality members</value>
   </data>
   <data name="RH1002MessageFormat" xml:space="preserve">
     <value>Types used for equality comparison must implement equality members</value>
@@ -1828,187 +1828,187 @@
     <value>Use string interpolation instead of string concatenation.</value>
   </data>
   <data name="RH5501MessageFormat" xml:space="preserve">
-    <value>Assembly attributes must be on their own line.</value>
+    <value>Assembly attributes must be on their own line</value>
   </data>
   <data name="RH5501Title" xml:space="preserve">
     <value>Assembly attributes must be on their own line</value>
   </data>
   <data name="RH5502MessageFormat" xml:space="preserve">
-    <value>Assembly attribute lists must use one attribute per list.</value>
+    <value>Assembly attribute lists must use one attribute per list</value>
   </data>
   <data name="RH5502Title" xml:space="preserve">
     <value>Assembly attribute lists must use one attribute per list</value>
   </data>
   <data name="RH5503MessageFormat" xml:space="preserve">
-    <value>Module attributes must be on their own line.</value>
+    <value>Module attributes must be on their own line</value>
   </data>
   <data name="RH5503Title" xml:space="preserve">
     <value>Module attributes must be on their own line</value>
   </data>
   <data name="RH5504MessageFormat" xml:space="preserve">
-    <value>Module attribute lists must use one attribute per list.</value>
+    <value>Module attribute lists must use one attribute per list</value>
   </data>
   <data name="RH5504Title" xml:space="preserve">
     <value>Module attribute lists must use one attribute per list</value>
   </data>
   <data name="RH5505MessageFormat" xml:space="preserve">
-    <value>Class attributes must be on their own line.</value>
+    <value>Class attributes must be on their own line</value>
   </data>
   <data name="RH5505Title" xml:space="preserve">
     <value>Class attributes must be on their own line</value>
   </data>
   <data name="RH5506MessageFormat" xml:space="preserve">
-    <value>Class attribute lists must use one attribute per list.</value>
+    <value>Class attribute lists must use one attribute per list</value>
   </data>
   <data name="RH5506Title" xml:space="preserve">
     <value>Class attribute lists must use one attribute per list</value>
   </data>
   <data name="RH5507MessageFormat" xml:space="preserve">
-    <value>Struct attributes must be on their own line.</value>
+    <value>Struct attributes must be on their own line</value>
   </data>
   <data name="RH5507Title" xml:space="preserve">
     <value>Struct attributes must be on their own line</value>
   </data>
   <data name="RH5508MessageFormat" xml:space="preserve">
-    <value>Struct attribute lists must use one attribute per list.</value>
+    <value>Struct attribute lists must use one attribute per list</value>
   </data>
   <data name="RH5508Title" xml:space="preserve">
     <value>Struct attribute lists must use one attribute per list</value>
   </data>
   <data name="RH5509MessageFormat" xml:space="preserve">
-    <value>Enum attributes must be on their own line.</value>
+    <value>Enum attributes must be on their own line</value>
   </data>
   <data name="RH5509Title" xml:space="preserve">
     <value>Enum attributes must be on their own line</value>
   </data>
   <data name="RH5510MessageFormat" xml:space="preserve">
-    <value>Enum attribute lists must use one attribute per list.</value>
+    <value>Enum attribute lists must use one attribute per list</value>
   </data>
   <data name="RH5510Title" xml:space="preserve">
     <value>Enum attribute lists must use one attribute per list</value>
   </data>
   <data name="RH5511MessageFormat" xml:space="preserve">
-    <value>Constructor attributes must be on their own line.</value>
+    <value>Constructor attributes must be on their own line</value>
   </data>
   <data name="RH5511Title" xml:space="preserve">
     <value>Constructor attributes must be on their own line</value>
   </data>
   <data name="RH5512MessageFormat" xml:space="preserve">
-    <value>Constructor attribute lists must use one attribute per list.</value>
+    <value>Constructor attribute lists must use one attribute per list</value>
   </data>
   <data name="RH5512Title" xml:space="preserve">
     <value>Constructor attribute lists must use one attribute per list</value>
   </data>
   <data name="RH5513MessageFormat" xml:space="preserve">
-    <value>Method attributes must be on their own line.</value>
+    <value>Method attributes must be on their own line</value>
   </data>
   <data name="RH5513Title" xml:space="preserve">
     <value>Method attributes must be on their own line</value>
   </data>
   <data name="RH5514MessageFormat" xml:space="preserve">
-    <value>Method attribute lists must use one attribute per list.</value>
+    <value>Method attribute lists must use one attribute per list</value>
   </data>
   <data name="RH5514Title" xml:space="preserve">
     <value>Method attribute lists must use one attribute per list</value>
   </data>
   <data name="RH5515MessageFormat" xml:space="preserve">
-    <value>Property attributes must be on their own line.</value>
+    <value>Property attributes must be on their own line</value>
   </data>
   <data name="RH5515Title" xml:space="preserve">
     <value>Property attributes must be on their own line</value>
   </data>
   <data name="RH5516MessageFormat" xml:space="preserve">
-    <value>Property attribute lists must use one attribute per list.</value>
+    <value>Property attribute lists must use one attribute per list</value>
   </data>
   <data name="RH5516Title" xml:space="preserve">
     <value>Property attribute lists must use one attribute per list</value>
   </data>
   <data name="RH5517MessageFormat" xml:space="preserve">
-    <value>Field attributes must be on their own line.</value>
+    <value>Field attributes must be on their own line</value>
   </data>
   <data name="RH5517Title" xml:space="preserve">
     <value>Field attributes must be on their own line</value>
   </data>
   <data name="RH5518MessageFormat" xml:space="preserve">
-    <value>Field attribute lists must use one attribute per list.</value>
+    <value>Field attribute lists must use one attribute per list</value>
   </data>
   <data name="RH5518Title" xml:space="preserve">
     <value>Field attribute lists must use one attribute per list</value>
   </data>
   <data name="RH5519MessageFormat" xml:space="preserve">
-    <value>Event attributes must be on their own line.</value>
+    <value>Event attributes must be on their own line</value>
   </data>
   <data name="RH5519Title" xml:space="preserve">
     <value>Event attributes must be on their own line</value>
   </data>
   <data name="RH5520MessageFormat" xml:space="preserve">
-    <value>Event attribute lists must use one attribute per list.</value>
+    <value>Event attribute lists must use one attribute per list</value>
   </data>
   <data name="RH5520Title" xml:space="preserve">
     <value>Event attribute lists must use one attribute per list</value>
   </data>
   <data name="RH5521MessageFormat" xml:space="preserve">
-    <value>Interface attributes must be on their own line.</value>
+    <value>Interface attributes must be on their own line</value>
   </data>
   <data name="RH5521Title" xml:space="preserve">
     <value>Interface attributes must be on their own line</value>
   </data>
   <data name="RH5522MessageFormat" xml:space="preserve">
-    <value>Interface attribute lists must use one attribute per list.</value>
+    <value>Interface attribute lists must use one attribute per list</value>
   </data>
   <data name="RH5522Title" xml:space="preserve">
     <value>Interface attribute lists must use one attribute per list</value>
   </data>
   <data name="RH5523MessageFormat" xml:space="preserve">
-    <value>Parameter attributes must stay inline.</value>
+    <value>Parameter attributes must stay inline</value>
   </data>
   <data name="RH5523Title" xml:space="preserve">
     <value>Parameter attributes must stay inline</value>
   </data>
   <data name="RH5524MessageFormat" xml:space="preserve">
-    <value>Parameter attributes must use merged attribute lists.</value>
+    <value>Parameter attributes must use merged attribute lists</value>
   </data>
   <data name="RH5524Title" xml:space="preserve">
     <value>Parameter attributes must use merged attribute lists</value>
   </data>
   <data name="RH5525MessageFormat" xml:space="preserve">
-    <value>Delegate attributes must be on their own line.</value>
+    <value>Delegate attributes must be on their own line</value>
   </data>
   <data name="RH5525Title" xml:space="preserve">
     <value>Delegate attributes must be on their own line</value>
   </data>
   <data name="RH5526MessageFormat" xml:space="preserve">
-    <value>Delegate attribute lists must use one attribute per list.</value>
+    <value>Delegate attribute lists must use one attribute per list</value>
   </data>
   <data name="RH5526Title" xml:space="preserve">
     <value>Delegate attribute lists must use one attribute per list</value>
   </data>
   <data name="RH5527MessageFormat" xml:space="preserve">
-    <value>Return value attributes must be on their own line.</value>
+    <value>Return value attributes must be on their own line</value>
   </data>
   <data name="RH5527Title" xml:space="preserve">
     <value>Return value attributes must be on their own line</value>
   </data>
   <data name="RH5528MessageFormat" xml:space="preserve">
-    <value>Return value attribute lists must use one attribute per list.</value>
+    <value>Return value attribute lists must use one attribute per list</value>
   </data>
   <data name="RH5528Title" xml:space="preserve">
     <value>Return value attribute lists must use one attribute per list</value>
   </data>
   <data name="RH5529MessageFormat" xml:space="preserve">
-    <value>Generic parameter attributes must use merged attribute lists.</value>
+    <value>Generic parameter attributes must use merged attribute lists</value>
   </data>
   <data name="RH5529Title" xml:space="preserve">
     <value>Generic parameter attributes must use merged attribute lists</value>
   </data>
   <data name="RH5530MessageFormat" xml:space="preserve">
-    <value>Accessor attributes must follow placement rules.</value>
+    <value>Accessor attributes must follow placement rules</value>
   </data>
   <data name="RH5530Title" xml:space="preserve">
     <value>Accessor attributes must follow placement rules</value>
   </data>
   <data name="RH5531MessageFormat" xml:space="preserve">
-    <value>Accessor attribute lists must follow shape rules.</value>
+    <value>Accessor attribute lists must follow shape rules</value>
   </data>
   <data name="RH5531Title" xml:space="preserve">
     <value>Accessor attribute lists must follow shape rules</value>

--- a/Reihitsu.Analyzer/Rules/Clarity/RH3001NotOperatorShouldNotBeUsedAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Clarity/RH3001NotOperatorShouldNotBeUsedAnalyzer.cs
@@ -9,7 +9,7 @@ using Reihitsu.Analyzer.Enumerations;
 namespace Reihitsu.Analyzer.Rules.Clarity;
 
 /// <summary>
-/// RH3001: The logical operator ! should not be used for clarity
+/// RH3001: Not operator should not be used
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH3001NotOperatorShouldNotBeUsedAnalyzer : DiagnosticAnalyzerBase

--- a/Reihitsu.Analyzer/Rules/Layout/RH5001TryStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Layout/RH5001TryStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -9,7 +9,7 @@ using Reihitsu.Analyzer.Enumerations;
 namespace Reihitsu.Analyzer.Rules.Layout;
 
 /// <summary>
-/// RH5001: The try-Statement should be preceded by a blank line
+/// RH5001: try-Statement should be preceded by a blank line
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH5001TryStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<TryStatementSyntax>

--- a/Reihitsu.Analyzer/Rules/Layout/RH5002IfStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Layout/RH5002IfStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -9,7 +9,7 @@ using Reihitsu.Analyzer.Enumerations;
 namespace Reihitsu.Analyzer.Rules.Layout;
 
 /// <summary>
-/// RH5002: The if-Statement should be preceded by a blank line
+/// RH5002: if-Statement should be preceded by a blank line
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH5002IfStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<IfStatementSyntax>

--- a/Reihitsu.Analyzer/Rules/Layout/RH5003WhileStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Layout/RH5003WhileStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -9,7 +9,7 @@ using Reihitsu.Analyzer.Enumerations;
 namespace Reihitsu.Analyzer.Rules.Layout;
 
 /// <summary>
-/// RH5003: The while-Statement should be preceded by a blank line
+/// RH5003: while-Statement should be preceded by a blank line
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH5003WhileStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<WhileStatementSyntax>

--- a/Reihitsu.Analyzer/Rules/Layout/RH5004DoStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Layout/RH5004DoStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -9,7 +9,7 @@ using Reihitsu.Analyzer.Enumerations;
 namespace Reihitsu.Analyzer.Rules.Layout;
 
 /// <summary>
-/// RH5004: The do-Statement should be preceded by a blank line
+/// RH5004: do-Statement should be preceded by a blank line
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH5004DoStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<DoStatementSyntax>

--- a/Reihitsu.Analyzer/Rules/Layout/RH5005UsingStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Layout/RH5005UsingStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -9,7 +9,7 @@ using Reihitsu.Analyzer.Enumerations;
 namespace Reihitsu.Analyzer.Rules.Layout;
 
 /// <summary>
-/// RH5005: The using-Statement should be preceded by a blank line
+/// RH5005: using-Statement should be preceded by a blank line
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH5005UsingStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<UsingStatementSyntax>

--- a/Reihitsu.Analyzer/Rules/Layout/RH5006ForeachStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Layout/RH5006ForeachStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -9,7 +9,7 @@ using Reihitsu.Analyzer.Enumerations;
 namespace Reihitsu.Analyzer.Rules.Layout;
 
 /// <summary>
-/// RH5006: The foreach-Statement should be preceded by a blank line
+/// RH5006: foreach-Statement should be preceded by a blank line
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH5006ForeachStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<CommonForEachStatementSyntax>

--- a/Reihitsu.Analyzer/Rules/Layout/RH5007ForStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Layout/RH5007ForStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -9,7 +9,7 @@ using Reihitsu.Analyzer.Enumerations;
 namespace Reihitsu.Analyzer.Rules.Layout;
 
 /// <summary>
-/// RH5007: The for-Statement should be preceded by a blank line
+/// RH5007: for-Statement should be preceded by a blank line
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH5007ForStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<ForStatementSyntax>

--- a/Reihitsu.Analyzer/Rules/Layout/RH5008ReturnStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Layout/RH5008ReturnStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -9,7 +9,7 @@ using Reihitsu.Analyzer.Enumerations;
 namespace Reihitsu.Analyzer.Rules.Layout;
 
 /// <summary>
-/// RH5008: The return-Statement should be preceded by a blank line
+/// RH5008: return-Statement should be preceded by a blank line
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH5008ReturnStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<ReturnStatementSyntax>

--- a/Reihitsu.Analyzer/Rules/Layout/RH5009GotoStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Layout/RH5009GotoStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -9,7 +9,7 @@ using Reihitsu.Analyzer.Enumerations;
 namespace Reihitsu.Analyzer.Rules.Layout;
 
 /// <summary>
-/// RH5009: The goto-Statement should be preceded by a blank line
+/// RH5009: goto-Statement should be preceded by a blank line
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH5009GotoStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<GotoStatementSyntax>

--- a/Reihitsu.Analyzer/Rules/Layout/RH5010BreakStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Layout/RH5010BreakStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -10,7 +10,7 @@ using Reihitsu.Core;
 namespace Reihitsu.Analyzer.Rules.Layout;
 
 /// <summary>
-/// RH5010: The break-Statement should be preceded by a blank line
+/// RH5010: break-Statement should be preceded by a blank line
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH5010BreakStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<BreakStatementSyntax>

--- a/Reihitsu.Analyzer/Rules/Layout/RH5011BreakStatementsShouldBeFollowedByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Layout/RH5011BreakStatementsShouldBeFollowedByABlankLineAnalyzer.cs
@@ -9,7 +9,7 @@ using Reihitsu.Analyzer.Enumerations;
 namespace Reihitsu.Analyzer.Rules.Layout;
 
 /// <summary>
-/// RH5011: The break-Statement should be followed by a blank line
+/// RH5011: break-Statement should be followed by a blank line
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH5011BreakStatementsShouldBeFollowedByABlankLineAnalyzer : StatementShouldBeFollowedByABlankLineAnalyzerBase<BreakStatementSyntax>

--- a/Reihitsu.Analyzer/Rules/Layout/RH5012ContinueStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Layout/RH5012ContinueStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -9,7 +9,7 @@ using Reihitsu.Analyzer.Enumerations;
 namespace Reihitsu.Analyzer.Rules.Layout;
 
 /// <summary>
-/// RH5012: The continue-Statement should be preceded by a blank line
+/// RH5012: continue-Statement should be preceded by a blank line
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH5012ContinueStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<ContinueStatementSyntax>

--- a/Reihitsu.Analyzer/Rules/Layout/RH5013ThrowStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Layout/RH5013ThrowStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -9,7 +9,7 @@ using Reihitsu.Analyzer.Enumerations;
 namespace Reihitsu.Analyzer.Rules.Layout;
 
 /// <summary>
-/// RH5013: The throw-Statement should be preceded by a blank line
+/// RH5013: throw-Statement should be preceded by a blank line
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH5013ThrowStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<ThrowStatementSyntax>

--- a/Reihitsu.Analyzer/Rules/Layout/RH5014SwitchStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Layout/RH5014SwitchStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -9,7 +9,7 @@ using Reihitsu.Analyzer.Enumerations;
 namespace Reihitsu.Analyzer.Rules.Layout;
 
 /// <summary>
-/// RH5014: The switch-Statement should be preceded by a blank line
+/// RH5014: switch-Statement should be preceded by a blank line
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH5014SwitchStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<SwitchStatementSyntax>

--- a/Reihitsu.Analyzer/Rules/Layout/RH5015CheckedStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Layout/RH5015CheckedStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -9,7 +9,7 @@ using Reihitsu.Analyzer.Enumerations;
 namespace Reihitsu.Analyzer.Rules.Layout;
 
 /// <summary>
-/// RH5015: The checked-Statement should be preceded by a blank line
+/// RH5015: checked-Statement should be preceded by a blank line
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH5015CheckedStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<CheckedStatementSyntax>

--- a/Reihitsu.Analyzer/Rules/Layout/RH5016UncheckedStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Layout/RH5016UncheckedStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -9,7 +9,7 @@ using Reihitsu.Analyzer.Enumerations;
 namespace Reihitsu.Analyzer.Rules.Layout;
 
 /// <summary>
-/// RH5016: The unchecked-Statement should be preceded by a blank line
+/// RH5016: unchecked-Statement should be preceded by a blank line
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH5016UncheckedStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<CheckedStatementSyntax>

--- a/Reihitsu.Analyzer/Rules/Layout/RH5017FixedStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Layout/RH5017FixedStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -9,7 +9,7 @@ using Reihitsu.Analyzer.Enumerations;
 namespace Reihitsu.Analyzer.Rules.Layout;
 
 /// <summary>
-/// RH5017: The fixed-Statement should be preceded by a blank line
+/// RH5017: fixed-Statement should be preceded by a blank line
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH5017FixedStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<FixedStatementSyntax>

--- a/Reihitsu.Analyzer/Rules/Layout/RH5018LockStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Layout/RH5018LockStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -9,7 +9,7 @@ using Reihitsu.Analyzer.Enumerations;
 namespace Reihitsu.Analyzer.Rules.Layout;
 
 /// <summary>
-/// RH5018: The lock-Statement should be preceded by a blank line
+/// RH5018: lock-Statement should be preceded by a blank line
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH5018LockStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<LockStatementSyntax>

--- a/Reihitsu.Analyzer/Rules/Layout/RH5019YieldStatementsShouldBePrecededByABlankLineAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Layout/RH5019YieldStatementsShouldBePrecededByABlankLineAnalyzer.cs
@@ -9,7 +9,7 @@ using Reihitsu.Analyzer.Enumerations;
 namespace Reihitsu.Analyzer.Rules.Layout;
 
 /// <summary>
-/// RH5019: The yield-Statement should be preceded by a blank line
+/// RH5019: yield-Statement should be preceded by a blank line
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH5019YieldStatementsShouldBePrecededByABlankLineAnalyzer : StatementShouldBePrecededByABlankLineAnalyzerBase<YieldStatementSyntax>

--- a/Reihitsu.Analyzer/Rules/Layout/RH5301ObjectInitializerShouldBeFormattedCorrectlyAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Layout/RH5301ObjectInitializerShouldBeFormattedCorrectlyAnalyzer.cs
@@ -12,7 +12,7 @@ using Reihitsu.Core;
 namespace Reihitsu.Analyzer.Rules.Layout;
 
 /// <summary>
-/// RH5301: The object initializer should be formatted correctly
+/// RH5301: Object initializer should be formatted correctly
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH5301ObjectInitializerShouldBeFormattedCorrectlyAnalyzer : DiagnosticAnalyzerBase

--- a/Reihitsu.Analyzer/Rules/Layout/RH5303CollectionInitializerShouldBeFormattedCorrectlyAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Layout/RH5303CollectionInitializerShouldBeFormattedCorrectlyAnalyzer.cs
@@ -14,7 +14,7 @@ using Reihitsu.Core;
 namespace Reihitsu.Analyzer.Rules.Layout;
 
 /// <summary>
-/// RH5303: The collection initializer should be formatted correctly
+/// RH5303: Collection initializer should be formatted correctly
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH5303CollectionInitializerShouldBeFormattedCorrectlyAnalyzer : DiagnosticAnalyzerBase

--- a/Reihitsu.Analyzer/Rules/Layout/RH5601UseTabsCorrectlyAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Layout/RH5601UseTabsCorrectlyAnalyzer.cs
@@ -10,7 +10,7 @@ using Reihitsu.Core;
 namespace Reihitsu.Analyzer.Rules.Layout;
 
 /// <summary>
-/// RH5601: Use tabs correctly
+/// RH5601: Tab characters must not be used
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH5601UseTabsCorrectlyAnalyzer : DiagnosticAnalyzerBase

--- a/Reihitsu.Analyzer/Rules/Naming/RH4004EnumNameCasingAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Naming/RH4004EnumNameCasingAnalyzer.cs
@@ -12,7 +12,7 @@ using Reihitsu.Core;
 namespace Reihitsu.Analyzer.Rules.Naming;
 
 /// <summary>
-/// RH4004: Enumeration names should be in PascalCase
+/// RH4004: Enum names should be in PascalCase
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH4004EnumNameCasingAnalyzer : CasingAnalyzerBase

--- a/Reihitsu.Analyzer/Rules/Naming/RH4101EnumMemberCasingAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Naming/RH4101EnumMemberCasingAnalyzer.cs
@@ -12,7 +12,7 @@ using Reihitsu.Core;
 namespace Reihitsu.Analyzer.Rules.Naming;
 
 /// <summary>
-/// RH4101: Enumeration members names should be in PascalCase
+/// RH4101: Enum member names should be in PascalCase
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH4101EnumMemberCasingAnalyzer : CasingAnalyzerBase

--- a/Reihitsu.Analyzer/Rules/Naming/RH4103MethodNameCasingAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Naming/RH4103MethodNameCasingAnalyzer.cs
@@ -12,7 +12,7 @@ using Reihitsu.Core;
 namespace Reihitsu.Analyzer.Rules.Naming;
 
 /// <summary>
-/// RH4103: Method members names should be in PascalCase
+/// RH4103: Method names should be in PascalCase
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH4103MethodNameCasingAnalyzer : CasingAnalyzerBase

--- a/Reihitsu.Analyzer/Rules/Organization/RH7301RegionsShouldMatchAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Organization/RH7301RegionsShouldMatchAnalyzer.cs
@@ -12,7 +12,7 @@ using Reihitsu.Core;
 namespace Reihitsu.Analyzer.Rules.Organization;
 
 /// <summary>
-/// RH7301: The description of the #region and #endregion should match
+/// RH7301: #region and #endregion descriptions should match
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH7301RegionsShouldMatchAnalyzer : DiagnosticAnalyzerBase

--- a/Reihitsu.Analyzer/Rules/Organization/RH7303DoNotPlaceRegionsWithinElementsAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Organization/RH7303DoNotPlaceRegionsWithinElementsAnalyzer.cs
@@ -8,7 +8,7 @@ using Reihitsu.Core;
 namespace Reihitsu.Analyzer.Rules.Organization;
 
 /// <summary>
-/// RH7303: Regions must not be placed within elements
+/// RH7303: Do not place regions within elements
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH7303DoNotPlaceRegionsWithinElementsAnalyzer : DiagnosticAnalyzerBase

--- a/Reihitsu.Analyzer/Rules/Performance/RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Performance/RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer.cs
@@ -10,7 +10,7 @@ using Reihitsu.Analyzer.Enumerations;
 namespace Reihitsu.Analyzer.Rules.Performance;
 
 /// <summary>
-/// RH1001: Types used as keys must implement equality members
+/// RH1001: Types used as dictionary keys or in hash sets must implement equality members
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class RH1001TypesUsedAsKeysMustImplementEqualityMembersAnalyzer : StructEqualityPerformanceAnalyzerBase


### PR DESCRIPTION
## Summary

Adds two `AnalyzerPackageMetadataTests` that read `AnalyzerResources.ResourceManager.GetString(...)` directly: one asserts every analyzer's title resource matches its `documentation/rules/RH####.md` title, the other asserts a message format with no `{n}` placeholders is identical to its title. Fixes every mismatch the two invariants found (44 titles, 145 message formats) and updates 29 stale class-summary comments the title fixes left behind.

## Why

`PackageReadmeDescriptionsMatchRuleDocumentationTitles` only compared the README against the docs; nothing compared the shipped analyzer title resource against either. Issue #672 measured 39 such mismatches (including RH4007/RH4008 sharing one title) and asked for the missing invariant test.

## Linked issues

Closes #672

## Review notes

- **Titles**: per direction from the issue author, the documentation title is authoritative. All 44 mismatching `Title` resources (including the RH4007/RH4008 duplicate, whose docs already differ - "File scoped namespace declarations..." vs. "Namespace declarations...") were rewritten to the doc's exact text, backticks included where the doc uses one (matching the precedent already set for the README in #675).
- **Message formats**: per the same direction, I evaluated every message format that differs from its (now-corrected) title with no placeholders (170 total) and equalized the 145 that carried no information the title lacked - 117 were a mechanical "The "/period wrapper, 28 were a same-fact rewording. Two of those 28 turned up real defects the equalization fixes: RH5601's message said "Use tabs correctly" while the rule (and its doc) prohibit tabs outright, and RH4001/RH5105/RH5106 enumerated only "class/struct/enum" or "methods and constructors" in the message while the analyzers check every type kind / a much wider declaration-kind list (verified against `ParameterListParentPolicy` and `RH4001TypeNameShouldMatchFileNameAnalyzer`).
- **Kept apart** (64 rules, listed with their reason in `AnalyzerPackageMetadataTests._messageFormatIntentionallyDiffersFromTitle`): the RH8001-RH8029/RH8402 family, where the title is the general plural rule and the message is the singular instance a diagnostic actually points at; the RH8030-8033/RH8101-8111/RH8204 family and a few others, where the message names a concrete XML tag or remediation step the title omits; RH3003/RH3101/RH3105/RH8202/RH8203, where the title carries a markdown code span inherited from the doc that plain runtime text shouldn't; and RH7106/RH7109, where the message is the scope-accurate text and the title matches the doc's own (narrower/broader) heading, which is out of scope for this test to rewrite.
- Message formats, diagnostic IDs, severities, and categories are otherwise unchanged, per the issue's acceptance criteria.
- This was scoped and implemented directly in this session at the requester's direction (small change, no Behavior Contract gate, no official preflight).

## Follow-up work

- RH7106's title ("Protected must come before internal") only names one of the two modifier pairs the analyzer checks (it also orders `private`/`protected`); RH7109's title ("Readonly elements...") is broader than the fields-only scope it actually checks. Both docs share the same wording as the title. Rewriting the doc headings (and titles) to be scope-accurate is a separate decision from this issue's title/doc alignment and is left as a follow-up.