### PR TITLE
Align formatter chain collapse, rejoin and initializer anchor with RH5201

### DIFF
--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5201MethodChainsShouldBeAlignedFormatterTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5201MethodChainsShouldBeAlignedFormatterTests.cs
@@ -217,5 +217,88 @@ public class RH5201MethodChainsShouldBeAlignedFormatterTests : FormatterTestsBas
                                                Diagnostics(RH5201MethodChainsShouldBeAlignedAnalyzer.DiagnosticId, AnalyzerResources.RH5201MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies that the formatter's output for a chain whose own first dot is wrapped is
+    /// RH5201-clean, so the formatter and the analyzer no longer disagree on this shape (issue #683)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFormatterOutputForWrappedFirstChainDotIsClean()
+    {
+        const string source = """
+                              internal class Example
+                              {
+                                  internal string Prop { get; set; }
+
+                                  internal static string Run(Example a)
+                                  {
+                                      return a.Prop?.ToString()
+                                                   .Trim();
+                                  }
+                              }
+                              """;
+
+        await VerifyFormatterStability(source);
+    }
+
+    /// <summary>
+    /// Verifies that the formatter's output for a chain rooted in a single-line array initializer is
+    /// RH5201-clean, so the code fix no longer moves a column the formatter puts back (issue #684)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFormatterOutputForChainRootedInSingleLineInitializerIsClean()
+    {
+        const string source = """
+                              using System.Linq;
+
+                              internal class Example
+                              {
+                                  internal static int[] Run()
+                                  {
+                                      return new[] { 1, 2, 3 }.Select(item => item)
+                                                              .ToArray();
+                                  }
+                              }
+                              """;
+
+        await VerifyFormatterStability(source);
+    }
+
+    /// <summary>
+    /// Verifies that the formatter's output for a chain whose member name was split from its own dot
+    /// is RH5201-clean once the name is rejoined (issue #685)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFormatterOutputForRejoinedSplitMemberNameIsClean()
+    {
+        const string source = """
+                              internal class Example
+                              {
+                                  internal Example Prop { get; set; }
+
+                                  internal Example Call()
+                                  {
+                                      return this;
+                                  }
+
+                                  internal Example Then()
+                                  {
+                                      return this;
+                                  }
+
+                                  internal static Example Run(Example a)
+                                  {
+                                      return a?.Prop
+                                              .Call()
+                                              .Then();
+                                  }
+                              }
+                              """;
+
+        await VerifyFormatterStability(source);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Formatter.Test/Regression/Indentation/Issue683To685ReproductionTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Indentation/Issue683To685ReproductionTests.cs
@@ -1,0 +1,221 @@
+using System;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Formatter.Test.Helpers;
+
+namespace Reihitsu.Formatter.Test.Regression.Indentation;
+
+/// <summary>
+/// Reproduction-gate tests for issues #683, #684 and #685 — asserted against each issue's own
+/// reported "Expected Formatted Output" so a failing run shows the issue's own observed-vs-expected
+/// difference
+/// </summary>
+[TestClass]
+public class Issue683To685ReproductionTests : FormatterTestsBase
+{
+    #region Methods
+
+    /// <summary>
+    /// Issue #683 — a chain whose own first wrapped dot is a plain, non-invoked property access
+    /// preceding the first invoked link should collapse onto the chain root, per the issue's own
+    /// reported Input/Expected Formatted Output
+    /// </summary>
+    [TestMethod]
+    public void Issue683WrappedNonInvokedFirstDotCollapsesOntoRoot()
+    {
+        // Arrange — verbatim from issue #683's "Input Code"
+        const string input = """
+                             internal sealed class Example
+                             {
+                                 internal static void Run(object a)
+                                 {
+                                     var x = a
+                                         .Prop?.ToString()
+                                               .Trim();
+                                 }
+                             }
+                             """;
+
+        // verbatim from issue #683's "Expected Formatted Output"
+        const string expected = """
+                                internal sealed class Example
+                                {
+                                    internal static void Run(object a)
+                                    {
+                                        var x = a.Prop?.ToString()
+                                                      .Trim();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Issue #684 — a chain rooted in a single-line object/array/collection initializer should align
+    /// its continuation dot the same way a multi-line initializer already does, per the issue's own
+    /// reported Input/Expected Formatted Output
+    /// </summary>
+    [TestMethod]
+    public void Issue684ChainRootedInSingleLineInitializerAlignsCorrectly()
+    {
+        // Arrange — verbatim from issue #684's "Input Code"
+        const string input = """
+                             using System.Collections.Generic;
+                             using System.Linq;
+
+                             internal sealed class Example
+                             {
+                                 internal sealed class Wrapper
+                                 {
+                                     public int Value { get; set; }
+                                 }
+
+                                 internal static List Convert()
+                                 {
+                                     var result = new[] { 1, 2, 3 }.Select(item => new Wrapper
+                                     {
+                                         Value = item
+                                     })
+                                                                    .ToList();
+
+                                     return result;
+                                 }
+                             }
+                             """;
+
+        // verbatim from issue #684's "Expected Formatted Output"
+        const string expected = """
+                                using System.Collections.Generic;
+                                using System.Linq;
+
+                                internal sealed class Example
+                                {
+                                    internal sealed class Wrapper
+                                    {
+                                        public int Value { get; set; }
+                                    }
+
+                                    internal static List Convert()
+                                    {
+                                        var result = new[] { 1, 2, 3 }.Select(item => new Wrapper
+                                                                                      {
+                                                                                          Value = item
+                                                                                      })
+                                                                      .ToList();
+
+                                        return result;
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Issue #685 — a plain member-access dot immediately followed by a line break, with the member
+    /// name on the next line (<c>a.</c> ⏎ <c>Prop</c>), should rejoin onto one line. The issue's own
+    /// "Expected Formatted Output" section states this is not yet fully determined, but gives a
+    /// literal minimum target for this exact fixture: <c>a.Prop.Call();</c>, "matching how x ⏎ .Prop
+    /// already rejoins today"
+    /// </summary>
+    [TestMethod]
+    public void Issue685TrailingDotBeforeLineBreakRejoinsWithMemberName()
+    {
+        // Arrange — first fixture from issue #685's "Input Code" (the plain, non-conditional case)
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var a1 = a.
+                                         Prop.Call();
+                                 }
+                             }
+                             """;
+
+        // verbatim minimum given in issue #685's "Expected Formatted Output": "a.Prop.Call();"
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var a1 = a.Prop.Call();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Issue #685 — the second, initializer-rooted fixture from the issue: a conditional-access dot
+    /// immediately followed by a line break (<c>}.</c> ⏎ <c>Choices</c>) should not leave
+    /// <c>Choices</c> orphaned on its own continuation line separated from its own dot. The issue does
+    /// not give a full target shape for this fixture, so this test checks only that stated minimum
+    /// rather than a specific alignment column
+    /// </summary>
+    [TestMethod]
+    public void Issue685TrailingDotAfterInitializerCloseBraceDoesNotOrphanMemberName()
+    {
+        // Arrange — second fixture from issue #685's "Input Code"
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = new Request
+                                             {
+                                                 Choices = data
+                                             }.
+                                                 Choices?.Select(item => new Wrapper
+                                                                         {
+                                                                             Value = item
+                                                                         })
+                                                        .ToList();
+                                 }
+                             }
+                             """;
+
+        // Act
+        var actual = ApplyRule(input, "\n");
+        var lines = actual.Split('\n');
+        var braceDotLineIndex = Array.FindIndex(lines, IsTrailingDotLine);
+
+        // Assert — the "}." line must exist and "Choices" must be joined onto it, not left as the
+        // sole content of the following continuation line (issue #685's stated minimum)
+        Assert.IsGreaterThanOrEqualTo(0, braceDotLineIndex, "Expected to find a line ending in '}.'.");
+
+        var nextLine = lines[braceDotLineIndex + 1].TrimStart();
+
+        Assert.IsFalse(nextLine.StartsWith("Choices", StringComparison.Ordinal), FormatOrphanMessage(lines[braceDotLineIndex], nextLine));
+    }
+
+    /// <summary>
+    /// Determines whether the given line's trailing content ends with a member-access dot with no
+    /// following name on the same line — the shape issue #685 reports as not being rejoined
+    /// </summary>
+    /// <param name="line">The candidate line</param>
+    /// <returns><see langword="true"/> when the trimmed line ends with a bare <c>.</c></returns>
+    private static bool IsTrailingDotLine(string line)
+    {
+        return line.TrimEnd().EndsWith("}.", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Builds the failure message for the orphaned-member-name assertion
+    /// </summary>
+    /// <param name="dotLine">The line ending in the trailing dot</param>
+    /// <param name="nextLine">The following, trimmed line</param>
+    /// <returns>The assertion failure message</returns>
+    private static string FormatOrphanMessage(string dotLine, string nextLine)
+    {
+        return $"Expected 'Choices' not to be orphaned on its own continuation line separated from its own '.'. Dot line: '{dotLine}', next line: '{nextLine}'.";
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Formatter.Test/Regression/Indentation/Issue683To685ReproductionTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Indentation/Issue683To685ReproductionTests.cs
@@ -1,5 +1,3 @@
-using System;
-
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Reihitsu.Formatter.Test.Helpers;
@@ -154,10 +152,15 @@ public class Issue683To685ReproductionTests : FormatterTestsBase
 
     /// <summary>
     /// Issue #685 — the second, initializer-rooted fixture from the issue: a conditional-access dot
-    /// immediately followed by a line break (<c>}.</c> ⏎ <c>Choices</c>) should not leave
-    /// <c>Choices</c> orphaned on its own continuation line separated from its own dot. The issue does
-    /// not give a full target shape for this fixture, so this test checks only that stated minimum
-    /// rather than a specific alignment column
+    /// immediately followed by a line break (<c>}.</c> ⏎ <c>Choices</c>) must not leave
+    /// <c>Choices</c> orphaned on its own continuation line separated from its own dot.
+    /// <para>
+    /// The issue states no full target shape for this fixture, only that minimum. The expected output
+    /// below is derived from the chain's reference column — <c>.ToList()</c> aligns to the <c>?</c> of
+    /// the first invoked link, the same column <c>RH5201MethodChainsShouldBeAlignedAnalyzer</c>
+    /// computes — and is byte-identical to the expected output the repository already asserts for the
+    /// same chain written with its initializer on one line
+    /// </para>
     /// </summary>
     [TestMethod]
     public void Issue685TrailingDotAfterInitializerCloseBraceDoesNotOrphanMemberName()
@@ -181,40 +184,25 @@ public class Issue683To685ReproductionTests : FormatterTestsBase
                              }
                              """;
 
-        // Act
-        var actual = ApplyRule(input, "\n");
-        var lines = actual.Split('\n');
-        var braceDotLineIndex = Array.FindIndex(lines, IsTrailingDotLine);
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = new Request
+                                                {
+                                                    Choices = data
+                                                }.Choices?.Select(item => new Wrapper
+                                                                          {
+                                                                              Value = item
+                                                                          })
+                                                         .ToList();
+                                    }
+                                }
+                                """;
 
-        // Assert — the "}." line must exist and "Choices" must be joined onto it, not left as the
-        // sole content of the following continuation line (issue #685's stated minimum)
-        Assert.IsGreaterThanOrEqualTo(0, braceDotLineIndex, "Expected to find a line ending in '}.'.");
-
-        var nextLine = lines[braceDotLineIndex + 1].TrimStart();
-
-        Assert.IsFalse(nextLine.StartsWith("Choices", StringComparison.Ordinal), FormatOrphanMessage(lines[braceDotLineIndex], nextLine));
-    }
-
-    /// <summary>
-    /// Determines whether the given line's trailing content ends with a member-access dot with no
-    /// following name on the same line — the shape issue #685 reports as not being rejoined
-    /// </summary>
-    /// <param name="line">The candidate line</param>
-    /// <returns><see langword="true"/> when the trimmed line ends with a bare <c>.</c></returns>
-    private static bool IsTrailingDotLine(string line)
-    {
-        return line.TrimEnd().EndsWith("}.", StringComparison.Ordinal);
-    }
-
-    /// <summary>
-    /// Builds the failure message for the orphaned-member-name assertion
-    /// </summary>
-    /// <param name="dotLine">The line ending in the trailing dot</param>
-    /// <param name="nextLine">The following, trimmed line</param>
-    /// <returns>The assertion failure message</returns>
-    private static string FormatOrphanMessage(string dotLine, string nextLine)
-    {
-        return $"Expected 'Choices' not to be orphaned on its own continuation line separated from its own '.'. Dot line: '{dotLine}', next line: '{nextLine}'.";
+        // Act & Assert
+        AssertRuleResult(input, expected);
     }
 
     #endregion // Methods

--- a/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
@@ -1443,12 +1443,14 @@ public class MethodChainAlignmentTests : FormatterTestsBase
     }
 
     /// <summary>
-    /// Verifies that a chain whose first collected dot is itself wrapped onto its own line keeps its
-    /// current alignment; issue #680's fix does not reach this shape, which has an independent,
-    /// pre-existing divergence from RH5201 tracked separately
+    /// Verifies that a chain whose own first dot is wrapped onto its own line collapses that dot back
+    /// onto the chain root, so the remaining continuation dots align to the first invoked link's
+    /// column — the column RH5201 computes — instead of to block indentation. The dot is a plain,
+    /// non-invoked property access, which the line-break phase's invoked-link-only view never
+    /// considered (issue #683)
     /// </summary>
     [TestMethod]
-    public void WrappedFirstChainDotKeepsCurrentAlignment()
+    public void WrappedFirstChainDotCollapsesOntoChainRoot()
     {
         // Arrange
         const string input = """
@@ -1463,8 +1465,19 @@ public class MethodChainAlignmentTests : FormatterTestsBase
                              }
                              """;
 
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a.Prop?.Call()
+                                                      .Then();
+                                    }
+                                }
+                                """;
+
         // Act & Assert
-        AssertRuleResult(input);
+        AssertRuleResult(input, expected);
     }
 
     /// <summary>
@@ -1509,14 +1522,15 @@ public class MethodChainAlignmentTests : FormatterTestsBase
     }
 
     /// <summary>
-    /// Verifies that the initializer-adjacent anchor correction does not mix columns from two
-    /// different source lines when the chain's first collected dot sits on an initializer's closing
-    /// brace line but the anchor link itself wraps onto a later line; the correction must only apply
-    /// when the anchor shares the first collected dot's own line, or a second formatter pass changes
-    /// the result (issue #680)
+    /// Verifies that a member-access dot immediately followed by a line break rejoins its own member
+    /// name, so the name is no longer left orphaned on a continuation line at block indentation. The
+    /// break lives in the dot's trailing trivia, which no chain predicate inspected (issue #685). The
+    /// rejoined result is byte-identical to the expected output of
+    /// <see cref="ConditionalAccessAfterInitializerCloseBraceAndPropertyAlignsToInvokedLink"/>, whose
+    /// input writes the same chain with its initializer on one line
     /// </summary>
     [TestMethod]
-    public void ConditionalAccessAnchorOnLaterLineThanInitializerCloseBraceStaysIdempotent()
+    public void TrailingDotAfterInitializerCloseBraceRejoinsItsMemberName()
     {
         // Arrange
         const string input = """
@@ -1545,7 +1559,68 @@ public class MethodChainAlignmentTests : FormatterTestsBase
                                         var x = new Request
                                                 {
                                                     Choices = data
+                                                }.Choices?.Select(item => new Wrapper
+                                                                          {
+                                                                              Value = item
+                                                                          })
+                                                         .ToList();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that the initializer-adjacent anchor correction does not mix columns from two
+    /// different source lines when the chain's first collected dot sits on an initializer's closing
+    /// brace line but the anchor link itself wraps onto a later line; the correction must only apply
+    /// when the anchor shares the first collected dot's own line, or a second formatter pass changes
+    /// the result (issue #680).
+    /// <para>
+    /// A comment between the dot and its member name is what keeps the two on separate lines here:
+    /// it blocks the rejoin that <see cref="TrailingDotAfterInitializerCloseBraceRejoinsItsMemberName"/>
+    /// performs, which is the only remaining way to reach the correction's unequal-line branch. The
+    /// blank line and the comment's own indentation in the expected output are pre-existing behavior
+    /// of the surrounding phases, unchanged by issues #683, #684 and #685, and are not what this test
+    /// guards
+    /// </para>
+    /// </summary>
+    [TestMethod]
+    public void ConditionalAccessAnchorOnLaterLineThanInitializerCloseBraceStaysIdempotent()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = new Request
+                                             {
+                                                 Choices = data
+                                             }.
+                                                 // keep
+                                                 Choices?.Select(item => new Wrapper
+                                                                         {
+                                                                             Value = item
+                                                                         })
+                                                        .ToList();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = new Request
+                                                {
+                                                    Choices = data
                                                 }.
+
+                                        // keep
                                         Choices?.Select(item => new Wrapper
                                                                 {
                                                                     Value = item

--- a/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
@@ -1634,5 +1634,505 @@ public class MethodChainAlignmentTests : FormatterTestsBase
         AssertRuleResult(input, expected);
     }
 
+    /// <summary>
+    /// Verifies that the wrapped-first-dot collapse does not depend on a conditional-access or
+    /// null-forgiving operator: a chain of plain dots diverges and converges identically (issue #683)
+    /// </summary>
+    [TestMethod]
+    public void WrappedFirstChainDotWithPlainDotsCollapsesOntoChainRoot()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                                         .Prop.ToString()
+                                         .Trim();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a.Prop.ToString()
+                                                      .Trim();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a null-forgiving operator introducing the first invoked link does not exempt the
+    /// chain from the wrapped-first-dot collapse (issue #683)
+    /// </summary>
+    [TestMethod]
+    public void WrappedFirstChainDotBeforeNullForgivingLinkCollapsesOntoChainRoot()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                                         .Prop!.ToString()
+                                         .Trim();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a.Prop!.ToString()
+                                                      .Trim();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a chain whose only wrapped dot is its own first dot collapses onto one line. No
+    /// invoked link wraps here, so the chain must not gain continuation breaks it never had — the
+    /// boundary that the invoked-link-only early-out used to decide (issue #683)
+    /// </summary>
+    [TestMethod]
+    public void WrappedFirstChainDotWithNoWrappedLinkCollapsesOntoOneLine()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                                         .Prop?.ToString().Trim();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a.Prop?.ToString().Trim();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that the wrapped-first-dot collapse applies inside an argument, so the enclosing
+    /// formatting scope is not a discriminator (issue #683)
+    /// </summary>
+    [TestMethod]
+    public void WrappedFirstChainDotInsideArgumentCollapsesOntoChainRoot()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M(object a)
+                                 {
+                                     Handle(a
+                                         .Prop?.ToString()
+                                         .Trim());
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M(object a)
+                                    {
+                                        Handle(a.Prop?.ToString()
+                                                     .Trim());
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies the other side of the collapse boundary: when the chain's own first dot already sits
+    /// on the root line, the wrapped link behind it still collapses exactly as it does today. A
+    /// substitution that simply took the first chain dot instead of the first invoked link would stop
+    /// collapsing this <c>?</c> (issue #683)
+    /// </summary>
+    [TestMethod]
+    public void UnwrappedFirstChainDotStillCollapsesTheWrappedLinkBehindIt()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a.Prop
+                                         ?.ToString()
+                                         .Trim();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a.Prop?.ToString()
+                                                      .Trim();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a fluent chain whose first dot is already on the root line stays wrapped, so the
+    /// widened collapse does not defeat <c>ChainWalker.ChainHasIntermediateMemberAccess</c>'s
+    /// deliberate keep-wrapped rule (issue #683)
+    /// </summary>
+    [TestMethod]
+    public void FluentChainWithUnwrappedFirstDotStaysWrapped()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a.Prop
+                                              .Foo()
+                                              .Bar();
+                                     var y = a.Prop
+                                              .Select(item => item);
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a chain with exactly one invoked link collapses its own wrapped first dot too,
+    /// so the same chain formats identically however the author placed the break. The wrapped fluent
+    /// link keeps its line and aligns to the chain's reference column (issue #683)
+    /// </summary>
+    [TestMethod]
+    public void WrappedFirstChainDotWithSingleInvokedLinkCollapsesOntoChainRoot()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                                         .Prop
+                                         .Select(item => item);
+                                     var a1 = a
+                                         .Prop.Call();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a.Prop
+                                                 .Select(item => item);
+                                        var a1 = a.Prop.Call();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a chain rooted in a single-line implicit array initializer aligns its
+    /// continuation dot to the first invoked link. The closing brace shares its line with the
+    /// initializer's elements, so rebasing the anchor onto the <c>new</c> keyword would shift it left
+    /// by the initializer's printed width (issue #684)
+    /// </summary>
+    [TestMethod]
+    public void ChainRootedInSingleLineImplicitArrayInitializerAlignsToInvokedLink()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = new[] { 1, 2, 3 }.Select(item => item)
+                                        .ToList();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = new[] { 1, 2, 3 }.Select(item => item)
+                                                                 .ToList();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that the same chain rooted in an explicit single-line array initializer aligns
+    /// identically, so the defect is not specific to the implicit-array arm (issue #684)
+    /// </summary>
+    [TestMethod]
+    public void ChainRootedInSingleLineExplicitArrayInitializerAlignsToInvokedLink()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = new int[] { 1, 2, 3 }.Select(item => item)
+                                        .ToList();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = new int[] { 1, 2, 3 }.Select(item => item)
+                                                                     .ToList();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies the other side of the initializer-correction boundary: an initializer whose closing
+    /// brace starts its own line still has its chain anchor rebased onto the creation expression's
+    /// <c>new</c> keyword, which is the arm the correction exists for (issue #684)
+    /// </summary>
+    [TestMethod]
+    public void ChainRootedInInitializerWithCloseBraceFirstOnLineKeepsNewKeywordRebase()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = new Wrapper
+                                     {
+                                         Value = 1
+                                     }.Select(item => item)
+                                        .ToList();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = new Wrapper
+                                                {
+                                                    Value = 1
+                                                }.Select(item => item)
+                                                 .ToList();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a chain whose first dot wraps after a single-line array initializer both
+    /// collapses that dot and aligns the remaining continuation dot — the shape where issues #683 and
+    /// #684 meet on one input
+    /// </summary>
+    [TestMethod]
+    public void WrappedFirstChainDotAfterSingleLineArrayInitializerCollapsesAndAligns()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = new[] { 1, 2, 3 }
+                                         .Select(item => item)
+                                         .ToList();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = new[] { 1, 2, 3 }.Select(item => item)
+                                                                 .ToList();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that every continuation dot of a three-link chain rooted in a single-line array
+    /// initializer lands on the same reference column (issue #684)
+    /// </summary>
+    [TestMethod]
+    public void ThreeLinkChainRootedInSingleLineArrayInitializerAlignsEveryContinuationDot()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = new[] { 1, 2, 3 }.Where(item => item > 0)
+                                        .Select(item => item)
+                                        .ToList();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = new[] { 1, 2, 3 }.Where(item => item > 0)
+                                                                 .Select(item => item)
+                                                                 .ToList();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a chain whose root ends in a token other than an initializer's closing brace is
+    /// untouched by the initializer correction (issue #684)
+    /// </summary>
+    [TestMethod]
+    public void ChainRootedInElementAccessIsUnaffectedByInitializerCorrection()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = arr[0].Foo()
+                                        .Bar();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = arr[0].Foo()
+                                                      .Bar();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Characterizes a shape that issues #683, #684 and #685 do <b>not</b> fix: a multi-line array
+    /// initializer whose closing brace shares its line with an element. The initializer correction
+    /// correctly no longer applies (the brace is not first on its line), but the fallback reads the
+    /// brace line's layout before <c>ObjectInitializerContributor</c> rebases it, so the continuation
+    /// dot still diverges from the column RH5201 computes. That contributor-ordering defect is a
+    /// separate mechanism, tracked as follow-up work; this test exists so the shape cannot drift
+    /// silently while it is open
+    /// </summary>
+    [TestMethod]
+    public void MultiLineArrayInitializerWithTrailingCloseBraceKeepsKnownDivergence()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = new int[] { 1,
+                                         2 }.Select(item => item)
+                                        .ToList();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = new int[] { 1,
+                                                    2 }.Select(item => item)
+                                           .ToList();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
     #endregion // Methods
 }

--- a/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
@@ -1877,6 +1877,89 @@ public class MethodChainAlignmentTests : FormatterTestsBase
     }
 
     /// <summary>
+    /// Verifies that a null-forgiving operator on the chain <b>root</b> is treated as part of that
+    /// root rather than as the chain's first dot, so the wrapped <c>.Prop</c> behind it is still the
+    /// collapse candidate. Every other null-forgiving fixture places the <c>!</c> after an
+    /// invocation, which never reaches this decision (issue #683)
+    /// </summary>
+    [TestMethod]
+    public void WrappedFirstChainDotAfterNullForgivingRootCollapsesOntoChainRoot()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a!
+                                         .Prop
+                                         .Foo()
+                                         .Bar();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a!.Prop
+                                                 .Foo()
+                                                 .Bar();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a comment above the collapse candidate refuses only that join: the chain stays
+    /// wrapped at the commented dot, but the continuation links still each start their own line, so
+    /// the output remains RH5201-clean. Aborting the whole normalization here would leave a trailing
+    /// link sharing its predecessor's line (issue #683)
+    /// </summary>
+    [TestMethod]
+    public void CommentAboveCollapseCandidateStillBreaksContinuationLinks()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                                             // keep this chain wrapped
+                                             .Prop
+                                             .Foo()
+                                             .Bar().Baz();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a
+
+                                                // keep this chain wrapped
+                                                .Prop
+                                                .Foo()
+                                                .Bar()
+                                                .Baz();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
     /// Verifies that a chain rooted in a single-line implicit array initializer aligns its
     /// continuation dot to the first invoked link. The closing brace shares its line with the
     /// initializer's elements, so rebasing the anchor onto the <c>new</c> keyword would shift it left
@@ -2100,7 +2183,12 @@ public class MethodChainAlignmentTests : FormatterTestsBase
     /// brace line's layout before <c>ObjectInitializerContributor</c> rebases it, so the continuation
     /// dot still diverges from the column RH5201 computes. That contributor-ordering defect is a
     /// separate mechanism, tracked as follow-up work; this test exists so the shape cannot drift
-    /// silently while it is open
+    /// silently while it is open.
+    /// <para>
+    /// The expected output is a <b>changed</b> baseline, not a preserved one: before issue #684's fix
+    /// the continuation dot sat at column 17, and it now sits at column 11. Both diverge from the
+    /// column RH5201 computes for this shape, so neither is correct
+    /// </para>
     /// </summary>
     [TestMethod]
     public void MultiLineArrayInitializerWithTrailingCloseBraceKeepsKnownDivergence()

--- a/Reihitsu.Formatter.Test/Regression/LineBreaks/ChainSplitMemberNameRejoinTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/LineBreaks/ChainSplitMemberNameRejoinTests.cs
@@ -1,0 +1,278 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Formatter.Test.Helpers;
+
+namespace Reihitsu.Formatter.Test.Regression.LineBreaks;
+
+/// <summary>
+/// Regression tests for issue #685: a member-access dot immediately followed by a line break, with
+/// the member name on the next line (<c>x.</c> ⏎ <c>Name</c>), must be rejoined. That break sits in
+/// the dot's trailing trivia, which every other chain predicate ignores, so the split survived and
+/// the orphaned name was re-indented to block level
+/// </summary>
+[TestClass]
+public class ChainSplitMemberNameRejoinTests : FormatterTestsBase
+{
+    #region Methods
+
+    /// <summary>
+    /// Verifies that a plain, non-conditional chain rejoins its split member name — the first fixture
+    /// reported in issue #685
+    /// </summary>
+    [TestMethod]
+    public void SplitMemberNameRejoinsOntoItsDot()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var a1 = a.
+                                         Prop.Call();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var a1 = a.Prop.Call();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that rejoining the split preserves a deliberate wrap further along the chain: the
+    /// name joins its dot while the wrapped <c>.Trim()</c> link keeps its own line and aligns to the
+    /// first invoked link
+    /// </summary>
+    [TestMethod]
+    public void SplitMemberNameRejoinsAndKeepsLaterWrappedLink()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a.
+                                         Prop?.ToString()
+                                         .Trim();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a.Prop?.ToString()
+                                                      .Trim();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a split whose chain is kept wrapped by a multi-line argument list still rejoins
+    /// the member name, and that the argument wrap itself survives
+    /// </summary>
+    [TestMethod]
+    public void SplitMemberNameRejoinsWithMultiLineArgumentList()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a.
+                                         Call(1,
+                                             2);
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a.Call(1,
+                                                       2);
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that every split at a chain-link boundary rejoins, not only the first one
+    /// </summary>
+    [TestMethod]
+    public void EverySplitMemberNameRejoins()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var v = a.
+                                         Prop.
+                                         Call(1,
+                                             2);
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var v = a.Prop.Call(1,
+                                                            2);
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a conditional-access chain rejoins the name onto its binding dot. The break
+    /// before <c>.Call()</c> is not the split being repaired: it is the wrap RH5201 requires once the
+    /// chain wraps at all, so the invoked links end up on their own lines at one column
+    /// </summary>
+    [TestMethod]
+    public void SplitMemberNameAfterConditionalAccessRejoins()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a?.
+                                         Prop.Call()
+                                         .Then();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a?.Prop
+                                                 .Call()
+                                                 .Then();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a chain carrying no invocation at all — reached through the member-access
+    /// rewriter rather than the chain normalizer — rejoins its split member name too
+    /// </summary>
+    [TestMethod]
+    public void SplitMemberNameRejoinsOnMemberAccessOnlyChain()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var v = a.
+                                         B.C;
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var v = a.B.C;
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a comment between the dot and its member name keeps the split: rejoining across
+    /// it would absorb the name into the comment
+    /// </summary>
+    [TestMethod]
+    public void CommentBetweenDotAndMemberNameKeepsSplit()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var a1 = a. // keep
+                                     Prop.Call();
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a block comment ending the dot's own line also keeps the split. Both this and
+    /// <see cref="CommentBetweenDotAndMemberNameKeepsSplit"/> exercise the single
+    /// <c>WouldJoinAcrossUnjoinableTrivia</c> call site that decides the refusal for every unjoinable
+    /// trivia kind — comment, preprocessor directive, and disabled text alike — without branching per
+    /// kind, so the directive and disabled-text arms are covered by that shared guard rather than by
+    /// their own fixtures
+    /// </summary>
+    [TestMethod]
+    public void BlockCommentBetweenDotAndMemberNameKeepsSplit()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var a1 = a. /* keep */
+                                     Prop.Call();
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Formatter.Test/Regression/LineBreaks/ChainSplitMemberNameRejoinTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/LineBreaks/ChainSplitMemberNameRejoinTests.cs
@@ -248,12 +248,9 @@ public class ChainSplitMemberNameRejoinTests : FormatterTestsBase
     }
 
     /// <summary>
-    /// Verifies that a block comment ending the dot's own line also keeps the split. Both this and
-    /// <see cref="CommentBetweenDotAndMemberNameKeepsSplit"/> exercise the single
-    /// <c>WouldJoinAcrossUnjoinableTrivia</c> call site that decides the refusal for every unjoinable
-    /// trivia kind — comment, preprocessor directive, and disabled text alike — without branching per
-    /// kind, so the directive and disabled-text arms are covered by that shared guard rather than by
-    /// their own fixtures
+    /// Verifies that a block comment ending the dot's own line also keeps the split. Together with
+    /// <see cref="CommentBetweenDotAndMemberNameKeepsSplit"/> this covers the refusal predicate's
+    /// first disjunct, which inspects the <b>dot's trailing</b> trivia
     /// </summary>
     [TestMethod]
     public void BlockCommentBetweenDotAndMemberNameKeepsSplit()
@@ -272,6 +269,92 @@ public class ChainSplitMemberNameRejoinTests : FormatterTestsBase
 
         // Act & Assert
         AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a comment on its own line before the member name keeps the split. This covers
+    /// the refusal predicate's <b>second</b> disjunct, which inspects the <b>name token's leading</b>
+    /// trivia — the only one a directive or an own-line comment can reach, and the one the two
+    /// trailing-trivia fixtures above never exercise. The blank line in the expected output is
+    /// pre-existing behavior of the surrounding phases and is not what this test guards
+    /// </summary>
+    [TestMethod]
+    public void OwnLineCommentBeforeMemberNameKeepsSplit()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var a1 = a.
+                                         // keep
+                                         Prop.Call();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var a1 = a.
+
+                                        // keep
+                                        Prop.Call();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a preprocessor directive between the dot and its member name keeps the split:
+    /// removing the end-of-line that terminates the directive's line would invalidate it. The
+    /// directive reaches the same name-token leading-trivia disjunct as
+    /// <see cref="OwnLineCommentBeforeMemberNameKeepsSplit"/>, with a trivia kind a comment-only
+    /// guard would miss. The indentation of the inactive branch is pre-existing behavior of the
+    /// surrounding phases and is not what this test guards
+    /// </summary>
+    [TestMethod]
+    public void DirectiveBetweenDotAndMemberNameKeepsSplit()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var a1 = a.
+                             #if DEBUG
+                                         Prop.Call();
+                             #else
+                                         Other.Call();
+                             #endif
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var a1 = a.
+                                #if DEBUG
+                                            Prop.Call();
+                                #else
+                                        Other.Call();
+                                #endif
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
     }
 
     #endregion // Methods

--- a/Reihitsu.Formatter.Test/Unit/Indentation/LayoutComputerTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/Indentation/LayoutComputerTests.cs
@@ -654,7 +654,7 @@ public class LayoutComputerTests
         Assert.IsTrue(model.TryGetLayout(6, out var where), "Line 6 (.Where) should have a layout entry.");
         Assert.IsTrue(model.TryGetLayout(7, out var select), "Line 7 (.Select) should have a layout entry.");
         Assert.AreEqual(8, where.Column, "Chained LINQ .Where should be at block indentation column.");
-        Assert.AreEqual(0, select.Column, "Chained LINQ .Select should be aligned to the chain anchor column.");
+        Assert.AreEqual(8, select.Column, "Chained LINQ .Select should be aligned to .Where, the chain's first invoked link.");
     }
 
     /// <summary>

--- a/Reihitsu.Formatter/Pipeline/Indentation/Contributors/MethodChainAlignmentContributor.cs
+++ b/Reihitsu.Formatter/Pipeline/Indentation/Contributors/MethodChainAlignmentContributor.cs
@@ -58,7 +58,14 @@ internal sealed class MethodChainAlignmentContributor : ILayoutContributor
     /// non-link prefix dot. An anchor that wraps onto a later line than the first dot has no such
     /// fixed offset from the brace, so it falls back to the ordinary adjusted-column lookup, which
     /// resolves the anchor's own line through the layout model instead of mixing columns from
-    /// unrelated lines
+    /// unrelated lines.
+    /// Rebasing onto the <c>new</c> keyword is only valid when the closing brace itself ends up at
+    /// that keyword's column, which happens exactly when the brace starts its own line — the same
+    /// condition <see cref="ObjectInitializerContributor"/> uses before it moves the brace there. A
+    /// brace that shares its line with earlier content (<c>new[] { 1, 2, 3 }.Select(…)</c>, or a
+    /// multi-line initializer closed by <c>2 }</c>) keeps its own line's indentation, so the rebase
+    /// would shift the anchor by the initializer's printed width; such a chain falls back to the
+    /// ordinary lookup instead (issue #684)
     /// </summary>
     /// <param name="anchorDot">The chain-link token chosen as the alignment anchor</param>
     /// <param name="firstDot">The chain's first collected dot, used to detect an initializer-rooted chain</param>
@@ -70,6 +77,7 @@ internal sealed class MethodChainAlignmentContributor : ILayoutContributor
 
         if (prevToken.IsKind(SyntaxKind.CloseBraceToken)
             && prevToken.Parent is InitializerExpressionSyntax initExpr
+            && LayoutComputer.IsFirstOnLine(prevToken)
             && LayoutComputer.GetLine(anchorDot) == LayoutComputer.GetLine(firstDot))
         {
             var newKeyword = GetCreationNewKeyword(initExpr.Parent);

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/Rewriter/ChainLineBreakRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/Rewriter/ChainLineBreakRewriter.cs
@@ -241,9 +241,13 @@ internal sealed class ChainLineBreakRewriter : CSharpSyntaxRewriter
     }
 
     /// <summary>
-    /// Collapses the first chain dot onto the root line when it starts on a continuation line
+    /// Collapses the chain's leading dot onto the line before it when that dot starts a continuation
+    /// line. The caller decides which dot that is — see <see cref="FindFirstWrappedChainOperator"/> —
+    /// and this method only refuses the join: a dot whose own receiver is another member or
+    /// conditional access belongs to a fluent chain that stays wrapped, and a comment, directive, or
+    /// disabled text in the gap keeps the two tokens on separate lines
     /// </summary>
-    /// <param name="firstDot">The first chain dot token</param>
+    /// <param name="firstDot">The chain dot to collapse</param>
     /// <param name="replacements">The token replacement map to populate</param>
     private static void TryCollapseFirstChainDot(SyntaxToken firstDot,
                                                  Dictionary<SyntaxToken, SyntaxToken> replacements)

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/Rewriter/ChainLineBreakRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/Rewriter/ChainLineBreakRewriter.cs
@@ -394,20 +394,24 @@ internal sealed class ChainLineBreakRewriter : CSharpSyntaxRewriter
             return node;
         }
 
-        var firstWrappedDot = FindFirstWrappedChainOperator(node, chainDots[0]);
-        var hasWrappedCandidate = firstWrappedDot.IsKind(SyntaxKind.None) == false;
-
-        if (hasWrappedCandidate
-            && ReihitsuFormatterHelpers.HasCommentDirectlyAbove(firstWrappedDot))
+        if (LineBreakTriviaUtilities.HasLeadingEndOfLine(chainDots[0])
+            && ReihitsuFormatterHelpers.HasCommentDirectlyAbove(chainDots[0]))
         {
             return node;
         }
 
+        var firstWrappedDot = FindFirstWrappedChainOperator(node, chainDots[0]);
+        var hasWrappedCandidate = firstWrappedDot.IsKind(SyntaxKind.None) == false;
         var replacements = new Dictionary<SyntaxToken, SyntaxToken>();
 
         CollectMemberNameRejoinReplacements(node, replacements);
 
-        if (hasWrappedCandidate)
+        // A comment above the collapse candidate refuses that one join; it must not suppress the
+        // rejoin or the continuation-break pass, which do not touch the commented gap. Only a comment
+        // above the chain's first invoked link keeps the whole chain as the author wrote it, and that
+        // is the pre-existing bail above.
+        if (hasWrappedCandidate
+            && ReihitsuFormatterHelpers.HasCommentDirectlyAbove(firstWrappedDot) == false)
         {
             TryCollapseFirstChainDot(firstWrappedDot, replacements);
         }

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/Rewriter/ChainLineBreakRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/Rewriter/ChainLineBreakRewriter.cs
@@ -93,22 +93,151 @@ internal sealed class ChainLineBreakRewriter : CSharpSyntaxRewriter
     }
 
     /// <summary>
-    /// Normalizes a chain containing a single dot token
+    /// Returns the pending replacement recorded for a token, or the token itself when none exists.
+    /// The chain normalization steps write into one shared replacement map, and more than one step
+    /// can legitimately touch the same token — rejoining a member name onto its dot clears that dot's
+    /// trailing end-of-line, and a later collapse may still need to clear the same token's leading
+    /// trivia. Composing on the pending token keeps the steps order-independent instead of letting
+    /// the last writer silently discard an earlier edit
     /// </summary>
-    /// <param name="node">The chain node</param>
-    /// <param name="chainDot">The chain dot token</param>
-    /// <returns>The updated chain node</returns>
-    private static SyntaxNode NormalizeSingleChainDot(SyntaxNode node,
-                                                      SyntaxToken chainDot)
+    /// <param name="token">The original token to look up</param>
+    /// <param name="replacements">The token replacement map built so far</param>
+    /// <returns>The pending replacement, or <paramref name="token"/> when it has not been replaced</returns>
+    private static SyntaxToken GetPendingToken(SyntaxToken token,
+                                               Dictionary<SyntaxToken, SyntaxToken> replacements)
     {
-        if (LineBreakTriviaUtilities.HasLeadingEndOfLine(chainDot)
-            && ChainWalker.DotHasIntermediateMemberAccess(chainDot) == false
-            && ReihitsuFormatterHelpers.HasCommentDirectlyAbove(chainDot) == false)
+        return replacements.TryGetValue(token, out var pending)
+                   ? pending
+                   : token;
+    }
+
+    /// <summary>
+    /// Chooses the dot the first-link collapse should consider: the chain's own first dot when the
+    /// chain wraps at that dot, and otherwise the first invoked link, exactly as before.
+    /// <para>
+    /// <see cref="ChainWalker.CollectInvokedLinkDots"/> reports invoked links only, so a chain whose
+    /// own first dot is a plain, non-invoked property access (<c>a</c> ⏎ <c>.Prop?.ToString()</c>)
+    /// never offered that dot to the collapse at all, and the chain stayed split at a boundary no
+    /// predicate ever tested (issue #683). Taking the first dot from the wider alignment set — the
+    /// same set <c>MethodChainAlignmentContributor</c> aligns against — closes that gap.
+    /// </para>
+    /// <para>
+    /// The substitution is deliberately confined to the chain's <em>own first</em> dot. A chain that
+    /// already starts on its root line has made a wrapping choice further along, and pulling that
+    /// later link back would undo it — so such a chain still answers with its first invoked link and
+    /// keeps today's behavior, including the intermediate-member-access refusal that keeps a fluent
+    /// chain wrapped.
+    /// </para>
+    /// <para>
+    /// A postfix null-forgiving operator is not a chain dot: <c>a!</c> is the chain's root, not its
+    /// first link, so the search skips it and considers the <c>.</c> that follows
+    /// </para>
+    /// </summary>
+    /// <param name="node">The outermost chain node</param>
+    /// <param name="firstInvokedDot">The chain's first invoked link dot, used as the fallback</param>
+    /// <returns>The dot token the collapse should consider</returns>
+    private static SyntaxToken FindFirstWrappedChainOperator(SyntaxNode node,
+                                                             SyntaxToken firstInvokedDot)
+    {
+        if (node is not ExpressionSyntax expression)
         {
-            return LineBreakTriviaUtilities.CollapseTokenToSameLine(node, chainDot);
+            return firstInvokedDot;
         }
 
-        return node;
+        var spineDots = new List<SyntaxToken>();
+
+        ChainWalker.CollectAlignmentDots(expression, spineDots);
+
+        var firstChainDot = spineDots.Find(static dot => dot.Parent is not PostfixUnaryExpressionSyntax);
+
+        if (firstChainDot.IsKind(SyntaxKind.None) == false
+            && LineBreakTriviaUtilities.HasLeadingEndOfLine(firstChainDot))
+        {
+            return firstChainDot;
+        }
+
+        return firstInvokedDot;
+    }
+
+    /// <summary>
+    /// Records the replacements that rejoin a member name onto its own member-access or
+    /// member-binding dot when a line break separates the two (<c>x.</c> ⏎ <c>Name</c>).
+    /// <para>
+    /// That break lives in the dot's <em>trailing</em> trivia, which no chain predicate inspects:
+    /// every other chain decision tests a token's leading trivia, so the split survives untouched and
+    /// the orphaned name is later re-indented to block level. The only existing code that clears the
+    /// slot is <see cref="CollapseChainToSingleLine"/>, which a chain reaches only while
+    /// <see cref="IsCollapsibleChain"/> holds (issue #685).
+    /// </para>
+    /// <para>
+    /// The dot is always immediately followed by its own name token, so the pair being joined is the
+    /// pair the unjoinable-trivia guard inspects. A comment, preprocessor directive, or disabled text
+    /// between the two keeps the split
+    /// </para>
+    /// </summary>
+    /// <param name="node">The outermost chain node</param>
+    /// <param name="replacements">The token replacement map to populate</param>
+    private static void CollectMemberNameRejoinReplacements(SyntaxNode node,
+                                                            Dictionary<SyntaxToken, SyntaxToken> replacements)
+    {
+        if (node is not ExpressionSyntax expression)
+        {
+            return;
+        }
+
+        var operatorTokens = new List<SyntaxToken>();
+        var otherTokens = new List<SyntaxToken>();
+
+        ChainWalker.CollectSpineTokens(expression, operatorTokens, otherTokens);
+
+        foreach (var operatorToken in operatorTokens)
+        {
+            if (operatorToken.Parent is not MemberAccessExpressionSyntax
+                && operatorToken.Parent is not MemberBindingExpressionSyntax)
+            {
+                continue;
+            }
+
+            var nameToken = operatorToken.GetNextToken();
+
+            if (nameToken == default
+                || nameToken.IsKind(SyntaxKind.None)
+                || LineBreakTriviaUtilities.HasLeadingEndOfLine(nameToken) == false
+                || LineBreakTriviaUtilities.WouldJoinAcrossUnjoinableTrivia(operatorToken, nameToken))
+            {
+                continue;
+            }
+
+            replacements[nameToken] = LineBreakTriviaUtilities.RemoveLeadingEndOfLineAndWhitespace(GetPendingToken(nameToken, replacements));
+
+            if (LineBreakTriviaUtilities.HasTrailingEndOfLine(operatorToken))
+            {
+                var pendingOperator = GetPendingToken(operatorToken, replacements);
+
+                replacements[operatorToken] = pendingOperator.WithTrailingTrivia(LineBreakTriviaUtilities.RemoveTrailingEndOfLineTrivia(pendingOperator.TrailingTrivia));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Rejoins split member names on a chain that no other normalization step visits, so the
+    /// <c>x.</c> ⏎ <c>Name</c> split is closed on member-access chains as well as on the invoked
+    /// chains <see cref="NormalizeChain"/> handles (issue #685)
+    /// </summary>
+    /// <param name="node">The outermost chain node</param>
+    /// <returns>The node with split member names rejoined</returns>
+    private static SyntaxNode RejoinSplitMemberNames(SyntaxNode node)
+    {
+        var replacements = new Dictionary<SyntaxToken, SyntaxToken>();
+
+        CollectMemberNameRejoinReplacements(node, replacements);
+
+        if (replacements.Count == 0)
+        {
+            return node;
+        }
+
+        return node.ReplaceTokens(replacements.Keys, (original, _) => replacements[original]);
     }
 
     /// <summary>
@@ -134,13 +263,15 @@ internal sealed class ChainLineBreakRewriter : CSharpSyntaxRewriter
             return;
         }
 
-        replacements[firstDot] = LineBreakTriviaUtilities.RemoveLeadingEndOfLineAndWhitespace(firstDot);
+        replacements[firstDot] = LineBreakTriviaUtilities.RemoveLeadingEndOfLineAndWhitespace(GetPendingToken(firstDot, replacements));
 
         if (previousToken != default
             && previousToken.IsKind(SyntaxKind.None) == false
             && LineBreakTriviaUtilities.HasTrailingEndOfLine(previousToken))
         {
-            replacements[previousToken] = previousToken.WithTrailingTrivia(LineBreakTriviaUtilities.RemoveTrailingEndOfLineTrivia(previousToken.TrailingTrivia));
+            var pendingPrevious = GetPendingToken(previousToken, replacements);
+
+            replacements[previousToken] = pendingPrevious.WithTrailingTrivia(LineBreakTriviaUtilities.RemoveTrailingEndOfLineTrivia(pendingPrevious.TrailingTrivia));
         }
     }
 
@@ -235,7 +366,16 @@ internal sealed class ChainLineBreakRewriter : CSharpSyntaxRewriter
     }
 
     /// <summary>
-    /// Normalizes a method chain or conditional access chain
+    /// Normalizes a method chain or conditional access chain.
+    /// <para>
+    /// Three decisions are made against three different token sets, and keeping them apart is what
+    /// makes the chain converge. The collapse candidate comes from the wider alignment set bounded by
+    /// the first invoked link, so a wrapped non-invoked property access is considered too (issue
+    /// #683). The member-name rejoin walks the spine's trailing trivia, which no other step inspects
+    /// (issue #685). Whether every continuation link must start its own line stays a question about
+    /// the <em>invoked</em> links alone: a chain that only wrapped a non-invoked prefix dot collapses
+    /// back onto one line and must not have breaks inserted into it
+    /// </para>
     /// </summary>
     /// <param name="node">The outermost chain node (invocation or conditional access)</param>
     /// <returns>The node with normalized chain line breaks</returns>
@@ -250,26 +390,28 @@ internal sealed class ChainLineBreakRewriter : CSharpSyntaxRewriter
             return node;
         }
 
-        if (chainDots.Count == 1)
-        {
-            return NormalizeSingleChainDot(node, chainDots[0]);
-        }
+        var firstWrappedDot = FindFirstWrappedChainOperator(node, chainDots[0]);
+        var hasWrappedCandidate = firstWrappedDot.IsKind(SyntaxKind.None) == false;
 
-        if (chainDots.Exists(LineBreakTriviaUtilities.HasLeadingEndOfLine) == false)
-        {
-            return node;
-        }
-
-        if (LineBreakTriviaUtilities.HasLeadingEndOfLine(chainDots[0])
-            && ReihitsuFormatterHelpers.HasCommentDirectlyAbove(chainDots[0]))
+        if (hasWrappedCandidate
+            && ReihitsuFormatterHelpers.HasCommentDirectlyAbove(firstWrappedDot))
         {
             return node;
         }
 
         var replacements = new Dictionary<SyntaxToken, SyntaxToken>();
 
-        TryCollapseFirstChainDot(chainDots[0], replacements);
-        EnsureContinuationDotsStartOnNewLine(chainDots, replacements);
+        CollectMemberNameRejoinReplacements(node, replacements);
+
+        if (hasWrappedCandidate)
+        {
+            TryCollapseFirstChainDot(firstWrappedDot, replacements);
+        }
+
+        if (chainDots.Exists(LineBreakTriviaUtilities.HasLeadingEndOfLine))
+        {
+            EnsureContinuationDotsStartOnNewLine(chainDots, replacements);
+        }
 
         if (replacements.Count == 0)
         {
@@ -296,8 +438,10 @@ internal sealed class ChainLineBreakRewriter : CSharpSyntaxRewriter
                 continue;
             }
 
-            var newLeading = chainDots[dotIndex].LeadingTrivia.Insert(0, endOfLine);
-            replacements[chainDots[dotIndex]] = chainDots[dotIndex].WithLeadingTrivia(newLeading);
+            var pendingDot = GetPendingToken(chainDots[dotIndex], replacements);
+            var newLeading = pendingDot.LeadingTrivia.Insert(0, endOfLine);
+
+            replacements[chainDots[dotIndex]] = pendingDot.WithLeadingTrivia(newLeading);
 
             var previousToken = chainDots[dotIndex].GetPreviousToken();
 
@@ -372,9 +516,11 @@ internal sealed class ChainLineBreakRewriter : CSharpSyntaxRewriter
         {
             node = (ConditionalAccessExpressionSyntax)NormalizeChain(node);
             node = CollapseMemberBindingToQuestionToken(node);
+
+            return node;
         }
 
-        return node;
+        return RejoinSplitMemberNames(node);
     }
 
     /// <inheritdoc/>
@@ -391,12 +537,17 @@ internal sealed class ChainLineBreakRewriter : CSharpSyntaxRewriter
             return null;
         }
 
-        if (isOutermost && IsCollapsibleChain(node))
+        if (isOutermost == false)
+        {
+            return node;
+        }
+
+        if (IsCollapsibleChain(node))
         {
             return CollapseChainToSingleLine(node);
         }
 
-        return node;
+        return RejoinSplitMemberNames(node);
     }
 
     #endregion // CSharpSyntaxVisitor

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/Utilities/ChainWalker.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/Utilities/ChainWalker.cs
@@ -9,10 +9,13 @@ namespace Reihitsu.Formatter.Pipeline.LineBreaks.Utilities;
 
 /// <summary>
 /// Centralizes traversal of method-chain and conditional-access expressions. It collects chain
-/// tokens (invoked-link dots for the line-break side, every member-access/conditional-access/postfix
-/// operator for the alignment side, and the full spine for chain rejoining) and answers chain-shape
-/// queries such as outermost-node detection, spine invocation count, multi-line argument detection,
-/// and intermediate member access
+/// tokens in three widening sets — invoked-link dots, every member-access/conditional-access/postfix
+/// operator, and the full spine including member names — and answers chain-shape queries such as
+/// outermost-node detection, spine invocation count, multi-line argument detection, and intermediate
+/// member access.
+/// The sets are chosen per decision rather than per phase: the line-break and indentation phases both
+/// read the operator set, so that the dot a chain is collapsed at and the dot it is aligned to are
+/// the same token (issue #683)
 /// </summary>
 internal static class ChainWalker
 {
@@ -78,10 +81,12 @@ internal static class ChainWalker
     }
 
     /// <summary>
-    /// Recursively collects all dot operator tokens from a chain expression for alignment.
+    /// Recursively collects every dot operator token from a chain expression, invoked or not.
     /// For conditional access, the <c>?</c> token from the <see cref="ConditionalAccessExpressionSyntax"/>
     /// is collected instead of the <c>.</c> from the <see cref="MemberBindingExpressionSyntax"/>,
-    /// because the <c>?</c> is the first token on a continuation line
+    /// because the <c>?</c> is the first token on a continuation line.
+    /// The indentation phase aligns continuation dots against this set, and the line-break phase picks
+    /// its collapse candidate from it, so both decisions are made about the same tokens (issue #683)
     /// </summary>
     /// <param name="expr">The expression to walk</param>
     /// <param name="dots">The list to accumulate dot tokens into</param>


### PR DESCRIPTION
## Summary

Brings three formatter chain decisions back in line with the column `RH5201MethodChainsShouldBeAlignedAnalyzer` computes:

- **#683** — `ChainLineBreakRewriter` decided the first-link collapse from `CollectInvokedLinkDots`, which reports invoked links only. A chain whose own first dot is a plain, non-invoked property access was never offered that dot, so it stayed split at a boundary no predicate tested. The collapse now takes the chain's own first dot from the wider alignment set when the chain wraps there, and otherwise keeps using the first invoked link exactly as before.
- **#684** — `MethodChainAlignmentContributor.GetChainAnchorColumn` rebased the anchor onto the creation expression's `new` keyword. That is only valid when the initializer's closing brace lands at that keyword's column, which happens exactly when the brace starts its own line — the same condition `ObjectInitializerContributor` uses before it moves the brace there. The correction now tests `IsFirstOnLine(prevToken)`.
- **#685 (partial)** — a line break in a chain dot's *trailing* trivia (`x.` ⏎ `Name`) was inspected by no chain predicate, so the split survived and the orphaned name was re-indented to block level. Such a name is now rejoined onto its own dot, unless a comment, directive, or disabled text sits between them.

`GetPendingToken` was added so the three normalization steps compose through one replacement map instead of the last writer discarding an earlier edit.

## Why

All three made `reihitsu-format` disagree with `RH5201`. #683 produced a stable format→fix→format oscillation the code fix could not resolve; #684 misaligned by roughly the initializer's printed width; #685 additionally inserted a break the input never had.

## Linked issues

Closes #683
Closes #684
Refs #685

## Review notes

- **#685 is linked as `Refs`, not `Closes`, on purpose.** Both scenarios that issue reports are fixed and covered by tests, but its defect class is not fully closed: the rejoin is skipped whenever the chain's *first invoked link* carries a comment directly above it, because the pre-existing whole-chain bail runs first. In that case `x.` ⏎ `Name` still survives even though no trivia sits between the dot and its name. Filed as follow-up rather than fixed here — widening that bail was tried during this work and regressed RH5201 parity, so it needs its own analysis.
- **#685's target shape was undecided in the issue.** Expected outputs are derived from the chain's reference column, not invented; the initializer-rooted result is byte-identical to what the repository already asserts for the same chain written with its initializer on one line.
- **Three existing tests change their assertions.** `WrappedFirstChainDotKeepsCurrentAlignment` (now `…CollapsesOntoChainRoot`) and `ConditionalAccessAnchorOnLaterLineThanInitializerCloseBraceStaysIdempotent` characterized the broken output; `LayoutComputerTests.ComputeHandlesLinqExpression` asserted a chain anchor of column 0, which was #684 at unit level.
- **The PR #681 guard keeps a fixture.** That test covered `GetChainAnchorColumn`'s unequal-line branch, and the trailing-dot split was its only input. It now uses a comment between the dot and its name, which blocks the rejoin and still reaches that branch; verified by construction.
- **#683's fix covers chains with a single invoked link** (`a` ⏎ `.Prop` ⏎ `.Select(…)` → `a.Prop` ⏎ `.Select(…)`), decided explicitly. The keep-wrapped rule is unaffected: `a.Prop` ⏎ `.Select(…)` remains a fixed point, because its first dot carries no line break.
- **Known divergence, characterized not fixed.** A multi-line array initializer whose closing brace shares its line with an element (`new int[] { 1,` ⏎ `2 }.Select(…)`) is still not RH5201-clean. The correction correctly no longer applies, but the fallback reads that line's layout before `ObjectInitializerContributor` rebases it — a contributor-ordering defect, distinct from all three issues and present on `main`. `MultiLineArrayInitializerWithTrailingCloseBraceKeepsKnownDivergence` pins the current output; its column moved from 17 to 11, both wrong.
- Unchanged by design: the RH5201 analyzer, its code fix, `documentation/rules/RH5201.md`, `FluentChainUtilities.GetInvokedLinkOperator`, `ObjectInitializerContributor`, and `IsCollapsibleChain`'s composition.

## Follow-up work

- Chain anchor fallback reads a layout entry that a later contributor overwrites (the ordering defect above).
- The whole-chain comment bail suppresses #685's member-name rejoin.
- The same bail leaves later links sharing a line, so a commented chain stays RH5201-dirty (pre-existing).
- A chain rooted in a parenthesized `with` expression misaligns both its closing brace and its continuation dot.
