### PR TITLE
Close the chain comment bail and stale anchor column defects

### DIFF
--- a/Reihitsu.Analyzer.Test/Formatting/RH5201MethodChainsShouldBeAlignedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH5201MethodChainsShouldBeAlignedAnalyzerTests.cs
@@ -1,10 +1,15 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Reihitsu.Analyzer.CodeFixes.Rules.Layout;
 using Reihitsu.Analyzer.Rules.Layout;
 using Reihitsu.Analyzer.Test.Base;
+using Reihitsu.Formatter.Data;
+using Reihitsu.Formatter.Pipeline;
 
 namespace Reihitsu.Analyzer.Test.Formatting;
 
@@ -678,6 +683,53 @@ public class RH5201MethodChainsShouldBeAlignedAnalyzerTests : AnalyzerTestsBase<
                                 """;
 
         await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies issue #690's reported input: a method chain rooted in a parenthesized <c>with</c>
+    /// expression. The formatter's own output for this input (produced directly through
+    /// <see cref="FormattingPipeline"/>, the same engine <c>reihitsu-format</c> uses) is fed to the
+    /// analyzer as-is, and it reports the diagnostic on the continuation dot — the formatter's own
+    /// output is not RH5201-clean for this shape
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFormatterOutputForChainRootedInParenthesizedWithExpressionReportsDiagnostic()
+    {
+        const string rawInput = """
+                                class C
+                                {
+                                    void M(Record r)
+                                    {
+                                        var x = (r with
+                                        {
+                                            Value = 1
+                                        }).Select(item => item)
+                                           .ToList();
+                                    }
+                                }
+                                """;
+
+        var formatted = FormatWithLineFeed(rawInput);
+
+        await Verify(formatted,
+                     test => test.CompilerDiagnostics = CompilerDiagnostics.None,
+                     Diagnostic(RH5201MethodChainsShouldBeAlignedAnalyzer.DiagnosticId).WithSpan(9, 11, 9, 12)
+                                                                                       .WithMessage(AnalyzerResources.RH5201MessageFormat));
+    }
+
+    /// <summary>
+    /// Formats the given source text through the shared formatting pipeline with LF line endings,
+    /// the same engine <c>reihitsu-format</c> uses, without going through the CLI
+    /// </summary>
+    /// <param name="rawInput">The source text to format</param>
+    /// <returns>The formatted source text</returns>
+    private static string FormatWithLineFeed(string rawInput)
+    {
+        var tree = CSharpSyntaxTree.ParseText(rawInput);
+        var context = new FormattingContext("\n");
+
+        return FormattingPipeline.Execute(tree.GetRoot(), context, CancellationToken.None).ToFullString();
     }
 
     #endregion // Tests

--- a/Reihitsu.Analyzer.Test/Formatting/RH5201MethodChainsShouldBeAlignedAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH5201MethodChainsShouldBeAlignedAnalyzerTests.cs
@@ -686,15 +686,15 @@ public class RH5201MethodChainsShouldBeAlignedAnalyzerTests : AnalyzerTestsBase<
     }
 
     /// <summary>
-    /// Verifies issue #690's reported input: a method chain rooted in a parenthesized <c>with</c>
-    /// expression. The formatter's own output for this input (produced directly through
-    /// <see cref="FormattingPipeline"/>, the same engine <c>reihitsu-format</c> uses) is fed to the
-    /// analyzer as-is, and it reports the diagnostic on the continuation dot — the formatter's own
-    /// output is not RH5201-clean for this shape
+    /// Verifies that the formatter's own output for a method chain rooted in a parenthesized
+    /// <c>with</c> expression is RH5201-clean. The output is produced directly through
+    /// <see cref="FormattingPipeline"/> — the same engine <c>reihitsu-format</c> uses — and fed to the
+    /// analyzer as-is, so the two surfaces are checked against each other rather than against a
+    /// hand-written expectation
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
     [TestMethod]
-    public async Task VerifyFormatterOutputForChainRootedInParenthesizedWithExpressionReportsDiagnostic()
+    public async Task VerifyFormatterOutputForChainRootedInParenthesizedWithExpressionIsClean()
     {
         const string rawInput = """
                                 class C
@@ -712,10 +712,7 @@ public class RH5201MethodChainsShouldBeAlignedAnalyzerTests : AnalyzerTestsBase<
 
         var formatted = FormatWithLineFeed(rawInput);
 
-        await Verify(formatted,
-                     test => test.CompilerDiagnostics = CompilerDiagnostics.None,
-                     Diagnostic(RH5201MethodChainsShouldBeAlignedAnalyzer.DiagnosticId).WithSpan(9, 11, 9, 12)
-                                                                                       .WithMessage(AnalyzerResources.RH5201MessageFormat));
+        await Verify(formatted, test => test.CompilerDiagnostics = CompilerDiagnostics.None);
     }
 
     /// <summary>

--- a/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
@@ -2286,6 +2286,250 @@ public class MethodChainAlignmentTests : FormatterTestsBase
     }
 
     /// <summary>
+    /// Verify that a comment above a conditional-access first invoked link keeps the chain wrapped
+    /// while every invoked link still starts its own line
+    /// </summary>
+    [TestMethod]
+    public void CommentAboveConditionalAccessChainRootKeepsEveryInvokedLinkOnItsOwnLine()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                                         // keep wrapped
+                                         ?.Foo()
+                                         .Bar().Baz();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a
+
+                                                // keep wrapped
+                                                ?.Foo()
+                                                .Bar()
+                                                .Baz();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verify that a non-invoked prefix dot on the chain root line keeps the anchor column while the
+    /// invoked links are broken onto their own lines
+    /// </summary>
+    [TestMethod]
+    public void CommentAboveChainWithPrefixDotOnRootLineBreaksLinksAtAnchorColumn()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a.Prop
+                                         // keep wrapped
+                                         .Foo()
+                                         .Bar().Baz();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a.Prop
+
+                                                 // keep wrapped
+                                                 .Foo()
+                                                 .Bar()
+                                                 .Baz();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verify that a conditional-access prefix whose binding is not invoked still breaks every
+    /// following invoked link onto its own line
+    /// </summary>
+    [TestMethod]
+    public void CommentAboveChainWithNonInvokedConditionalPrefixBreaksEveryInvokedLink()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                                         // keep wrapped
+                                         ?.Prop.Foo()
+                                         .Bar().Baz();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a
+
+                                                // keep wrapped
+                                                ?.Prop
+                                                .Foo()
+                                                .Bar()
+                                                .Baz();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verify that a comment above the first invoked link still suppresses the collapse of a
+    /// separately wrapped non-invoked prefix dot
+    /// </summary>
+    [TestMethod]
+    public void CommentAboveFirstInvokedLinkKeepsWrappedPrefixDotUncollapsed()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                                         .Prop
+                                         // keep wrapped
+                                         .Foo()
+                                         .Bar();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a
+                                        .Prop
+
+                                        // keep wrapped
+                                        .Foo()
+                                        .Bar();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verify that a pragma directive above the first invoked link leaves every invoked link on its
+    /// own line
+    /// </summary>
+    [TestMethod]
+    public void PragmaAboveFirstInvokedLinkKeepsEveryInvokedLinkOnItsOwnLine()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                             #pragma warning disable 1234
+                                         .Foo()
+                                         .Bar().Baz();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a
+                                #pragma warning disable 1234
+                                                .Foo()
+                                                .Bar()
+                                                .Baz();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verify that disabled text above the first invoked link leaves every invoked link on its own
+    /// line
+    /// </summary>
+    [TestMethod]
+    public void DisabledTextAboveFirstInvokedLinkKeepsEveryInvokedLinkOnItsOwnLine()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                             #if false
+                                     .Nope()
+                             #endif
+                                         .Foo()
+                                         .Bar().Baz();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a
+                                #if false
+                                        .Nope()
+                                #endif
+                                                .Foo()
+                                                .Bar()
+                                                .Baz();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
     /// Verify that a wrapped null-conditional chain whose continuations sit on the chain-root dot is
     /// realigned to the first invoked link
     /// </summary>

--- a/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
@@ -2177,6 +2177,212 @@ public class MethodChainAlignmentTests : FormatterTestsBase
     }
 
     /// <summary>
+    /// Verify that an argument list nested under a chain continuation line is aligned against the
+    /// chain's final column rather than the column the chain held before its anchor was resolved
+    /// </summary>
+    [TestMethod]
+    public void ArgumentListUnderChainContinuationLineFollowsTheResolvedChainColumn()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = new int[] { 1,
+                                         2 }.Select(item => item)
+                                            .Where(alpha,
+                                                beta)
+                                            .ToList();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = new int[] { 1,
+                                                    2 }.Select(item => item)
+                                                       .Where(alpha,
+                                                              beta)
+                                                       .ToList();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verify that an argument list nested under the continuation line of a chain rooted in a
+    /// parenthesized <c>with</c> expression follows the chain's resolved column
+    /// </summary>
+    [TestMethod]
+    public void ArgumentListUnderWithExpressionChainContinuationFollowsTheResolvedChainColumn()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M(Record r)
+                                 {
+                                     var x = (r with
+                                     {
+                                         Value = 1
+                                     }).Select(item => item)
+                                        .Where(alpha,
+                                            beta)
+                                        .ToList();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M(Record r)
+                                    {
+                                        var x = (r with
+                                                   {
+                                                       Value = 1
+                                                   }).Select(item => item)
+                                                     .Where(alpha,
+                                                            beta)
+                                                     .ToList();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verify that a statement lambda nested under a chain continuation line follows the chain's
+    /// resolved column
+    /// </summary>
+    [TestMethod]
+    public void StatementLambdaUnderChainContinuationLineFollowsTheResolvedChainColumn()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = new int[] { 1,
+                                         2 }.Select(item =>
+                                             {
+                                                 return item;
+                                             })
+                                            .ToList();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = new int[] { 1,
+                                                    2 }.Select(item =>
+                                                               {
+                                                                   return item;
+                                                               })
+                                                       .ToList();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verify that a ternary nested under a chain continuation line follows the chain's resolved
+    /// column
+    /// </summary>
+    [TestMethod]
+    public void TernaryUnderChainContinuationLineFollowsTheResolvedChainColumn()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = new int[] { 1,
+                                         2 }.Select(flag
+                                                 ? one
+                                                 : two)
+                                            .ToList();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = new int[] { 1,
+                                                    2 }.Select(flag
+                                                                   ? one
+                                                                   : two)
+                                                       .ToList();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verify that a directive above the first invoked link leaves the collapse of a wrapped prefix
+    /// dot enabled, unlike the comment arm. The line-break phase's exemption is deliberately
+    /// comment-only; this test pins the directive side of that decision so it cannot drift silently
+    /// </summary>
+    [TestMethod]
+    public void DirectiveAboveFirstInvokedLinkStillCollapsesWrappedPrefixDot()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                                         .Prop
+                             #pragma warning disable 1234
+                                         .Foo()
+                                         .Bar();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a.Prop
+                                #pragma warning disable 1234
+                                                 .Foo()
+                                                 .Bar();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
     /// Verify that a chain rooted in a multi-line array initializer whose closing brace shares its
     /// line with an element aligns its continuation dot to the first invoked link. The initializer
     /// correction does not apply here (the brace is not first on its line), so the anchor falls back

--- a/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
@@ -2222,5 +2222,68 @@ public class MethodChainAlignmentTests : FormatterTestsBase
         AssertRuleResult(input, expected);
     }
 
+    /// <summary>
+    /// Verifies issue #687's reported input: a null-conditional chain whose continuation dots are
+    /// already aligned to the first invoked link (<c>?.FirstOrDefault()</c>) stays unchanged, rather
+    /// than having its continuation indentation reduced
+    /// </summary>
+    [TestMethod]
+    public void NullConditionalChainAlreadyAlignedToFirstInvokedLinkStaysUnchanged()
+    {
+        // Arrange
+        const string input = """
+                             var filePath = metadata.Media?.FirstOrDefault()
+                                                          ?.Part
+                                                          ?.FirstOrDefault()
+                                                          ?.File;
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies issue #689's reported input: a comment above the chain's own first dot keeps the
+    /// chain wrapped, and every remaining invoked link still starts its own line — the arrangement
+    /// <c>RH5201MethodChainsShouldBeAlignedAnalyzer</c> requires. Today the trailing <c>.Bar().Baz()</c>
+    /// stays merged on one line because the same whole-chain bail that keeps the comment's chain
+    /// wrapped also suppresses the continuation-dot line breaks
+    /// </summary>
+    [TestMethod]
+    public void CommentAboveChainRootKeepsEveryInvokedLinkOnItsOwnLine()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                                         // keep wrapped
+                                         .Foo()
+                                         .Bar().Baz();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a
+
+                                                // keep wrapped
+                                                .Foo()
+                                                .Bar()
+                                                .Baz();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
     #endregion // Methods
 }

--- a/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
@@ -2285,5 +2285,108 @@ public class MethodChainAlignmentTests : FormatterTestsBase
         AssertRuleResult(input, expected);
     }
 
+    /// <summary>
+    /// Verify that a wrapped null-conditional chain whose continuations sit on the chain-root dot is
+    /// realigned to the first invoked link
+    /// </summary>
+    [TestMethod]
+    public void NullConditionalChainMisalignedToChainRootDotIsRealignedToInvokedLink()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M(object metadata)
+                                 {
+                                     var filePath = metadata.Media?.FirstOrDefault()
+                                                    ?.Part
+                                                    ?.FirstOrDefault()
+                                                    ?.File;
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M(object metadata)
+                                    {
+                                        var filePath = metadata.Media?.FirstOrDefault()
+                                                                     ?.Part
+                                                                     ?.FirstOrDefault()
+                                                                     ?.File;
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verify that a top-level null-conditional chain misaligned to the chain-root dot is realigned to
+    /// the first invoked link
+    /// </summary>
+    [TestMethod]
+    public void TopLevelNullConditionalChainMisalignedToChainRootDotIsRealignedToInvokedLink()
+    {
+        // Arrange
+        const string input = """
+                             var filePath = metadata.Media?.FirstOrDefault()
+                                            ?.Part
+                                            ?.FirstOrDefault()
+                                            ?.File;
+                             """;
+
+        const string expected = """
+                                var filePath = metadata.Media?.FirstOrDefault()
+                                                             ?.Part
+                                                             ?.FirstOrDefault()
+                                                             ?.File;
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verify that a null-conditional chain whose root is split across lines rejoins the non-invoked
+    /// first dot onto its root and aligns the continuations to the first invoked link
+    /// </summary>
+    [TestMethod]
+    public void NullConditionalChainWithSplitRootRejoinsAndAlignsToInvokedLink()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M(object metadata)
+                                 {
+                                     var filePath = metadata
+                                                    .Media?.FirstOrDefault()
+                                                          ?.Part
+                                                          ?.FirstOrDefault()
+                                                          ?.File;
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M(object metadata)
+                                    {
+                                        var filePath = metadata.Media?.FirstOrDefault()
+                                                                     ?.Part
+                                                                     ?.FirstOrDefault()
+                                                                     ?.File;
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
     #endregion // Methods
 }

--- a/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
@@ -2177,21 +2177,17 @@ public class MethodChainAlignmentTests : FormatterTestsBase
     }
 
     /// <summary>
-    /// Characterizes a shape that issues #683, #684 and #685 do <b>not</b> fix: a multi-line array
-    /// initializer whose closing brace shares its line with an element. The initializer correction
-    /// correctly no longer applies (the brace is not first on its line), but the fallback reads the
-    /// brace line's layout before <c>ObjectInitializerContributor</c> rebases it, so the continuation
-    /// dot still diverges from the column RH5201 computes. That contributor-ordering defect is a
-    /// separate mechanism, tracked as follow-up work; this test exists so the shape cannot drift
-    /// silently while it is open.
+    /// Verify that a chain rooted in a multi-line array initializer whose closing brace shares its
+    /// line with an element aligns its continuation dot to the first invoked link. The initializer
+    /// correction does not apply here (the brace is not first on its line), so the anchor falls back
+    /// to the adjusted-column lookup — which is resolved after the initializer has claimed its own
+    /// line, rather than against that line's block indentation.
     /// <para>
-    /// The expected output is a <b>changed</b> baseline, not a preserved one: before issue #684's fix
-    /// the continuation dot sat at column 17, and it now sits at column 11. Both diverge from the
-    /// column RH5201 computes for this shape, so neither is correct
+    /// The initializer's own layout is deliberately left untouched: only the continuation dot moves
     /// </para>
     /// </summary>
     [TestMethod]
-    public void MultiLineArrayInitializerWithTrailingCloseBraceKeepsKnownDivergence()
+    public void MultiLineArrayInitializerWithTrailingCloseBraceAlignsToInvokedLink()
     {
         // Arrange
         const string input = """
@@ -2213,7 +2209,7 @@ public class MethodChainAlignmentTests : FormatterTestsBase
                                     {
                                         var x = new int[] { 1,
                                                     2 }.Select(item => item)
-                                           .ToList();
+                                                       .ToList();
                                     }
                                 }
                                 """;
@@ -2277,6 +2273,278 @@ public class MethodChainAlignmentTests : FormatterTestsBase
                                                 .Foo()
                                                 .Bar()
                                                 .Baz();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verify that a chain rooted in a multi-line implicit array initializer whose closing brace
+    /// shares its line with an element aligns its continuation dot to the first invoked link
+    /// </summary>
+    [TestMethod]
+    public void MultiLineImplicitArrayInitializerWithTrailingCloseBraceAlignsToInvokedLink()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = new[] { 1,
+                                         2 }.Select(item => item)
+                                        .ToList();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = new[] { 1,
+                                                    2 }.Select(item => item)
+                                                       .ToList();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verify that a chain rooted in a parenthesized <c>with</c> expression aligns its continuation
+    /// dot to the first invoked link while the initializer braces stay on the <c>with</c> keyword
+    /// </summary>
+    [TestMethod]
+    public void ChainRootedInParenthesizedWithExpressionAlignsToInvokedLink()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M(Record r)
+                                 {
+                                     var x = (r with
+                                     {
+                                         Value = 1
+                                     }).Select(item => item)
+                                        .ToList();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M(Record r)
+                                    {
+                                        var x = (r with
+                                                   {
+                                                       Value = 1
+                                                   }).Select(item => item)
+                                                     .ToList();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verify that a chain rooted in a parenthesized object creation aligns its continuation dot to
+    /// the first invoked link
+    /// </summary>
+    [TestMethod]
+    public void ChainRootedInParenthesizedObjectCreationAlignsToInvokedLink()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = (new Wrapper
+                                     {
+                                         Value = 1
+                                     }).Select(item => item)
+                                        .ToList();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = (new Wrapper
+                                                 {
+                                                     Value = 1
+                                                 }).Select(item => item)
+                                                   .ToList();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verify that a chain rooted in a parenthesized array creation whose closing brace shares its
+    /// line with an element aligns its continuation dot to the first invoked link
+    /// </summary>
+    [TestMethod]
+    public void ChainRootedInParenthesizedArrayCreationAlignsToInvokedLink()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = (new int[] { 1,
+                                         2 }).Select(item => item)
+                                        .ToList();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = (new int[] { 1,
+                                                     2 }).Select(item => item)
+                                                         .ToList();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verify that a chain rooted in a collection expression aligns its continuation dot to the first
+    /// invoked link
+    /// </summary>
+    [TestMethod]
+    public void ChainRootedInCollectionExpressionAlignsToInvokedLink()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = [1,
+                                         2 ].Select(item => item)
+                                        .ToList();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = [
+                                                    1,
+                                                    2
+                                                ].Select(item => item)
+                                                 .ToList();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verify that a chain rooted in an anonymous object creation aligns its continuation dot to the
+    /// first invoked link
+    /// </summary>
+    [TestMethod]
+    public void ChainRootedInAnonymousObjectAlignsToInvokedLink()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = new
+                                     {
+                                         Value = 1
+                                     }.ToString()
+                                      .Trim();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = new
+                                                {
+                                                    Value = 1
+                                                }.ToString()
+                                                 .Trim();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verify that a chain rooted in a parenthesized switch expression aligns its continuation dot to
+    /// the first invoked link
+    /// </summary>
+    [TestMethod]
+    public void ChainRootedInParenthesizedSwitchExpressionAlignsToInvokedLink()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M(int i)
+                                 {
+                                     var x = (i switch
+                                     {
+                                         1 => "a",
+                                         _ => "b"
+                                     }).Select(item => item)
+                                        .ToList();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M(int i)
+                                    {
+                                        var x = (i switch
+                                                 {
+                                                     1 => "a",
+                                                     _ => "b"
+                                                 }).Select(item => item)
+                                                   .ToList();
                                     }
                                 }
                                 """;

--- a/Reihitsu.Formatter.Test/Regression/LineBreaks/ChainSplitMemberNameRejoinTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/LineBreaks/ChainSplitMemberNameRejoinTests.cs
@@ -357,5 +357,47 @@ public class ChainSplitMemberNameRejoinTests : FormatterTestsBase
         AssertRuleResult(input, expected);
     }
 
+    /// <summary>
+    /// Verifies the remaining arm from issue #685's follow-up comment: a chain whose first invoked
+    /// link dot carries a comment directly above it must still rejoin a split member name elsewhere
+    /// in the chain. The comment sits above <c>.Foo()</c>, nowhere near the <c>.Bar()</c> split, but
+    /// the whole-chain bail for a commented first invoked link runs before the rejoin today
+    /// </summary>
+    [TestMethod]
+    public void CommentAboveFirstInvokedLinkDotStillRejoinsLaterSplitMemberName()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                                         // keep wrapped
+                                         .Foo().
+                                         Bar()
+                                         .Baz();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a
+
+                                                // keep wrapped
+                                                .Foo().Bar()
+                                                .Baz();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
     #endregion // Methods
 }

--- a/Reihitsu.Formatter.Test/Regression/LineBreaks/ChainSplitMemberNameRejoinTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/LineBreaks/ChainSplitMemberNameRejoinTests.cs
@@ -389,7 +389,90 @@ public class ChainSplitMemberNameRejoinTests : FormatterTestsBase
                                         var x = a
 
                                                 // keep wrapped
-                                                .Foo().Bar()
+                                                .Foo()
+                                                .Bar()
+                                                .Baz();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verify that a documentation comment above the first invoked link does not suppress the split
+    /// member name rejoin
+    /// </summary>
+    [TestMethod]
+    public void DocumentationCommentAboveFirstInvokedLinkDotStillRejoinsSplitMemberName()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                                         /// keep wrapped
+                                         .Foo().
+                                         Bar()
+                                         .Baz();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a
+
+                                                /// keep wrapped
+                                                .Foo()
+                                                .Bar()
+                                                .Baz();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verify that a block comment on its own line above the first invoked link does not suppress the
+    /// split member name rejoin
+    /// </summary>
+    [TestMethod]
+    public void BlockCommentAboveFirstInvokedLinkDotStillRejoinsSplitMemberName()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                                         /* keep wrapped */
+                                         .Foo().
+                                         Bar()
+                                         .Baz();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a
+
+                                                /* keep wrapped */
+                                                .Foo()
+                                                .Bar()
                                                 .Baz();
                                     }
                                 }

--- a/Reihitsu.Formatter.Test/Unit/Indentation/LayoutModelTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/Indentation/LayoutModelTests.cs
@@ -228,5 +228,134 @@ public class LayoutModelTests
         Assert.AreEqual(0, model.Count);
     }
 
+    /// <summary>
+    /// Verifies that <see cref="LayoutModel.MatchesColumns"/> reports a match when nothing changed
+    /// since the snapshot was captured
+    /// </summary>
+    [TestMethod]
+    public void MatchesColumnsForUnchangedModelReturnsTrue()
+    {
+        // Arrange
+        var model = new LayoutModel();
+
+        model.Set(1, new TokenLayout(4, "block"));
+        model.Set(2, new TokenLayout(8, "chain"));
+
+        // Act
+        var columns = model.CaptureColumns();
+
+        // Assert
+        Assert.IsTrue(model.MatchesColumns(columns));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="LayoutModel.MatchesColumns"/> reports a mismatch when an existing
+    /// entry is moved to a different column. This is the observation that keeps the alignment sweep
+    /// running for another pass
+    /// </summary>
+    [TestMethod]
+    public void MatchesColumnsAfterColumnChangeReturnsFalse()
+    {
+        // Arrange
+        var model = new LayoutModel();
+
+        model.Set(1, new TokenLayout(4, "block"));
+
+        var columns = model.CaptureColumns();
+
+        // Act
+        model.Set(1, new TokenLayout(12, "chain"));
+
+        // Assert
+        Assert.IsFalse(model.MatchesColumns(columns));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="LayoutModel.MatchesColumns"/> reports a mismatch when a line gains
+    /// an entry it did not have when the snapshot was captured
+    /// </summary>
+    [TestMethod]
+    public void MatchesColumnsAfterEntryAddedReturnsFalse()
+    {
+        // Arrange
+        var model = new LayoutModel();
+
+        model.Set(1, new TokenLayout(4, "block"));
+
+        var columns = model.CaptureColumns();
+
+        // Act
+        model.Set(2, new TokenLayout(4, "block"));
+
+        // Assert
+        Assert.IsFalse(model.MatchesColumns(columns));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="LayoutModel.MatchesColumns"/> ignores the
+    /// <see cref="TokenLayout.Source"/> label, so a sweep in which one contributor merely takes
+    /// ownership of a column another already set still counts as settled
+    /// </summary>
+    [TestMethod]
+    public void MatchesColumnsIgnoresSourceLabelChange()
+    {
+        // Arrange
+        var model = new LayoutModel();
+
+        model.Set(1, new TokenLayout(4, "block"));
+
+        var columns = model.CaptureColumns();
+
+        // Act
+        model.Set(1, new TokenLayout(4, "chain"));
+
+        // Assert
+        Assert.IsTrue(model.MatchesColumns(columns));
+    }
+
+    /// <summary>
+    /// Verifies that a snapshot taken from <see cref="LayoutModel.CaptureColumns"/> is detached from
+    /// the model, so a later mutation cannot retroactively change what the snapshot recorded
+    /// </summary>
+    [TestMethod]
+    public void CaptureColumnsSnapshotIsDetachedFromTheModel()
+    {
+        // Arrange
+        var model = new LayoutModel();
+
+        model.Set(1, new TokenLayout(4, "block"));
+
+        // Act
+        var columns = model.CaptureColumns();
+
+        model.Set(1, new TokenLayout(20, "chain"));
+
+        // Assert
+        Assert.AreEqual(4, columns[1]);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="LayoutModel.MatchesColumns"/> reports a mismatch after
+    /// <see cref="LayoutModel.ShiftRange"/> moves entries, since a shift is the one mutation that
+    /// derives a new column from the current one
+    /// </summary>
+    [TestMethod]
+    public void MatchesColumnsAfterShiftRangeReturnsFalse()
+    {
+        // Arrange
+        var model = new LayoutModel();
+
+        model.Set(1, new TokenLayout(4, "block"));
+        model.Set(2, new TokenLayout(8, "block"));
+
+        var columns = model.CaptureColumns();
+
+        // Act
+        model.ShiftRange(1, 2, 6, "shift");
+
+        // Assert
+        Assert.IsFalse(model.MatchesColumns(columns));
+    }
+
     #endregion // Methods
 }

--- a/Reihitsu.Formatter/Pipeline/Indentation/Utilities/LayoutComputer.cs
+++ b/Reihitsu.Formatter/Pipeline/Indentation/Utilities/LayoutComputer.cs
@@ -44,7 +44,13 @@ internal static class LayoutComputer
         // every other contributor has written its entries. A chain anchored on a line that a
         // construct nested inside the chain root owns (a multi-line initializer closed by "2 }", a
         // parenthesized initializer or switch expression) would otherwise be measured against that
-        // line's pass-1 block indentation, which the owning contributor overwrites above
+        // line's pass-1 block indentation, which the owning contributor overwrites above.
+        // The contributor deliberately stays registered in pass 2 as well, and the repetition is
+        // load-bearing rather than redundant: pass 2 keeps the chain's entries in their established
+        // priority order against the contributors that follow it, while this pass only corrects the
+        // anchor column those entries were measured from. Dropping either one changes layout —
+        // removing the pass-2 registration regresses the chain/argument and chain/initializer
+        // priority on shared lines
         var chainContributor = new MethodChainAlignmentContributor();
 
         foreach (var node in root.DescendantNodesAndSelf())

--- a/Reihitsu.Formatter/Pipeline/Indentation/Utilities/LayoutComputer.cs
+++ b/Reihitsu.Formatter/Pipeline/Indentation/Utilities/LayoutComputer.cs
@@ -17,10 +17,13 @@ internal static class LayoutComputer
     #region Constants
 
     /// <summary>
-    /// Upper bound on the alignment sweeps in pass 2. The sweep normally settles on the second one —
+    /// Upper bound on the alignment sweeps in pass 2. The corrective sweeps settle by the second —
     /// the first resolves every anchor whose own line is already final, the second the anchors that
-    /// depended on those. The bound only guards against a cycle between two contributors that would
-    /// otherwise spin; reaching it leaves the last computed state, which is still deterministic
+    /// depended on those — and a further sweep then observes no change and stops the loop, so the
+    /// shapes this bound exists for run three times. Measured maxima: repository sources two sweeps,
+    /// the repository's own test fixtures three, generated adversarial nesting four. The bound only
+    /// guards against a cycle between two contributors that would otherwise spin; reaching it leaves
+    /// the last computed state, which is still deterministic
     /// </summary>
     private const int MaxAlignmentPasses = 8;
 

--- a/Reihitsu.Formatter/Pipeline/Indentation/Utilities/LayoutComputer.cs
+++ b/Reihitsu.Formatter/Pipeline/Indentation/Utilities/LayoutComputer.cs
@@ -40,6 +40,18 @@ internal static class LayoutComputer
             }
         }
 
+        // Pass 2b: Chain alignment — re-resolve the continuation columns of method chains now that
+        // every other contributor has written its entries. A chain anchored on a line that a
+        // construct nested inside the chain root owns (a multi-line initializer closed by "2 }", a
+        // parenthesized initializer or switch expression) would otherwise be measured against that
+        // line's pass-1 block indentation, which the owning contributor overwrites above
+        var chainContributor = new MethodChainAlignmentContributor();
+
+        foreach (var node in root.DescendantNodesAndSelf())
+        {
+            chainContributor.Contribute(node, model, context);
+        }
+
         // Pass 3: Comment alignment — align comments to the code they precede
         var commentContributor = new CommentIndentationContributor();
 

--- a/Reihitsu.Formatter/Pipeline/Indentation/Utilities/LayoutComputer.cs
+++ b/Reihitsu.Formatter/Pipeline/Indentation/Utilities/LayoutComputer.cs
@@ -9,10 +9,23 @@ namespace Reihitsu.Formatter.Pipeline.Indentation.Utilities;
 
 /// <summary>
 /// Computes the indentation layout model for a syntax tree.
-/// Uses a three-pass approach: block indentation, alignment overrides, and comment alignment
+/// Applies block indentation, then repeats an alignment sweep until the columns settle, then
+/// aligns comments to the code they precede
 /// </summary>
 internal static class LayoutComputer
 {
+    #region Constants
+
+    /// <summary>
+    /// Upper bound on the alignment sweeps in pass 2. The sweep normally settles on the second one —
+    /// the first resolves every anchor whose own line is already final, the second the anchors that
+    /// depended on those. The bound only guards against a cycle between two contributors that would
+    /// otherwise spin; reaching it leaves the last computed state, which is still deterministic
+    /// </summary>
+    private const int MaxAlignmentPasses = 8;
+
+    #endregion // Constants
+
     #region Methods
 
     /// <summary>
@@ -32,30 +45,30 @@ internal static class LayoutComputer
         // Pass 2: Alignment contributors — override block indentation for specific constructs
         var contributors = CreateContributors();
 
-        foreach (var node in root.DescendantNodesAndSelf())
+        // The sweep repeats until no column changes, because a single ordered sweep cannot satisfy
+        // the dependencies in both directions. A contributor resolves its anchor through
+        // GetAdjustedColumn, which is only correct once that anchor's line is final, and the
+        // dependencies run both ways across the node order: a chain's anchor sits on a line owned by
+        // a construct nested inside the chain root (a multi-line initializer closed by "2 }"), which
+        // the pre-order walk reaches after the chain, while an argument list or lambda nested under a
+        // continuation line depends on the chain's own column and is reached before it is final.
+        // Sweeping once leaves whichever side runs last measuring against a stale column
+        for (var pass = 0; pass < MaxAlignmentPasses; pass++)
         {
-            foreach (var contributor in contributors)
+            var columns = model.CaptureColumns();
+
+            foreach (var node in root.DescendantNodesAndSelf())
             {
-                contributor.Contribute(node, model, context);
+                foreach (var contributor in contributors)
+                {
+                    contributor.Contribute(node, model, context);
+                }
             }
-        }
 
-        // Pass 2b: Chain alignment — re-resolve the continuation columns of method chains now that
-        // every other contributor has written its entries. A chain anchored on a line that a
-        // construct nested inside the chain root owns (a multi-line initializer closed by "2 }", a
-        // parenthesized initializer or switch expression) would otherwise be measured against that
-        // line's pass-1 block indentation, which the owning contributor overwrites above.
-        // The contributor deliberately stays registered in pass 2 as well, and the repetition is
-        // load-bearing rather than redundant: pass 2 keeps the chain's entries in their established
-        // priority order against the contributors that follow it, while this pass only corrects the
-        // anchor column those entries were measured from. Dropping either one changes layout —
-        // removing the pass-2 registration regresses the chain/argument and chain/initializer
-        // priority on shared lines
-        var chainContributor = new MethodChainAlignmentContributor();
-
-        foreach (var node in root.DescendantNodesAndSelf())
-        {
-            chainContributor.Contribute(node, model, context);
+            if (model.MatchesColumns(columns))
+            {
+                break;
+            }
         }
 
         // Pass 3: Comment alignment — align comments to the code they precede

--- a/Reihitsu.Formatter/Pipeline/Indentation/Utilities/LayoutModel.cs
+++ b/Reihitsu.Formatter/Pipeline/Indentation/Utilities/LayoutModel.cs
@@ -53,6 +53,48 @@ internal sealed class LayoutModel
     }
 
     /// <summary>
+    /// Captures the current column of every entry, so a later state can be compared against it.
+    /// Only the columns are captured: the <see cref="TokenLayout.Source"/> label is a debug aid and
+    /// two states that differ only in which contributor last wrote the same column are equivalent
+    /// </summary>
+    /// <returns>A snapshot mapping line numbers to their currently desired column</returns>
+    public Dictionary<int, int> CaptureColumns()
+    {
+        var columns = new Dictionary<int, int>(_layouts.Count);
+
+        foreach (var entry in _layouts)
+        {
+            columns[entry.Key] = entry.Value.Column;
+        }
+
+        return columns;
+    }
+
+    /// <summary>
+    /// Determines whether every entry still holds the column it held in the given snapshot
+    /// </summary>
+    /// <param name="columns">A snapshot previously returned by <see cref="CaptureColumns"/></param>
+    /// <returns><see langword="true"/> if no column changed and no entry was added; otherwise, <see langword="false"/></returns>
+    public bool MatchesColumns(Dictionary<int, int> columns)
+    {
+        if (_layouts.Count != columns.Count)
+        {
+            return false;
+        }
+
+        foreach (var entry in _layouts)
+        {
+            if (columns.TryGetValue(entry.Key, out var column) == false
+                || column != entry.Value.Column)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
     /// Tries to get the layout for the given token by looking up its line number
     /// </summary>
     /// <param name="token">The syntax token</param>

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/Rewriter/ChainLineBreakRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/Rewriter/ChainLineBreakRewriter.cs
@@ -394,11 +394,12 @@ internal sealed class ChainLineBreakRewriter : CSharpSyntaxRewriter
             return node;
         }
 
-        if (LineBreakTriviaUtilities.HasLeadingEndOfLine(chainDots[0])
-            && ReihitsuFormatterHelpers.HasCommentDirectlyAbove(chainDots[0]))
-        {
-            return node;
-        }
+        // A comment above the chain's first invoked link keeps the chain wrapped the way the author
+        // wrote it, so the collapse must not run. It gates that step alone: the rejoin joins a dot to
+        // its own member name and the continuation-break pass only inserts end-of-line trivia, and
+        // neither touches the gap the comment occupies.
+        var keepsAuthoredWrapping = LineBreakTriviaUtilities.HasLeadingEndOfLine(chainDots[0])
+                                    && ReihitsuFormatterHelpers.HasCommentDirectlyAbove(chainDots[0]);
 
         var firstWrappedDot = FindFirstWrappedChainOperator(node, chainDots[0]);
         var hasWrappedCandidate = firstWrappedDot.IsKind(SyntaxKind.None) == false;
@@ -410,7 +411,8 @@ internal sealed class ChainLineBreakRewriter : CSharpSyntaxRewriter
         // rejoin or the continuation-break pass, which do not touch the commented gap. Only a comment
         // above the chain's first invoked link keeps the whole chain as the author wrote it, and that
         // is the pre-existing bail above.
-        if (hasWrappedCandidate
+        if (keepsAuthoredWrapping == false
+            && hasWrappedCandidate
             && ReihitsuFormatterHelpers.HasCommentDirectlyAbove(firstWrappedDot) == false)
         {
             TryCollapseFirstChainDot(firstWrappedDot, replacements);

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/Rewriter/ChainLineBreakRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/Rewriter/ChainLineBreakRewriter.cs
@@ -378,7 +378,12 @@ internal sealed class ChainLineBreakRewriter : CSharpSyntaxRewriter
     /// #683). The member-name rejoin walks the spine's trailing trivia, which no other step inspects
     /// (issue #685). Whether every continuation link must start its own line stays a question about
     /// the <em>invoked</em> links alone: a chain that only wrapped a non-invoked prefix dot collapses
-    /// back onto one line and must not have breaks inserted into it
+    /// back onto one line and must not have breaks inserted into it.
+    /// </para>
+    /// <para>
+    /// A comment above the first invoked link is likewise a decision about one of the three, not
+    /// about the chain as a whole: it keeps the author's wrapping by suppressing the collapse, and
+    /// leaves the rejoin and the continuation breaks to their own trivia guards (issues #685, #689)
     /// </para>
     /// </summary>
     /// <param name="node">The outermost chain node (invocation or conditional access)</param>

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/Rewriter/ChainLineBreakRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/Rewriter/ChainLineBreakRewriter.cs
@@ -403,6 +403,13 @@ internal sealed class ChainLineBreakRewriter : CSharpSyntaxRewriter
         // wrote it, so the collapse must not run. It gates that step alone: the rejoin joins a dot to
         // its own member name and the continuation-break pass only inserts end-of-line trivia, and
         // neither touches the gap the comment occupies.
+        // The predicate stays comment-only and deliberately does not use the wider
+        // WouldJoinAcrossUnjoinableTrivia that the alignment phase applies (issue #489). Widening it
+        // would newly suppress the collapse for a chain carrying a directive above its first invoked
+        // link, which today collapses a wrapped prefix dot and aligns the remaining links under it —
+        // a strictly better layout than the block-level one the comment arm produces. Issues #685 and
+        // #689 asked for the divergence to be settled; it is settled here in favour of leaving the
+        // directive arm alone, and both arms are pinned by tests.
         var keepsAuthoredWrapping = LineBreakTriviaUtilities.HasLeadingEndOfLine(chainDots[0])
                                     && ReihitsuFormatterHelpers.HasCommentDirectlyAbove(chainDots[0]);
 


### PR DESCRIPTION
## Summary

Two independent defects in method-chain formatting.

**Line-break phase.** `ChainLineBreakRewriter.NormalizeChain` bailed out of the whole method when a comment sat directly above the chain's first invoked link. That bail exists to keep a deliberately wrapped chain wrapped, but it also suppressed the split-member-name rejoin and the per-link continuation breaks, neither of which touches the gap the comment occupies. It now gates the first-link collapse alone.

**Indentation phase.** `MethodChainAlignmentContributor` resolved its anchor through `LayoutComputer.GetAdjustedColumn`, which is only correct once the anchor's line is final. A chain rooted in a construct whose closing delimiter shares its line with an element read that line's block indentation before the owning contributor rebased it. The alignment sweep now repeats until no column changes, so every anchor is resolved against final entries.

## Why

Closes #685 (remaining arm), #688, #689 and #690. The four reports turned out to describe two mechanisms, not four, and each mechanism reached shapes no issue named:

- the line-break bail equally suppressed the rejoin (#685) and the per-link breaks (#689), and reaches `///` and block comments as well as line comments;
- the stale anchor read affects implicit arrays, parenthesized object and array creation, collection expressions, anonymous objects and parenthesized switch expressions in addition to the explicit array (#688) and `with` expression (#690) that were filed.

All are closed here, since one repair covers each mechanism and splitting would have re-derived the same evidence several times.

Three claims in the reports were falsified by measurement and are **not** implemented as written:

- #690's closing brace is already at the `with` keyword's column; only the continuation dot was wrong.
- #690's suggested `WithExpressionSyntax` arm in `GetCreationNewKeyword` is not the mechanism — parenthesized object creation, whose arm already exists, reproduces identically.
- #688's suggested reordering of `LayoutComputer.CreateContributors()` cannot close the defect at all: `Compute` iterates nodes outer and contributors inner, and the two contributions happen on different nodes, so the contributor order only breaks ties within one node.

## Linked issues

Closes #685
Closes #688
Closes #689
Closes #690

Refs #687

## Review notes

- **The alignment sweep repeats to a fixed point.** The dependency runs both ways across the pre-order walk: a chain's anchor sits on a line owned by a construct nested inside the chain root, while an argument list or lambda nested under a continuation line depends on the chain's own column. A single ordered sweep leaves whichever side runs last measuring against a stale column. Convergence rests on every contributor writing absolute columns; the one exception, `LambdaAlignmentContributor`'s `ShiftRange`, recomputes its delta from current state and returns early at zero. Measured sweep counts: repository sources 2, the repository's own test fixtures 3, generated adversarial nesting 4, against a bound of 8. Cost is ≈0.1–0.3% of formatting time.
- **The comment bail stays comment-only** rather than adopting the wider `WouldJoinAcrossUnjoinableTrivia` the alignment phase uses. #685 and #689 both asked for that divergence to be settled; it is settled in favour of leaving the directive arm alone. Widening was measured on a variant build: it degrades the `#pragma`, `#region` and `#if` arms from `a.Prop` with links aligned at 17 to a flat column-8 layout, while leaving the comment arm unchanged. All three directive arms are byte-identical to `main`, so this preserves shipped behavior rather than choosing new behavior. Both arms are pinned by tests.
- Formatter output for every affected shape was checked against RH5201, RH5203, RH5204, RH5205 and RH5206 under LF and CRLF, including chains composed with nested argument lists, lambdas and ternaries, and nested chains.
- Of the four composed-shape tests, the two argument-list ones falsify the pre-repair code; the statement-lambda and ternary ones produce identical output before and after and are characterization coverage proving the fixed point moved nothing there.
- The array initializer's own layout in #688 (`new int[] { 1,` / `2 }`) is deliberately unchanged — only the continuation dot moves.
- `documentation/rules/RH5201.md` is unchanged: no rule behavior changed, only formatter output that already had to satisfy it.

## Follow-up work

- A comment-exempt chain aligns its links to the chain root, while RH5201 measures from the first invoked link, so `a` / `// c` / `.Prop.Foo()` / `.Bar()` remains RH5201-dirty. Distinct mechanism, unaffected by either repair here.
- A comment above the first invoked link pins a chain with a wrapped non-invoked prefix at block indentation rather than under its root. Pre-existing and byte-identical to `main`, RH5201-clean, but now covered by a test and worth an explicit decision.
