### PR TITLE
Keep interpolation-alignment commas compact in the formatter and RH6002

### DIFF
--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH6002CommasMustBeSpacedCorrectlyFormatterTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH6002CommasMustBeSpacedCorrectlyFormatterTests.cs
@@ -121,5 +121,57 @@ public class RH6002CommasMustBeSpacedCorrectlyFormatterTests : FormatterTestsBas
         await VerifyFormatterStability(testData);
     }
 
+    /// <summary>
+    /// Verifies that a compact interpolation-alignment comma stays unchanged and analyzer-clean (issue #696)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCompactInterpolationAlignmentCommaStaysAnalyzerClean()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    string Method(string value)
+                                    {
+                                        return $"{value,-10}";
+                                    }
+                                }
+                                """;
+
+        await VerifyFormatterStability(testData);
+    }
+
+    /// <summary>
+    /// Verifies that the formatter removes a space after an interpolation-alignment comma, clears the
+    /// analyzer diagnostic, and remains stable on a second pass (issue #696)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFormatterFixesSpaceAfterInterpolationAlignmentCommaAndIsIdempotent()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    string Method(string value)
+                                    {
+                                        return $"{value{|#0:,|} -10}";
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     string Method(string value)
+                                     {
+                                         return $"{value,-10}";
+                                     }
+                                 }
+                                 """;
+
+        await VerifyFormatterFixAndIdempotency(testData,
+                                               fixedData,
+                                               Diagnostics(RH6002CommasMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6002MessageFormat));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatting/RH6002CommasMustBeSpacedCorrectlyAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH6002CommasMustBeSpacedCorrectlyAnalyzerTests.cs
@@ -365,5 +365,116 @@ public class RH6002CommasMustBeSpacedCorrectlyAnalyzerTests : AnalyzerTestsBase<
         await Verify(testData, fixedData, Diagnostics(RH6002CommasMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6002MessageFormat));
     }
 
+    /// <summary>
+    /// Verifies that a compact interpolation-alignment comma does not produce a diagnostic
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyCompactInterpolationAlignmentCommaDoesNotProduceDiagnostics()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    string Method(string value)
+                                    {
+                                        return $"{value,-10}";
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies that a space after an interpolation-alignment comma is detected and fixed
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifySpaceAfterInterpolationAlignmentCommaIsDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    string Method(string value)
+                                    {
+                                        return $"{value{|#0:,|} -10}";
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     string Method(string value)
+                                     {
+                                         return $"{value,-10}";
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH6002CommasMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6002MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that a space before an interpolation-alignment comma is still detected and fixed, so the
+    /// new zero-after-space owner does not regress coverage of the before-comma gap
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifySpaceBeforeInterpolationAlignmentCommaIsStillDetectedAndFixed()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    string Method(string value)
+                                    {
+                                        return $"{value {|#0:,|}-10}";
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     string Method(string value)
+                                     {
+                                         return $"{value,-10}";
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData, fixedData, Diagnostics(RH6002CommasMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6002MessageFormat));
+    }
+
+    /// <summary>
+    /// Verifies that Fix All converges two interpolation-alignment commas in one document
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyMultipleInterpolationAlignmentCommaDiagnosticsAreFixedInOneFixAllIteration()
+    {
+        const string testData = """
+                                internal class TestClass
+                                {
+                                    string Method(string a, string b)
+                                    {
+                                        return $"{a{|#0:,|} -10}{b{|#1:,|} 5}";
+                                    }
+                                }
+                                """;
+        const string fixedData = """
+                                 internal class TestClass
+                                 {
+                                     string Method(string a, string b)
+                                     {
+                                         return $"{a,-10}{b,5}";
+                                     }
+                                 }
+                                 """;
+
+        await Verify(testData,
+                     fixedData,
+                     static config => config.NumberOfFixAllIterations = 1,
+                     Diagnostics(RH6002CommasMustBeSpacedCorrectlyAnalyzer.DiagnosticId, AnalyzerResources.RH6002MessageFormat, 2));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer/Rules/Spacing/RH6002CommasMustBeSpacedCorrectlyAnalyzer.cs
+++ b/Reihitsu.Analyzer/Rules/Spacing/RH6002CommasMustBeSpacedCorrectlyAnalyzer.cs
@@ -59,7 +59,7 @@ public class RH6002CommasMustBeSpacedCorrectlyAnalyzer : DiagnosticAnalyzerBase
         if (nextToken.RawKind != 0
             && SyntaxTriviaUtilities.AreSeparatedByEndOfLine(token, nextToken) == false)
         {
-            normalizedCommaToken = SyntaxTriviaUtilities.SetTrailingWhitespace(token, 1);
+            normalizedCommaToken = SyntaxTriviaUtilities.SetTrailingWhitespace(token, CommaSpacingUtilities.GetDesiredSpacesAfter(token));
         }
 
         return (previousToken, normalizedPreviousToken, normalizedCommaToken);

--- a/Reihitsu.Core.Test/CommaSpacingUtilitiesTests.cs
+++ b/Reihitsu.Core.Test/CommaSpacingUtilitiesTests.cs
@@ -1,0 +1,103 @@
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Reihitsu.Core.Test;
+
+/// <summary>
+/// Contains unit tests for <see cref="CommaSpacingUtilities"/>
+/// </summary>
+[TestClass]
+public class CommaSpacingUtilitiesTests
+{
+    #region Tests
+
+    /// <summary>
+    /// Verifies that an ordinary argument-list comma requires one space after it
+    /// </summary>
+    [TestMethod]
+    public void GetDesiredSpacesAfterReturnsOneForOrdinaryArgumentComma()
+    {
+        var token = GetCommaToken("class C { void M() { N(1,2); } }");
+
+        Assert.AreEqual(1, CommaSpacingUtilities.GetDesiredSpacesAfter(token));
+    }
+
+    /// <summary>
+    /// Verifies that a sized array-rank comma requires one space after it, unlike its rank-only sibling
+    /// </summary>
+    [TestMethod]
+    public void GetDesiredSpacesAfterReturnsOneForSizedArrayRankSpecifierComma()
+    {
+        var token = GetCommaToken("class C { void M() { _ = new int[1,2]; } }");
+
+        Assert.AreEqual(1, CommaSpacingUtilities.GetDesiredSpacesAfter(token));
+    }
+
+    /// <summary>
+    /// Verifies that a rank-only array-specifier comma requires no space after it
+    /// </summary>
+    [TestMethod]
+    public void GetDesiredSpacesAfterReturnsZeroForRankOnlyArraySpecifierComma()
+    {
+        var token = GetCommaToken("class C { int[,] M() { return null; } }");
+
+        Assert.AreEqual(0, CommaSpacingUtilities.GetDesiredSpacesAfter(token));
+    }
+
+    /// <summary>
+    /// Verifies that an unbound generic type comma requires no space after it
+    /// </summary>
+    [TestMethod]
+    public void GetDesiredSpacesAfterReturnsZeroForUnboundGenericTypeComma()
+    {
+        var token = GetCommaToken("class C { System.Type M() { return typeof(System.Collections.Generic.Dictionary<,>); } }");
+
+        Assert.AreEqual(0, CommaSpacingUtilities.GetDesiredSpacesAfter(token));
+    }
+
+    /// <summary>
+    /// Verifies that the comma of an interpolated-string alignment component requires no space after it
+    /// </summary>
+    [TestMethod]
+    public void GetDesiredSpacesAfterReturnsZeroForInterpolationAlignmentComma()
+    {
+        var token = GetCommaToken("""class C { string M(string value) { return $"{value,-10}"; } }""");
+
+        Assert.AreEqual(0, CommaSpacingUtilities.GetDesiredSpacesAfter(token));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CommaSpacingUtilities.IsSpacingExempt"/> stays <see langword="false"/> for
+    /// the interpolation-alignment comma. Unlike the rank-only array specifier and unbound generic type
+    /// owners, this comma must stay subject to spacing analysis rather than being skipped entirely, so the
+    /// analyzer keeps reporting a stray space around it (issue #696)
+    /// </summary>
+    [TestMethod]
+    public void IsSpacingExemptReturnsFalseForInterpolationAlignmentComma()
+    {
+        var token = GetCommaToken("""class C { string M(string value) { return $"{value,-10}"; } }""");
+
+        Assert.IsFalse(CommaSpacingUtilities.IsSpacingExempt(token));
+    }
+
+    #endregion // Tests
+
+    #region Methods
+
+    /// <summary>
+    /// Parses the source and returns its single comma token
+    /// </summary>
+    /// <param name="source">Source text</param>
+    /// <returns>The comma token</returns>
+    private static SyntaxToken GetCommaToken(string source)
+    {
+        var root = CoreSyntaxTestHelper.ParseCompilationUnit(source);
+
+        return root.DescendantTokens().Single(currentToken => currentToken.IsKind(SyntaxKind.CommaToken));
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Core/CommaSpacingUtilities.cs
+++ b/Reihitsu.Core/CommaSpacingUtilities.cs
@@ -27,6 +27,23 @@ public static class CommaSpacingUtilities
     }
 
     /// <summary>
+    /// Determines the number of spaces required after a comma. Unlike <see cref="IsSpacingExempt"/>, this
+    /// covers commas that stay subject to spacing analysis but whose required spacing after the comma is
+    /// zero rather than one, such as the alignment comma of an interpolated-string alignment component
+    /// </summary>
+    /// <param name="commaToken">Comma token to inspect</param>
+    /// <returns>The number of spaces required after the comma</returns>
+    public static int GetDesiredSpacesAfter(SyntaxToken commaToken)
+    {
+        if (IsSpacingExempt(commaToken))
+        {
+            return 0;
+        }
+
+        return commaToken.Parent is InterpolationAlignmentClauseSyntax ? 0 : 1;
+    }
+
+    /// <summary>
     /// Determines whether an array rank specifier declares only rank without size expressions
     /// </summary>
     /// <param name="arrayRankSpecifier">Array rank specifier to inspect</param>

--- a/Reihitsu.Formatter.Test/Regression/Spacing/InterpolationAlignmentSpacingReproTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Spacing/InterpolationAlignmentSpacingReproTests.cs
@@ -5,8 +5,10 @@ using Reihitsu.Formatter.Test.Helpers;
 namespace Reihitsu.Formatter.Test.Regression.Spacing;
 
 /// <summary>
-/// Reproduction-gate tests for issue #696: the formatter is reported to insert a space between the
-/// comma and a negative alignment component of an interpolated-string alignment clause
+/// Formatter regression tests for the interpolated-string alignment comma (issue #696): the comma
+/// separating the interpolated expression from its alignment component is a fixed grammatical
+/// delimiter, not a value separator, and must stay compact regardless of the alignment's sign, operand
+/// shape, or the presence of a format specifier
 /// </summary>
 [TestClass]
 public class InterpolationAlignmentSpacingReproTests : FormatterTestsBase
@@ -81,6 +83,345 @@ public class InterpolationAlignmentSpacingReproTests : FormatterTestsBase
                                  public string Format(int value)
                                  {
                                      return $"{value,-10}";
+                                 }
+                             }
+                             """;
+
+        // Act & Assert (expected: no change)
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Sibling shape: a zero alignment component
+    /// </summary>
+    [TestMethod]
+    public void ZeroAlignmentComponentStaysAdjacentToComma()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public string Value { get; set; } = $"{"Foo",0}";
+                             }
+                             """;
+
+        // Act & Assert (expected: no change)
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// A format specifier without an alignment component carries no comma and must stay untouched
+    /// </summary>
+    [TestMethod]
+    public void FormatSpecifierWithoutAlignmentStaysUnchanged()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public string Value { get; set; } = $"{42:X}";
+                             }
+                             """;
+
+        // Act & Assert (expected: no change)
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// The formatter's own current (pre-fix) output must be normalized back to a compact comma
+    /// </summary>
+    [TestMethod]
+    public void SingleSpaceAfterAlignmentCommaIsRemoved()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public string Value { get; set; } = $"{value, -10}";
+                             }
+                             """;
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public string Value { get; set; } = $"{value,-10}";
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Several spaces after the alignment comma collapse to a compact comma, mirroring how
+    /// <c>int[,   ]</c> collapses to <c>int[,]</c>
+    /// </summary>
+    [TestMethod]
+    public void MultipleSpacesAfterAlignmentCommaAreCollapsed()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public string Value { get; set; } = $"{value,   -10}";
+                             }
+                             """;
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public string Value { get; set; } = $"{value,-10}";
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// A stray space before the alignment comma is removed independently of the after-comma fix,
+    /// because the before-gap is owned by a different spacing rule
+    /// </summary>
+    [TestMethod]
+    public void SpaceBeforeAlignmentCommaIsRemoved()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public string Value { get; set; } = $"{value ,-10}";
+                             }
+                             """;
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public string Value { get; set; } = $"{value,-10}";
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Stray spaces on both sides of the alignment comma are removed together
+    /// </summary>
+    [TestMethod]
+    public void SpacesOnBothSidesOfAlignmentCommaAreRemoved()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public string Value { get; set; } = $"{value , -10}";
+                             }
+                             """;
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public string Value { get; set; } = $"{value,-10}";
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Sibling shape: a parenthesized alignment expression stays adjacent to the comma
+    /// </summary>
+    [TestMethod]
+    public void ParenthesizedAlignmentComponentStaysAdjacentToComma()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public string Value { get; set; } = $"{value,(-10)}";
+                             }
+                             """;
+
+        // Act & Assert (expected: no change)
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Sibling shape: a member-access operand stays adjacent to the comma
+    /// </summary>
+    [TestMethod]
+    public void MemberAccessOperandAlignmentComponentStaysAdjacentToComma()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public string Format(object value)
+                                 {
+                                     return $"{value.ToString(),-10}";
+                                 }
+                             }
+                             """;
+
+        // Act & Assert (expected: no change)
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Sibling shape: a nested interpolated string as the operand keeps both holes compact
+    /// </summary>
+    [TestMethod]
+    public void NestedInterpolationHoleAlignmentComponentsStayAdjacentToComma()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public string Format(string value)
+                                 {
+                                     return $"{$"{value,-3}",-10}";
+                                 }
+                             }
+                             """;
+
+        // Act & Assert (expected: no change)
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Sibling shape: a verbatim interpolated string keeps the alignment comma compact
+    /// </summary>
+    [TestMethod]
+    public void VerbatimInterpolatedStringAlignmentComponentStaysAdjacentToComma()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public string Format(string value)
+                                 {
+                                     return $@"{value,-10}";
+                                 }
+                             }
+                             """;
+
+        // Act & Assert (expected: no change)
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Sibling shape: a raw-string interpolated string keeps the alignment comma compact
+    /// </summary>
+    [TestMethod]
+    public void RawStringInterpolatedStringAlignmentComponentStaysAdjacentToComma()
+    {
+        // Arrange
+        const string input = """"
+                             public class Implementation
+                             {
+                                 public string Format(string value)
+                                 {
+                                     return $$"""{{value,-10}}""";
+                                 }
+                             }
+                             """";
+
+        // Act & Assert (expected: no change)
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// A comment before the alignment comma leaves the comma compact and preserves the space in front
+    /// of the comment
+    /// </summary>
+    [TestMethod]
+    public void CommentBeforeAlignmentCommaStaysUnchanged()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public string Format(string value)
+                                 {
+                                     return $"{value /* comment */,-10}";
+                                 }
+                             }
+                             """;
+
+        // Act & Assert (expected: no change)
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// A comment attached to the alignment comma's trailing trivia still loses the space between the
+    /// comment and the alignment component, because the comma's desired spacing after it is now zero
+    /// </summary>
+    [TestMethod]
+    public void SpaceAfterCommentFollowingAlignmentCommaIsRemoved()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public string Format(string value)
+                                 {
+                                     return $"{value,/* comment */ -10}";
+                                 }
+                             }
+                             """;
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public string Format(string value)
+                                    {
+                                        return $"{value,/* comment */-10}";
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// A comma and its alignment component separated by a line break inside the interpolation hole
+    /// receive no spacing decision at all, and the surrounding layout is left untouched
+    /// </summary>
+    [TestMethod]
+    public void AlignmentCommaSeparatedFromAlignmentByLineBreakStaysUnchanged()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public string Format(string value)
+                                 {
+                                     return $"{value
+                                     ,-10}";
+                                 }
+                             }
+                             """;
+
+        // Act & Assert (expected: no change)
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Non-alignment commas keep exactly one space after them; the alignment-comma exemption must not
+    /// widen to ordinary argument or array-initializer commas
+    /// </summary>
+    [TestMethod]
+    public void NonAlignmentCommasStayUnaffected()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Method()
+                                 {
+                                     M(1, 2);
+                                     _ = new int[1, 2];
+                                 }
+
+                                 private static void M(int a, int b)
+                                 {
                                  }
                              }
                              """;

--- a/Reihitsu.Formatter.Test/Regression/Spacing/InterpolationAlignmentSpacingReproTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Spacing/InterpolationAlignmentSpacingReproTests.cs
@@ -1,0 +1,93 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Formatter.Test.Helpers;
+
+namespace Reihitsu.Formatter.Test.Regression.Spacing;
+
+/// <summary>
+/// Reproduction-gate tests for issue #696: the formatter is reported to insert a space between the
+/// comma and a negative alignment component of an interpolated-string alignment clause
+/// </summary>
+[TestClass]
+public class InterpolationAlignmentSpacingReproTests : FormatterTestsBase
+{
+    #region Methods
+
+    /// <summary>
+    /// Literal scenario from issue #696: a negative alignment component should stay adjacent to the comma
+    /// </summary>
+    [TestMethod]
+    public void NegativeAlignmentComponentStaysAdjacentToComma()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public string Value { get; set; } = $"{"Foo",-50}";
+                             }
+                             """;
+
+        // Act & Assert (expected: no change, per the issue's claim)
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Sibling shape: a positive alignment component
+    /// </summary>
+    [TestMethod]
+    public void PositiveAlignmentComponentStaysAdjacentToComma()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public string Value { get; set; } = $"{"Foo",50}";
+                             }
+                             """;
+
+        // Act & Assert (expected: no change)
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Sibling shape: negative alignment component combined with a format specifier
+    /// </summary>
+    [TestMethod]
+    public void NegativeAlignmentComponentWithFormatSpecifierStaysAdjacentToComma()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public string Value { get; set; } = $"{42,-5:X}";
+                             }
+                             """;
+
+        // Act & Assert (expected: no change)
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Sibling shape: negative alignment component on a simple identifier expression, without a
+    /// nested string literal
+    /// </summary>
+    [TestMethod]
+    public void NegativeAlignmentComponentOnIdentifierStaysAdjacentToComma()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public string Format(int value)
+                                 {
+                                     return $"{value,-10}";
+                                 }
+                             }
+                             """;
+
+        // Act & Assert (expected: no change)
+        AssertRuleResult(input);
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Formatter/Pipeline/HorizontalSpacing/Rules/CommaSpacingRule.cs
+++ b/Reihitsu.Formatter/Pipeline/HorizontalSpacing/Rules/CommaSpacingRule.cs
@@ -7,7 +7,8 @@ namespace Reihitsu.Formatter.Pipeline.HorizontalSpacing.Rules;
 
 /// <summary>
 /// Requires exactly one space after a comma, except inside a rank-only array specifier such as
-/// <c>int[,]</c> or an unbound generic type such as <c>Dictionary&lt;,&gt;</c> where the commas stay compact
+/// <c>int[,]</c>, an unbound generic type such as <c>Dictionary&lt;,&gt;</c>, or an interpolated-string
+/// alignment component such as <c>$"{value,-10}"</c>, where the commas stay compact
 /// </summary>
 internal sealed class CommaSpacingRule : ISpacingRule
 {
@@ -20,7 +21,7 @@ internal sealed class CommaSpacingRule : ISpacingRule
     /// <returns>The required number of spaces after the comma</returns>
     private static int GetSpacesAfterComma(SyntaxToken current)
     {
-        return CommaSpacingUtilities.IsSpacingExempt(current) ? 0 : 1;
+        return CommaSpacingUtilities.GetDesiredSpacesAfter(current);
     }
 
     #endregion // Methods

--- a/documentation/rules/RH6002.md
+++ b/documentation/rules/RH6002.md
@@ -21,10 +21,11 @@ Remove any space before the comma and ensure exactly one space follows it. The c
 
 ## Exceptions
 
-Commas that do not separate values are left compact and are not reported:
+Commas that do not separate values are left compact:
 
-- Rank-only array specifiers, such as `int[,]`.
-- Unbound generic types where the type arguments are omitted, such as `typeof(Dictionary<,>)` or `typeof(Func<,,>)`.
+- Rank-only array specifiers, such as `int[,]`. These commas are skipped entirely and are never reported, even when spaced.
+- Unbound generic types where the type arguments are omitted, such as `typeof(Dictionary<,>)` or `typeof(Func<,,>)`. Skipped entirely as well.
+- The alignment comma of an interpolated-string alignment component, such as `$"{value,-10}"`. Unlike the two exemptions above, this comma stays reported and fixed when a stray space follows it — the desired spacing after it is zero rather than one, not because the comma is skipped.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

The comma of an interpolated-string alignment clause (`$"{expr,alignment}"`) is a fixed grammatical delimiter, not a value separator. The formatter now keeps it compact regardless of the alignment's sign, and RH6002 shares the same fix.

## Why

Fixes #696. The reported example only mentioned the negative case, but the underlying defect is not sign-specific — positive and zero alignment reproduce identically. The shared `Reihitsu.Core/CommaSpacingUtilities` policy consumed by both the formatter's `CommaSpacingRule` and the RH6002 analyzer inserted a space after this comma unconditionally; RH6002 additionally flagged the issue's own already-correct example and its code fix made it worse. Both surfaces are fixed together from the one shared policy owner, by exposing a spacing *amount* (0 or 1) instead of only the previous binary skip flag — the naive fix of adding the new case to the existing skip set would have silently dropped RH6002's coverage of the comma's *before*-gap.

## Linked issues

Closes #696

## Review notes

Behavioral change to shipped RH6002 diagnostics: it now reports and fixes a stray space after an interpolation-alignment comma instead of never inspecting it, while the two pre-existing exemptions (`int[,]`, `Dictionary<,>`) are untouched. Passed official preflight (attempt 1/2) with zero blocking findings.

## Follow-up work

None in this PR. Preflight surfaced one unrelated, pre-existing defect in the same area (RH6002's code fix does not converge on implicit-array rank commas, e.g. `new[,,]`) — confirmed to reproduce identically on `main` before this change, so it is not addressed here. A ready-to-file issue draft is prepared locally for the maintainer to review and file separately.