### PR TITLE
Align formatter chain anchor to the first RH5201 link

### DIFF
--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5201MethodChainsShouldBeAlignedFormatterTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5201MethodChainsShouldBeAlignedFormatterTests.cs
@@ -134,5 +134,88 @@ public class RH5201MethodChainsShouldBeAlignedFormatterTests : FormatterTestsBas
                                                Diagnostics(RH5201MethodChainsShouldBeAlignedAnalyzer.DiagnosticId, AnalyzerResources.RH5201MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies that the formatter's own output for a wrapped chain whose first invoked link is
+    /// introduced by <c>!.</c> after a plain (non-invoked) property access satisfies RH5201 and stays
+    /// stable on a second pass. <c>!.</c> selects a different anchor token than <c>?.</c>
+    /// (<see cref="Reihitsu.Core.FluentChainUtilities.GetInvokedLinkOperator"/> returns the <c>!</c>,
+    /// not the following <c>.</c>), so this is the arm most able to drift from the analyzer (issue #680)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFormatterFixesNullForgivingAfterPlainPropertyAccessViolation()
+    {
+        const string input = """
+                             using System.Collections.Generic;
+                             using System.Linq;
+
+                             internal sealed class Example
+                             {
+                                 internal sealed class Choice
+                                 {
+                                     public string Name { get; set; }
+                                 }
+
+                                 internal sealed class Option
+                                 {
+                                     public string Name { get; set; }
+                                 }
+
+                                 internal sealed class Request
+                                 {
+                                     public IEnumerable<Choice> Choices { get; set; }
+                                 }
+
+                                 internal static List<Option> Convert(Request request)
+                                 {
+                                     var options = request.Choices!.Select(choice => new Option
+                                                                                     {
+                                                                                         Name = choice.Name
+                                                                                     })
+                                                          {|#0:.|}ToList();
+
+                                     return options;
+                                 }
+                             }
+                             """;
+        const string fixedData = """
+                                 using System.Collections.Generic;
+                                 using System.Linq;
+
+                                 internal sealed class Example
+                                 {
+                                     internal sealed class Choice
+                                     {
+                                         public string Name { get; set; }
+                                     }
+
+                                     internal sealed class Option
+                                     {
+                                         public string Name { get; set; }
+                                     }
+
+                                     internal sealed class Request
+                                     {
+                                         public IEnumerable<Choice> Choices { get; set; }
+                                     }
+
+                                     internal static List<Option> Convert(Request request)
+                                     {
+                                         var options = request.Choices!.Select(choice => new Option
+                                                                                         {
+                                                                                             Name = choice.Name
+                                                                                         })
+                                                                      .ToList();
+
+                                         return options;
+                                     }
+                                 }
+                                 """;
+
+        await VerifyFormatterFixAndIdempotency(input,
+                                               fixedData,
+                                               Diagnostics(RH5201MethodChainsShouldBeAlignedAnalyzer.DiagnosticId, AnalyzerResources.RH5201MessageFormat));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5201MethodChainsShouldBeAlignedFormatterTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5201MethodChainsShouldBeAlignedFormatterTests.cs
@@ -53,5 +53,86 @@ public class RH5201MethodChainsShouldBeAlignedFormatterTests : FormatterTestsBas
                                  Diagnostics(RH5201MethodChainsShouldBeAlignedAnalyzer.DiagnosticId, AnalyzerResources.RH5201MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies that the formatter's own output for a wrapped chain whose first invoked link is
+    /// introduced by <c>?.</c> after a plain (non-invoked) property access satisfies RH5201 and stays
+    /// stable on a second pass, closing the format-fix-format oscillation reported in issue #680
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFormatterFixesConditionalAccessAfterPlainPropertyAccessViolation()
+    {
+        const string input = """
+                             using System.Collections.Generic;
+                             using System.Linq;
+
+                             internal sealed class Example
+                             {
+                                 internal sealed class Choice
+                                 {
+                                     public string Name { get; set; }
+                                 }
+
+                                 internal sealed class Option
+                                 {
+                                     public string Name { get; set; }
+                                 }
+
+                                 internal sealed class Request
+                                 {
+                                     public IEnumerable<Choice> Choices { get; set; }
+                                 }
+
+                                 internal static List<Option> Convert(Request request)
+                                 {
+                                     var options = request.Choices?.Select(choice => new Option
+                                                                                     {
+                                                                                         Name = choice.Name
+                                                                                     })
+                                                          {|#0:.|}ToList();
+
+                                     return options;
+                                 }
+                             }
+                             """;
+        const string fixedData = """
+                                 using System.Collections.Generic;
+                                 using System.Linq;
+
+                                 internal sealed class Example
+                                 {
+                                     internal sealed class Choice
+                                     {
+                                         public string Name { get; set; }
+                                     }
+
+                                     internal sealed class Option
+                                     {
+                                         public string Name { get; set; }
+                                     }
+
+                                     internal sealed class Request
+                                     {
+                                         public IEnumerable<Choice> Choices { get; set; }
+                                     }
+
+                                     internal static List<Option> Convert(Request request)
+                                     {
+                                         var options = request.Choices?.Select(choice => new Option
+                                                                                         {
+                                                                                             Name = choice.Name
+                                                                                         })
+                                                                      .ToList();
+
+                                         return options;
+                                     }
+                                 }
+                                 """;
+
+        await VerifyFormatterFixAndIdempotency(input,
+                                               fixedData,
+                                               Diagnostics(RH5201MethodChainsShouldBeAlignedAnalyzer.DiagnosticId, AnalyzerResources.RH5201MessageFormat));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
@@ -1508,5 +1508,56 @@ public class MethodChainAlignmentTests : FormatterTestsBase
         AssertRuleResult(input, expected);
     }
 
+    /// <summary>
+    /// Verifies that the initializer-adjacent anchor correction does not mix columns from two
+    /// different source lines when the chain's first collected dot sits on an initializer's closing
+    /// brace line but the anchor link itself wraps onto a later line; the correction must only apply
+    /// when the anchor shares the brace's own line, or a second formatter pass changes the result
+    /// (issue #680)
+    /// </summary>
+    [TestMethod]
+    public void ConditionalAccessAnchorOnLaterLineThanInitializerCloseBraceStaysIdempotent()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = new Request
+                                             {
+                                                 Choices = data
+                                             }.
+                                                 Choices?.Select(item => new Wrapper
+                                                                         {
+                                                                             Value = item
+                                                                         })
+                                                        .ToList();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = new Request
+                                                {
+                                                    Choices = data
+                                                }.
+                                        Choices?.Select(item => new Wrapper
+                                                                {
+                                                                    Value = item
+                                                                })
+                                               .ToList();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
     #endregion // Methods
 }

--- a/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
@@ -1512,8 +1512,8 @@ public class MethodChainAlignmentTests : FormatterTestsBase
     /// Verifies that the initializer-adjacent anchor correction does not mix columns from two
     /// different source lines when the chain's first collected dot sits on an initializer's closing
     /// brace line but the anchor link itself wraps onto a later line; the correction must only apply
-    /// when the anchor shares the brace's own line, or a second formatter pass changes the result
-    /// (issue #680)
+    /// when the anchor shares the first collected dot's own line, or a second formatter pass changes
+    /// the result (issue #680)
     /// </summary>
     [TestMethod]
     public void ConditionalAccessAnchorOnLaterLineThanInitializerCloseBraceStaysIdempotent()

--- a/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
@@ -1177,5 +1177,336 @@ public class MethodChainAlignmentTests : FormatterTestsBase
         AssertRuleResult(input, expected);
     }
 
+    /// <summary>
+    /// Verifies that a wrapped chain whose first invoked link is introduced by <c>!.</c> and is
+    /// preceded by a plain (non-invoked) property access aligns continuation dots to that
+    /// <c>!.</c>-invoked link (issue #680)
+    /// </summary>
+    [TestMethod]
+    public void NullForgivingAfterPlainPropertyAccessAlignsToInvokedLink()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var options = request.Choices!.Select(choice => new Option
+                                     {
+                                         Name = choice.Name
+                                     })
+                                                           .ToList();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var options = request.Choices!.Select(choice => new Option
+                                                                                        {
+                                                                                            Name = choice.Name
+                                                                                        })
+                                                                     .ToList();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a null-forgiving operator on a non-invoked member access is not treated as a
+    /// chain link: the anchor stays the first plain invoked dot, unaffected by issue #680's fix
+    /// </summary>
+    [TestMethod]
+    public void NonInvokedNullForgivingIsNotTheChainAnchor()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var options = request!.Choices.Select(choice => new Option
+                                                                                     {
+                                                                                         Name = choice.Name
+                                                                                     })
+                                                                   .ToList();
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a wrapped chain whose first invoked link is introduced by <c>?.</c> aligns to
+    /// that link even when two plain (non-invoked) property accesses precede it (issue #680)
+    /// </summary>
+    [TestMethod]
+    public void DeepPlainPrefixBeforeConditionalAccessAlignsToInvokedLink()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a.B.C?.Select(item => new Wrapper
+                                     {
+                                         Value = item
+                                     })
+                                               .ToList();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a.B.C?.Select(item => new Wrapper
+                                                                      {
+                                                                          Value = item
+                                                                      })
+                                                     .ToList();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that when a wrapped chain has two <c>?.</c>-invoked links, continuation dots align
+    /// to the first one rather than to a plain (non-invoked) property access before it (issue #680)
+    /// </summary>
+    [TestMethod]
+    public void MultipleConditionalAccessLinksAlignToFirstLink()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a.Prop?.Select(item => new Wrapper
+                                     {
+                                         Value = item
+                                     })
+                                              ?.Where(item => item != null)
+                                               .ToList();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a.Prop?.Select(item => new Wrapper
+                                                                       {
+                                                                           Value = item
+                                                                       })
+                                                      ?.Where(item => item != null)
+                                                      .ToList();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a non-invoked trailing property access at the end of a wrapped chain aligns to
+    /// the same <c>?.</c>-invoked link as the rest of the chain (issue #680)
+    /// </summary>
+    [TestMethod]
+    public void TrailingPropertyAfterConditionalAccessChainAlignsToInvokedLink()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var count = a.Choices?.Select(item => new Wrapper
+                                     {
+                                         Value = item
+                                     })
+                                                   .ToList()
+                                                   .Count;
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var count = a.Choices?.Select(item => new Wrapper
+                                                                              {
+                                                                                  Value = item
+                                                                              })
+                                                             .ToList()
+                                                             .Count;
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a <c>?.</c> link directly after a collection initializer's closing brace keeps
+    /// anchoring correctly, unaffected by issue #680's fix for a non-invoked prefix dot between them
+    /// </summary>
+    [TestMethod]
+    public void ConditionalAccessDirectlyAfterInitializerCloseBraceKeepsAnchor()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = new List<string>
+                                             {
+                                                 "a",
+                                                 "b"
+                                             }?.Select(item => new Wrapper
+                                                               {
+                                                                   Value = item
+                                                               })
+                                              .ToList();
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a <c>?.</c> link aligns correctly when it is separated from an initializer's
+    /// closing brace by a plain (non-invoked) property access, so the anchor's column is still
+    /// derived from the creation expression's <c>new</c> keyword rather than left unadjusted (issue #680)
+    /// </summary>
+    [TestMethod]
+    public void ConditionalAccessAfterInitializerCloseBraceAndPropertyAlignsToInvokedLink()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = new Request { Choices = data }.Choices?.Select(item => new Wrapper
+                                     {
+                                         Value = item
+                                     })
+                                                                            .ToList();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = new Request
+                                                {
+                                                    Choices = data
+                                                }.Choices?.Select(item => new Wrapper
+                                                                          {
+                                                                              Value = item
+                                                                          })
+                                                         .ToList();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a chain whose first collected dot is itself wrapped onto its own line keeps its
+    /// current alignment; issue #680's fix does not reach this shape, which has an independent,
+    /// pre-existing divergence from RH5201 tracked separately
+    /// </summary>
+    [TestMethod]
+    public void WrappedFirstChainDotKeepsCurrentAlignment()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                                     .Prop?.Call()
+                                     .Then();
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a block comment between a plain (non-invoked) property access and its following
+    /// <c>?.</c>-invoked link does not shift the anchor: continuation dots still align to the link's
+    /// own column, which sits to the right of the comment (issue #680)
+    /// </summary>
+    [TestMethod]
+    public void BlockCommentBeforeConditionalAccessLinkDoesNotShiftAnchor()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a.Prop /* keep */ ?.Select(item => new Wrapper
+                                     {
+                                         Value = item
+                                     })
+                                               .ToList();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a.Prop /* keep */?.Select(item => new Wrapper
+                                                                                  {
+                                                                                      Value = item
+                                                                                  })
+                                                                 .ToList();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
     #endregion // Methods
 }

--- a/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
@@ -1096,5 +1096,86 @@ public class MethodChainAlignmentTests : FormatterTestsBase
         AssertRuleResult(input);
     }
 
+    /// <summary>
+    /// Verifies that a wrapped chain whose first invoked link is introduced by <c>?.</c> and is
+    /// preceded by a plain (non-invoked) property access aligns continuation dots to that
+    /// <c>?.</c>-invoked link (issue #680)
+    /// </summary>
+    [TestMethod]
+    public void ConditionalAccessAfterPlainPropertyAccessAlignsToInvokedLink()
+    {
+        // Arrange
+        const string input = """
+                             using System.Collections.Generic;
+                             using System.Linq;
+
+                             internal sealed class Example
+                             {
+                                 internal sealed class Choice
+                                 {
+                                     public string Name { get; set; }
+                                 }
+
+                                 internal sealed class Option
+                                 {
+                                     public string Name { get; set; }
+                                 }
+
+                                 internal sealed class Request
+                                 {
+                                     public IEnumerable Choices { get; set; }
+                                 }
+
+                                 internal static List Convert(Request request)
+                                 {
+                                     var options = request.Choices?.Select(choice => new Option
+                                     {
+                                         Name = choice.Name
+                                     })
+                                                           .ToList();
+
+                                     return options;
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                using System.Collections.Generic;
+                                using System.Linq;
+
+                                internal sealed class Example
+                                {
+                                    internal sealed class Choice
+                                    {
+                                        public string Name { get; set; }
+                                    }
+
+                                    internal sealed class Option
+                                    {
+                                        public string Name { get; set; }
+                                    }
+
+                                    internal sealed class Request
+                                    {
+                                        public IEnumerable Choices { get; set; }
+                                    }
+
+                                    internal static List Convert(Request request)
+                                    {
+                                        var options = request.Choices?.Select(choice => new Option
+                                                                                        {
+                                                                                            Name = choice.Name
+                                                                                        })
+                                                                     .ToList();
+
+                                        return options;
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
     #endregion // Methods
 }

--- a/Reihitsu.Formatter/Pipeline/Indentation/Contributors/MethodChainAlignmentContributor.cs
+++ b/Reihitsu.Formatter/Pipeline/Indentation/Contributors/MethodChainAlignmentContributor.cs
@@ -53,12 +53,12 @@ internal sealed class MethodChainAlignmentContributor : ILayoutContributor
     /// not have adjusted that brace's line yet (due to pre-order traversal) — regardless of whether
     /// the first dot itself was wrapped onto its own line. In that case, and only when the anchor is
     /// still on the first dot's own line, the column is computed directly from the creation
-    /// expression's <c>new</c> keyword position, preserving the first dot's original source offset
-    /// from the closing brace and applying it to the anchor — even when the anchor is a later link
-    /// separated from the first dot by a non-link prefix dot. An anchor that wraps onto a later line
-    /// than the first dot has no such fixed offset from the brace, so it falls back to the ordinary
-    /// adjusted-column lookup, which resolves the anchor's own line through the layout model instead
-    /// of mixing columns from unrelated lines
+    /// expression's <c>new</c> keyword position, preserving the anchor's original source offset from
+    /// the closing brace — even when the anchor is a later link separated from the first dot by a
+    /// non-link prefix dot. An anchor that wraps onto a later line than the first dot has no such
+    /// fixed offset from the brace, so it falls back to the ordinary adjusted-column lookup, which
+    /// resolves the anchor's own line through the layout model instead of mixing columns from
+    /// unrelated lines
     /// </summary>
     /// <param name="anchorDot">The chain-link token chosen as the alignment anchor</param>
     /// <param name="firstDot">The chain's first collected dot, used to detect an initializer-rooted chain</param>

--- a/Reihitsu.Formatter/Pipeline/Indentation/Contributors/MethodChainAlignmentContributor.cs
+++ b/Reihitsu.Formatter/Pipeline/Indentation/Contributors/MethodChainAlignmentContributor.cs
@@ -49,14 +49,16 @@ internal sealed class MethodChainAlignmentContributor : ILayoutContributor
 
     /// <summary>
     /// Computes the alignment column for the chain anchor. When the chain's first collected dot
-    /// shares a line with a closing brace of an initializer expression, the initializer contributor
-    /// may not have adjusted that line yet (due to pre-order traversal). In that case, and only when
-    /// the anchor itself is still on that same source line, the column is computed directly from the
-    /// creation expression's <c>new</c> keyword position, preserving the anchor's original source
-    /// offset from the closing brace — even when the anchor is a later link separated from the brace
-    /// by a non-link prefix dot. An anchor that wraps onto a later line has no such fixed offset from
-    /// the brace, so it falls back to the ordinary adjusted-column lookup, which resolves the anchor's
-    /// own line through the layout model instead of mixing columns from two different lines
+    /// directly follows a closing brace of an initializer expression, the initializer contributor may
+    /// not have adjusted that brace's line yet (due to pre-order traversal) — regardless of whether
+    /// the first dot itself was wrapped onto its own line. In that case, and only when the anchor is
+    /// still on the first dot's own line, the column is computed directly from the creation
+    /// expression's <c>new</c> keyword position, preserving the first dot's original source offset
+    /// from the closing brace and applying it to the anchor — even when the anchor is a later link
+    /// separated from the first dot by a non-link prefix dot. An anchor that wraps onto a later line
+    /// than the first dot has no such fixed offset from the brace, so it falls back to the ordinary
+    /// adjusted-column lookup, which resolves the anchor's own line through the layout model instead
+    /// of mixing columns from unrelated lines
     /// </summary>
     /// <param name="anchorDot">The chain-link token chosen as the alignment anchor</param>
     /// <param name="firstDot">The chain's first collected dot, used to detect an initializer-rooted chain</param>
@@ -68,7 +70,7 @@ internal sealed class MethodChainAlignmentContributor : ILayoutContributor
 
         if (prevToken.IsKind(SyntaxKind.CloseBraceToken)
             && prevToken.Parent is InitializerExpressionSyntax initExpr
-            && LayoutComputer.GetLine(anchorDot) == LayoutComputer.GetLine(prevToken))
+            && LayoutComputer.GetLine(anchorDot) == LayoutComputer.GetLine(firstDot))
         {
             var newKeyword = GetCreationNewKeyword(initExpr.Parent);
 

--- a/Reihitsu.Formatter/Pipeline/Indentation/Contributors/MethodChainAlignmentContributor.cs
+++ b/Reihitsu.Formatter/Pipeline/Indentation/Contributors/MethodChainAlignmentContributor.cs
@@ -22,7 +22,7 @@ internal sealed class MethodChainAlignmentContributor : ILayoutContributor
 
     /// <summary>
     /// Determines the anchor column for a method chain. The anchor is the first collected dot that
-    /// is itself a chain link — a plain dot on an invoked member access, a conditional-access
+    /// is itself an invoked chain link — a plain dot on an invoked member access, a conditional-access
     /// operator, or a null-forgiving operator introducing an invoked link. If no such link precedes
     /// the first wrapped dot, the anchor falls back to the first collected dot
     /// </summary>
@@ -38,7 +38,7 @@ internal sealed class MethodChainAlignmentContributor : ILayoutContributor
                 break;
             }
 
-            if (IsChainLinkDot(dot))
+            if (ChainWalker.IsInvokedLinkDot(dot))
             {
                 return GetChainAnchorColumn(dot, dots[0], model);
             }
@@ -48,38 +48,15 @@ internal sealed class MethodChainAlignmentContributor : ILayoutContributor
     }
 
     /// <summary>
-    /// Determines whether a collected chain dot is a chain link: a conditional-access operator, a
-    /// null-forgiving operator whose postfix expression is the receiver of an invoked member access,
-    /// or a plain dot on a directly invoked member access. This mirrors
-    /// <see cref="Reihitsu.Core.FluentChainUtilities.GetInvokedLinkOperator"/>'s definition of an
-    /// invoked link so the anchor always agrees with the RH5201 analyzer's reference column
-    /// </summary>
-    /// <param name="dot">The collected dot token to classify</param>
-    /// <returns><see langword="true"/> if the token is a chain link; otherwise, <see langword="false"/></returns>
-    private static bool IsChainLinkDot(SyntaxToken dot)
-    {
-        if (dot.Parent is ConditionalAccessExpressionSyntax)
-        {
-            return true;
-        }
-
-        if (dot.Parent is PostfixUnaryExpressionSyntax postfixUnary)
-        {
-            return postfixUnary.Parent is MemberAccessExpressionSyntax postfixMemberAccess
-                   && postfixMemberAccess.Parent is InvocationExpressionSyntax;
-        }
-
-        return dot.Parent is MemberAccessExpressionSyntax memberAccess
-               && memberAccess.Parent is InvocationExpressionSyntax;
-    }
-
-    /// <summary>
     /// Computes the alignment column for the chain anchor. When the chain's first collected dot
     /// shares a line with a closing brace of an initializer expression, the initializer contributor
-    /// may not have adjusted that line yet (due to pre-order traversal). In that case, the column is
-    /// computed directly from the creation expression's <c>new</c> keyword position, preserving the
-    /// anchor's original source offset from the closing brace — even when the anchor is a later link
-    /// separated from the brace by a non-link prefix dot
+    /// may not have adjusted that line yet (due to pre-order traversal). In that case, and only when
+    /// the anchor itself is still on that same source line, the column is computed directly from the
+    /// creation expression's <c>new</c> keyword position, preserving the anchor's original source
+    /// offset from the closing brace — even when the anchor is a later link separated from the brace
+    /// by a non-link prefix dot. An anchor that wraps onto a later line has no such fixed offset from
+    /// the brace, so it falls back to the ordinary adjusted-column lookup, which resolves the anchor's
+    /// own line through the layout model instead of mixing columns from two different lines
     /// </summary>
     /// <param name="anchorDot">The chain-link token chosen as the alignment anchor</param>
     /// <param name="firstDot">The chain's first collected dot, used to detect an initializer-rooted chain</param>
@@ -90,7 +67,8 @@ internal sealed class MethodChainAlignmentContributor : ILayoutContributor
         var prevToken = firstDot.GetPreviousToken();
 
         if (prevToken.IsKind(SyntaxKind.CloseBraceToken)
-            && prevToken.Parent is InitializerExpressionSyntax initExpr)
+            && prevToken.Parent is InitializerExpressionSyntax initExpr
+            && LayoutComputer.GetLine(anchorDot) == LayoutComputer.GetLine(prevToken))
         {
             var newKeyword = GetCreationNewKeyword(initExpr.Parent);
 

--- a/Reihitsu.Formatter/Pipeline/Indentation/Contributors/MethodChainAlignmentContributor.cs
+++ b/Reihitsu.Formatter/Pipeline/Indentation/Contributors/MethodChainAlignmentContributor.cs
@@ -12,17 +12,19 @@ using Reihitsu.Formatter.Pipeline.LineBreaks.Utilities;
 namespace Reihitsu.Formatter.Pipeline.Indentation.Contributors;
 
 /// <summary>
-/// Aligns dots in method chains so that continuation dots align to the first dot's column.
-/// Conditional access operators (<c>?.</c>) are treated as chain links
+/// Aligns dots in method chains so that continuation dots align to the first chain link's column.
+/// Conditional access operators (<c>?.</c>) and null-forgiving operators introducing an invoked
+/// link (<c>!.</c>) are treated as chain links, matching the RH5201 analyzer's definition
 /// </summary>
 internal sealed class MethodChainAlignmentContributor : ILayoutContributor
 {
     #region Methods
 
     /// <summary>
-    /// Determines the anchor column for a method chain. If the first dot in the chain is part of
-    /// a qualified name prefix (e.g., <c>System.Linq.Enumerable</c>), the anchor is the first
-    /// invocation dot that remains on the root line. Otherwise, the anchor is the first dot
+    /// Determines the anchor column for a method chain. The anchor is the first collected dot that
+    /// is itself a chain link — a plain dot on an invoked member access, a conditional-access
+    /// operator, or a null-forgiving operator introducing an invoked link. If no such link precedes
+    /// the first wrapped dot, the anchor falls back to the first collected dot
     /// </summary>
     /// <param name="dots">The collected chain dots</param>
     /// <param name="model">The layout model</param>
@@ -36,28 +38,54 @@ internal sealed class MethodChainAlignmentContributor : ILayoutContributor
                 break;
             }
 
-            var isInvocationDot = dot.Parent is MemberAccessExpressionSyntax memberAccess
-                                  && memberAccess.Parent is InvocationExpressionSyntax;
-
-            if (isInvocationDot)
+            if (IsChainLinkDot(dot))
             {
-                return GetChainAnchorColumn(dot, model);
+                return GetChainAnchorColumn(dot, dots[0], model);
             }
         }
 
-        return GetChainAnchorColumn(dots[0], model);
+        return GetChainAnchorColumn(dots[0], dots[0], model);
     }
 
     /// <summary>
-    /// Computes the alignment column for the first dot in a chain. When the first dot shares
-    /// a line with a closing brace of an initializer expression, the initializer contributor
-    /// may not have adjusted that line yet (due to pre-order traversal). In that case, the
-    /// column is computed directly from the creation expression's <c>new</c> keyword position
+    /// Determines whether a collected chain dot is a chain link: a conditional-access operator, a
+    /// null-forgiving operator whose postfix expression is the receiver of an invoked member access,
+    /// or a plain dot on a directly invoked member access. This mirrors
+    /// <see cref="Reihitsu.Core.FluentChainUtilities.GetInvokedLinkOperator"/>'s definition of an
+    /// invoked link so the anchor always agrees with the RH5201 analyzer's reference column
     /// </summary>
-    /// <param name="firstDot">The first dot token in the chain</param>
+    /// <param name="dot">The collected dot token to classify</param>
+    /// <returns><see langword="true"/> if the token is a chain link; otherwise, <see langword="false"/></returns>
+    private static bool IsChainLinkDot(SyntaxToken dot)
+    {
+        if (dot.Parent is ConditionalAccessExpressionSyntax)
+        {
+            return true;
+        }
+
+        if (dot.Parent is PostfixUnaryExpressionSyntax postfixUnary)
+        {
+            return postfixUnary.Parent is MemberAccessExpressionSyntax postfixMemberAccess
+                   && postfixMemberAccess.Parent is InvocationExpressionSyntax;
+        }
+
+        return dot.Parent is MemberAccessExpressionSyntax memberAccess
+               && memberAccess.Parent is InvocationExpressionSyntax;
+    }
+
+    /// <summary>
+    /// Computes the alignment column for the chain anchor. When the chain's first collected dot
+    /// shares a line with a closing brace of an initializer expression, the initializer contributor
+    /// may not have adjusted that line yet (due to pre-order traversal). In that case, the column is
+    /// computed directly from the creation expression's <c>new</c> keyword position, preserving the
+    /// anchor's original source offset from the closing brace — even when the anchor is a later link
+    /// separated from the brace by a non-link prefix dot
+    /// </summary>
+    /// <param name="anchorDot">The chain-link token chosen as the alignment anchor</param>
+    /// <param name="firstDot">The chain's first collected dot, used to detect an initializer-rooted chain</param>
     /// <param name="model">The layout model</param>
     /// <returns>The adjusted column for the chain anchor</returns>
-    private static int GetChainAnchorColumn(SyntaxToken firstDot, LayoutModel model)
+    private static int GetChainAnchorColumn(SyntaxToken anchorDot, SyntaxToken firstDot, LayoutModel model)
     {
         var prevToken = firstDot.GetPreviousToken();
 
@@ -68,14 +96,14 @@ internal sealed class MethodChainAlignmentContributor : ILayoutContributor
 
             if (newKeyword != default)
             {
-                var dotOffset = LayoutComputer.GetColumn(firstDot) - LayoutComputer.GetColumn(prevToken);
+                var dotOffset = LayoutComputer.GetColumn(anchorDot) - LayoutComputer.GetColumn(prevToken);
                 var newColumn = LayoutComputer.GetAdjustedColumn(newKeyword, model);
 
                 return newColumn + dotOffset;
             }
         }
 
-        return LayoutComputer.GetAdjustedColumn(firstDot, model);
+        return LayoutComputer.GetAdjustedColumn(anchorDot, model);
     }
 
     /// <summary>

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/Utilities/ChainWalker.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/Utilities/ChainWalker.cs
@@ -130,6 +130,34 @@ internal static class ChainWalker
     }
 
     /// <summary>
+    /// Determines whether a chain dot collected by <see cref="CollectAlignmentDots"/> is an invoked
+    /// chain link: a conditional-access operator, a null-forgiving operator whose postfix expression
+    /// is the receiver of an invoked member access, or a plain dot on a directly invoked member
+    /// access. These are the same three token shapes <see cref="CollectInvokedLinkDots"/> collects
+    /// from the tree, and they mirror <see cref="FluentChainUtilities.GetInvokedLinkOperator"/>'s
+    /// definition of an invoked link, so a caller classifying an already-collected dot and a caller
+    /// walking the tree from scratch agree on the same link set
+    /// </summary>
+    /// <param name="dot">The collected dot token to classify</param>
+    /// <returns><see langword="true"/> if the token is an invoked chain link; otherwise, <see langword="false"/></returns>
+    public static bool IsInvokedLinkDot(SyntaxToken dot)
+    {
+        if (dot.Parent is ConditionalAccessExpressionSyntax)
+        {
+            return true;
+        }
+
+        if (dot.Parent is PostfixUnaryExpressionSyntax postfixUnary)
+        {
+            return postfixUnary.Parent is MemberAccessExpressionSyntax postfixMemberAccess
+                   && postfixMemberAccess.Parent is InvocationExpressionSyntax;
+        }
+
+        return dot.Parent is MemberAccessExpressionSyntax memberAccess
+               && memberAccess.Parent is InvocationExpressionSyntax;
+    }
+
+    /// <summary>
     /// Determines whether an invocation expression is the outermost node in a method chain.
     /// An invocation is outermost if it is not an inner link of a larger chain
     /// and not nested inside a conditional access expression


### PR DESCRIPTION
## Summary

`MethodChainAlignmentContributor.FindChainAnchorColumn` now anchors a wrapped method chain to its first RH5201 chain link — a plain invoked `.`, a `?.`, or an invoked `!.` — instead of only recognizing a plain invoked `.`. The initializer-adjacent anchor correction (for a chain rooted in an object/collection initializer) was also widened and hardened so it stays correct and idempotent when the anchor is a later link separated from the initializer's closing brace by a non-invoked prefix dot.

## Why

Reported in #680: the formatter's chain-anchor computation was a third, independent reimplementation of "what is the chain's reference column," alongside the RH5201 analyzer and its code fix (which already share `FluentChainAnalysisHelper.CollectChainLinks`). For the reported shape (`request.Choices?.Select(...).ToList()`), formatting and applying the RH5201 code fix disagreed indefinitely — each pass undid the other.

## Linked issues

Closes #680

## Review notes

- The chain-link classification is a new `ChainWalker.IsInvokedLinkDot` predicate, co-located with the formatter's existing `ChainWalker.CollectInvokedLinkDots` and mirroring `Reihitsu.Core.FluentChainUtilities.GetInvokedLinkOperator`'s invoked-link definition. It does not touch the analyzer, the code fix, `Reihitsu.Core`'s public surface, or `documentation/rules/RH5201.md` (already documents `.`/`?.`/`!.` as links). The issue's own "suggested direction" (a shared `Reihitsu.Core` helper) was explicitly non-prescriptive and confirmed optional by analysis — kept local to `Reihitsu.Formatter` to avoid an unforced public-API change.
- An official preflight audit caught a genuine idempotency bug in the first version of the initializer-correction widening (cross-line column arithmetic that could mix columns from two different source lines) plus two smaller gaps (a missing analyzer-parity test for the `!.` arm, and the new predicate duplicating existing logic instead of sharing it). All three were fixed, and a second, independent audit pass confirmed the fix (`PASS`, with two trivial doc-comment wording corrections applied and proven text-only afterward).
- Three small, unrelated, pre-existing formatter defects surfaced during analysis, audit, and post-merge review — all explicitly out of scope for this PR; see Follow-up work.

## Follow-up work

- #683 — a chain whose own first collected dot is a non-invoked property access preceding the first real invoked link never gets collapsed onto the chain root, so it can still disagree with RH5201 — an independent, pre-existing mechanism in `ChainLineBreakRewriter`'s collapse-eligibility check, not touched by this PR's fix.
- #684 — the initializer-adjacent anchor correction assumes the initializer prints as multiple lines; when it stays on one line, the correction misaligns the anchor by roughly the initializer's own width — also independent and pre-existing.
- #685 — a member-access dot immediately followed by a line break, with its own member name starting the next line, is not rejoined; documented as an observation (root cause not fully confirmed, possibly related to #683) rather than a diagnosed fix.