### PR TITLE
Add --version flag to reihitsu-format CLI

### DIFF
--- a/Reihitsu.Cli.Test/EndToEnd/CliEndToEndTests.cs
+++ b/Reihitsu.Cli.Test/EndToEnd/CliEndToEndTests.cs
@@ -112,6 +112,28 @@ public class CliEndToEndTests
     }
 
     /// <summary>
+    /// Verifies that the --version flag prints the tool name and version, and returns success
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test</returns>
+    [TestMethod]
+    public async Task MainVersionFlagPrintsVersionAndReturnsSuccess()
+    {
+        // Act
+        int exitCode;
+        string output;
+
+        using (var capture = new ConsoleCapture())
+        {
+            exitCode = await Program.Main(["--version"]);
+            output = capture.StandardOutput;
+        }
+
+        // Assert
+        Assert.AreEqual(ExitCodes.Success, exitCode);
+        Assert.Contains("reihitsu-format", output);
+    }
+
+    /// <summary>
     /// Verifies that an unknown option prints an error message and returns an error exit code
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous test</returns>

--- a/Reihitsu.Cli.Test/Unit/ProgramTests.cs
+++ b/Reihitsu.Cli.Test/Unit/ProgramTests.cs
@@ -25,6 +25,7 @@ public class ProgramTests
         Assert.IsFalse(result.Force);
         Assert.IsFalse(result.Utf8Bom);
         Assert.IsFalse(result.ShowHelp);
+        Assert.IsFalse(result.ShowVersion);
         Assert.IsEmpty(result.Paths);
         Assert.IsNull(result.UnknownOption);
     }
@@ -43,6 +44,7 @@ public class ProgramTests
         Assert.IsFalse(result.Force);
         Assert.IsFalse(result.Utf8Bom);
         Assert.IsFalse(result.ShowHelp);
+        Assert.IsFalse(result.ShowVersion);
         Assert.IsEmpty(result.Paths);
         Assert.IsNull(result.UnknownOption);
     }
@@ -61,6 +63,7 @@ public class ProgramTests
         Assert.IsFalse(result.Force);
         Assert.IsFalse(result.Utf8Bom);
         Assert.IsFalse(result.ShowHelp);
+        Assert.IsFalse(result.ShowVersion);
         Assert.IsEmpty(result.Paths);
         Assert.IsNull(result.UnknownOption);
     }
@@ -79,6 +82,7 @@ public class ProgramTests
         Assert.IsFalse(result.Force);
         Assert.IsFalse(result.Utf8Bom);
         Assert.IsFalse(result.ShowHelp);
+        Assert.IsFalse(result.ShowVersion);
         Assert.IsEmpty(result.Paths);
         Assert.IsNull(result.UnknownOption);
     }
@@ -97,6 +101,7 @@ public class ProgramTests
         Assert.IsTrue(result.Force);
         Assert.IsFalse(result.Utf8Bom);
         Assert.IsFalse(result.ShowHelp);
+        Assert.IsFalse(result.ShowVersion);
         Assert.IsEmpty(result.Paths);
         Assert.IsNull(result.UnknownOption);
     }
@@ -115,6 +120,7 @@ public class ProgramTests
         Assert.IsFalse(result.Force);
         Assert.IsTrue(result.Utf8Bom);
         Assert.IsFalse(result.ShowHelp);
+        Assert.IsFalse(result.ShowVersion);
         Assert.IsEmpty(result.Paths);
         Assert.IsNull(result.UnknownOption);
     }
@@ -133,6 +139,7 @@ public class ProgramTests
         Assert.IsFalse(result.Force);
         Assert.IsFalse(result.Utf8Bom);
         Assert.IsTrue(result.ShowHelp);
+        Assert.IsFalse(result.ShowVersion);
         Assert.IsEmpty(result.Paths);
         Assert.IsNull(result.UnknownOption);
     }
@@ -151,6 +158,26 @@ public class ProgramTests
         Assert.IsFalse(result.Force);
         Assert.IsFalse(result.Utf8Bom);
         Assert.IsTrue(result.ShowHelp);
+        Assert.IsFalse(result.ShowVersion);
+        Assert.IsEmpty(result.Paths);
+        Assert.IsNull(result.UnknownOption);
+    }
+
+    /// <summary>
+    /// Verifies that <c>--version</c> sets <see cref="ParseResult.ShowVersion"/> to <see langword="true"/>
+    /// </summary>
+    [TestMethod]
+    public void ParseArgumentsVersionFlagSetsShowVersion()
+    {
+        var result = Program.ParseArguments(["--version"]);
+
+        Assert.IsFalse(result.CheckOnly);
+        Assert.IsFalse(result.DryRun);
+        Assert.IsFalse(result.Verbose);
+        Assert.IsFalse(result.Force);
+        Assert.IsFalse(result.Utf8Bom);
+        Assert.IsFalse(result.ShowHelp);
+        Assert.IsTrue(result.ShowVersion);
         Assert.IsEmpty(result.Paths);
         Assert.IsNull(result.UnknownOption);
     }
@@ -180,6 +207,7 @@ public class ProgramTests
         Assert.IsFalse(result.Force);
         Assert.IsTrue(result.Utf8Bom);
         Assert.IsFalse(result.ShowHelp);
+        Assert.IsFalse(result.ShowVersion);
         Assert.IsEmpty(result.Paths);
         Assert.IsNull(result.UnknownOption);
     }
@@ -201,6 +229,7 @@ public class ProgramTests
         Assert.IsFalse(result.Force);
         Assert.IsFalse(result.Utf8Bom);
         Assert.IsFalse(result.ShowHelp);
+        Assert.IsFalse(result.ShowVersion);
         Assert.IsNull(result.UnknownOption);
     }
 
@@ -218,6 +247,7 @@ public class ProgramTests
         Assert.IsFalse(result.Force);
         Assert.IsFalse(result.Utf8Bom);
         Assert.IsFalse(result.ShowHelp);
+        Assert.IsFalse(result.ShowVersion);
         Assert.HasCount(1, result.Paths);
         Assert.AreEqual("file.cs", result.Paths[0]);
         Assert.IsNull(result.UnknownOption);

--- a/Reihitsu.Cli/ParseResult.cs
+++ b/Reihitsu.Cli/ParseResult.cs
@@ -11,6 +11,7 @@ namespace Reihitsu.Cli;
 /// <param name="Force">Whether --force was specified</param>
 /// <param name="Utf8Bom">Whether --utf8-bom was specified</param>
 /// <param name="ShowHelp">Whether --help was specified</param>
+/// <param name="ShowVersion">Whether --version was specified</param>
 /// <param name="Paths">The list of file/directory paths</param>
 /// <param name="UnknownOption">The first unrecognized option, or null</param>
-internal readonly record struct ParseResult(bool CheckOnly, bool DryRun, bool Verbose, bool Force, bool Utf8Bom, bool ShowHelp, IReadOnlyList<string> Paths, string UnknownOption);
+internal readonly record struct ParseResult(bool CheckOnly, bool DryRun, bool Verbose, bool Force, bool Utf8Bom, bool ShowHelp, bool ShowVersion, IReadOnlyList<string> Paths, string UnknownOption);

--- a/Reihitsu.Cli/Program.cs
+++ b/Reihitsu.Cli/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Reflection;
 using System.Threading.Tasks;
 
 using Reihitsu.Cli.Abstractions;
@@ -33,6 +34,13 @@ internal static class Program
         if (result.ShowHelp)
         {
             PrintUsage(Console.Out);
+
+            return ExitCodes.Success;
+        }
+
+        if (result.ShowVersion)
+        {
+            Console.Out.WriteLine($"reihitsu-format {GetVersion()}");
 
             return ExitCodes.Success;
         }
@@ -109,6 +117,7 @@ internal static class Program
         var force = false;
         var utf8Bom = false;
         var showHelp = false;
+        var showVersion = false;
         var paths = new List<string>();
         string unknownOption = null;
         var pathsOnly = false;
@@ -168,6 +177,12 @@ internal static class Program
                     }
                     break;
 
+                case "--version":
+                    {
+                        showVersion = true;
+                    }
+                    break;
+
                 default:
                     {
                         if (arg.StartsWith('-'))
@@ -183,7 +198,7 @@ internal static class Program
             }
         }
 
-        return new ParseResult(checkOnly, dryRun, verbose, force, utf8Bom, showHelp, paths, unknownOption);
+        return new ParseResult(checkOnly, dryRun, verbose, force, utf8Bom, showHelp, showVersion, paths, unknownOption);
     }
 
     /// <summary>
@@ -204,7 +219,19 @@ internal static class Program
         writer.WriteLine($"  --force      Skip the confirmation prompt shown when more than {FormatCommandHandler.LargeRunConfirmationThreshold} files would be formatted");
         writer.WriteLine("  --utf8-bom   Write processed files as UTF-8 with a byte order mark");
         writer.WriteLine("  --help, -h   Show this help message");
+        writer.WriteLine("  --version    Show version information");
         writer.WriteLine("  --           Treat all following arguments as paths");
+    }
+
+    /// <summary>
+    /// Gets the CLI's version string
+    /// </summary>
+    /// <returns>The informational version reported by <c>--version</c></returns>
+    private static string GetVersion()
+    {
+        var assembly = typeof(Program).Assembly;
+
+        return assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? assembly.GetName().Version?.ToString() ?? "unknown";
     }
 
     #endregion // Methods

--- a/Reihitsu.Cli/README.MD
+++ b/Reihitsu.Cli/README.MD
@@ -32,6 +32,7 @@ reihitsu-format [options] [<paths>...]
 | `--force`   | Skip the confirmation prompt that is shown when a run would format more than 25 files. Required for large runs when standard input is not interactive (e.g. CI). |
 | `--utf8-bom` | Normalize processed files to UTF-8 with a byte order mark. Encoding-only changes are reported in `--check` and `--dry-run` modes. |
 | `--help`    | Show help message.                                                 |
+| `--version` | Show version information.                                          |
 
 ### Exit Codes
 


### PR DESCRIPTION
## Summary

Adds a `--version` flag to the `reihitsu-format` CLI. It prints the tool name and informational version (e.g. `reihitsu-format 1.0.0-rc1`) to standard output and exits with success, following the same parsing/handling pattern as the existing `--help` flag.

## Why

The CLI had no way to report its own version.

## Linked issues

None.

## Review notes

- `ParseResult` gained a `ShowVersion` field; the only production constructor call site (`Program.ParseArguments`) was updated accordingly.
- Version is read via reflection from `AssemblyInformationalVersionAttribute` (falling back to the assembly version, then `"unknown"`), so it stays in sync with `Directory.Build.props` without hardcoding.
- No short flag (`-v`) was added, to avoid ambiguity with the existing `--verbose` flag; this mirrors the majority of existing options, which are long-form only.
- Updated `README.MD` and the in-app usage text to document the new option.

## Follow-up work

None.


---
_Generated by [Claude Code](https://claude.ai/code/session_014hjb2f9d6MmDrKZvd7cfhw)_