### PR TITLE
Allow empty switch cases

### DIFF
--- a/Reihitsu.Formatter.Test/Regression/Structural/SwitchCaseBracesTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Structural/SwitchCaseBracesTests.cs
@@ -461,5 +461,37 @@ public class SwitchCaseBracesTests : FormatterTestsBase
         AssertRuleResult(input, expected);
     }
 
+    /// <summary>
+    /// No braces should be added to a switch section that contains no statements
+    /// </summary>
+    [TestMethod]
+    public void EmptyCasedShouldNotBeChanged()
+    {
+        // Arrange
+        const string input = """
+                             internal class TestClass
+                             {
+                                 void Check(int x, int y)
+                                 {
+                                     switch (x)
+                                     {
+                                         case 1:
+                                         case 2:
+                                             break;
+
+                                         default:
+                                             {
+                                                 Console.WriteLine("Default case");
+                                             }
+                                             break;
+                                     }
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input, input);
+    }
+
     #endregion // Methods
 }

--- a/Reihitsu.Formatter/Pipeline/SwitchCaseBraces/Rewriter/SwitchCaseBraceRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/SwitchCaseBraces/Rewriter/SwitchCaseBraceRewriter.cs
@@ -89,6 +89,16 @@ internal sealed class SwitchCaseBraceRewriter : CSharpSyntaxRewriter
     }
 
     /// <summary>
+    /// Determines whether a switch section is empty (contains no statements)
+    /// </summary>
+    /// <param name="section">The switch section to check</param>
+    /// <returns><see langword="true"/> if the section is empty; otherwise, <see langword="false"/></returns>
+    private static bool IsEmptySection(SwitchSectionSyntax section)
+    {
+        return section.Statements.Any(statement => statement.IsKind(SyntaxKind.BreakStatement) == false) == false;
+    }
+
+    /// <summary>
     /// Determines whether a switch section has multiple statements on separate lines and ends in
     /// return or throw. A trailing break is intentionally excluded because it remains outside an
     /// inserted brace block
@@ -560,7 +570,14 @@ internal sealed class SwitchCaseBraceRewriter : CSharpSyntaxRewriter
 
             if (anyMultiLine)
             {
-                newSections.Add(AddBraces(section));
+                var newSection = section;
+
+                if (IsEmptySection(section) == false)
+                {
+                    newSection = AddBraces(section);
+                }
+
+                newSections.Add(newSection);
             }
             else
             {


### PR DESCRIPTION
## Summary
Do not add braces to empty switch cases.

## Why
Empty braces to not add any value.

