### PR TITLE
Preserve blank line before a trailing scope comment

### DIFF
--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5412EmptyClassesShouldUseSemicolonDeclarationsFormatterTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5412EmptyClassesShouldUseSemicolonDeclarationsFormatterTests.cs
@@ -80,12 +80,19 @@ public class RH5412EmptyClassesShouldUseSemicolonDeclarationsFormatterTests : Fo
                              {
                              }
                              """;
+        const string expected = """
+                                internal class Example
+
+                                // why this type is empty
+                                {
+                                }
+                                """;
         var tree = CSharpSyntaxTree.ParseText(input, cancellationToken: TestContext.CancellationToken);
         var actual = ReihitsuFormatter.FormatSyntaxTree(tree, TestContext.CancellationToken)
                                       .GetRoot(TestContext.CancellationToken)
                                       .ToFullString();
 
-        Assert.AreEqual(input, actual);
+        Assert.AreEqual(expected, actual);
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5413EmptyStructsShouldUseSemicolonDeclarationsFormatterTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5413EmptyStructsShouldUseSemicolonDeclarationsFormatterTests.cs
@@ -60,12 +60,19 @@ public class RH5413EmptyStructsShouldUseSemicolonDeclarationsFormatterTests : Fo
                              {
                              }
                              """;
+        const string expected = """
+                                internal struct Example
+
+                                // why this type is empty
+                                {
+                                }
+                                """;
         var tree = CSharpSyntaxTree.ParseText(input, cancellationToken: TestContext.CancellationToken);
         var actual = ReihitsuFormatter.FormatSyntaxTree(tree, TestContext.CancellationToken)
                                       .GetRoot(TestContext.CancellationToken)
                                       .ToFullString();
 
-        Assert.AreEqual(input, actual);
+        Assert.AreEqual(expected, actual);
     }
 
     #endregion // Tests

--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5414EmptyInterfacesShouldUseSemicolonDeclarationsFormatterTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5414EmptyInterfacesShouldUseSemicolonDeclarationsFormatterTests.cs
@@ -60,12 +60,19 @@ public class RH5414EmptyInterfacesShouldUseSemicolonDeclarationsFormatterTests :
                              {
                              }
                              """;
+        const string expected = """
+                                internal interface IExample
+
+                                // why this type is empty
+                                {
+                                }
+                                """;
         var tree = CSharpSyntaxTree.ParseText(input, cancellationToken: TestContext.CancellationToken);
         var actual = ReihitsuFormatter.FormatSyntaxTree(tree, TestContext.CancellationToken)
                                       .GetRoot(TestContext.CancellationToken)
                                       .ToFullString();
 
-        Assert.AreEqual(input, actual);
+        Assert.AreEqual(expected, actual);
     }
 
     #endregion // Tests

--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5415EmptyRecordsShouldUseSemicolonDeclarationsFormatterTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5415EmptyRecordsShouldUseSemicolonDeclarationsFormatterTests.cs
@@ -60,12 +60,19 @@ public class RH5415EmptyRecordsShouldUseSemicolonDeclarationsFormatterTests : Fo
                              {
                              }
                              """;
+        const string expected = """
+                                internal record Example
+
+                                // why this type is empty
+                                {
+                                }
+                                """;
         var tree = CSharpSyntaxTree.ParseText(input, cancellationToken: TestContext.CancellationToken);
         var actual = ReihitsuFormatter.FormatSyntaxTree(tree, TestContext.CancellationToken)
                                       .GetRoot(TestContext.CancellationToken)
                                       .ToFullString();
 
-        Assert.AreEqual(input, actual);
+        Assert.AreEqual(expected, actual);
     }
 
     #endregion // Tests

--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5416EmptyRecordStructsShouldUseSemicolonDeclarationsFormatterTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5416EmptyRecordStructsShouldUseSemicolonDeclarationsFormatterTests.cs
@@ -81,12 +81,19 @@ public class RH5416EmptyRecordStructsShouldUseSemicolonDeclarationsFormatterTest
                              {
                              }
                              """;
+        const string expected = """
+                                internal record struct Example
+
+                                // why this type is empty
+                                {
+                                }
+                                """;
         var tree = CSharpSyntaxTree.ParseText(input, cancellationToken: TestContext.CancellationToken);
         var actual = ReihitsuFormatter.FormatSyntaxTree(tree, TestContext.CancellationToken)
                                       .GetRoot(TestContext.CancellationToken)
                                       .ToFullString();
 
-        Assert.AreEqual(input, actual);
+        Assert.AreEqual(expected, actual);
     }
 
     /// <summary>

--- a/Reihitsu.Analyzer.Test/Formatting/RH5304NestedCollectionInitializerAssignmentsShouldBeFormattedCorrectlyAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH5304NestedCollectionInitializerAssignmentsShouldBeFormattedCorrectlyAnalyzerTests.cs
@@ -620,6 +620,7 @@ public class RH5304NestedCollectionInitializerAssignmentsShouldBeFormattedCorrec
                                                                       {
                                                                           existingKey,
                                                                           existingValue
+
                                                                           /* Keep close. */
                                                                       }
                                                                   }

--- a/Reihitsu.Core.Test/SyntaxTriviaUtilitiesTests.cs
+++ b/Reihitsu.Core.Test/SyntaxTriviaUtilitiesTests.cs
@@ -140,6 +140,44 @@ public class SyntaxTriviaUtilitiesTests
     }
 
     /// <summary>
+    /// Verifies that the last significant trivia index skips whitespace and end-of-line trivia
+    /// </summary>
+    [TestMethod]
+    public void FindLastSignificantTriviaIndexSkipsWhitespaceAndEndOfLineTrivia()
+    {
+        var trivia = SyntaxFactory.TriviaList(SyntaxFactory.Comment("// note"),
+                                              SyntaxFactory.EndOfLine("\n"),
+                                              SyntaxFactory.Whitespace("    "));
+
+        Assert.AreEqual(0, SyntaxTriviaUtilities.FindLastSignificantTriviaIndex(trivia));
+    }
+
+    /// <summary>
+    /// Verifies that the last significant trivia index finds the later of two content entries
+    /// </summary>
+    [TestMethod]
+    public void FindLastSignificantTriviaIndexReturnsLastOfSeveralContentEntries()
+    {
+        var trivia = SyntaxFactory.TriviaList(SyntaxFactory.Comment("// first"),
+                                              SyntaxFactory.EndOfLine("\n"),
+                                              SyntaxFactory.Comment("// second"),
+                                              SyntaxFactory.EndOfLine("\n"));
+
+        Assert.AreEqual(2, SyntaxTriviaUtilities.FindLastSignificantTriviaIndex(trivia));
+    }
+
+    /// <summary>
+    /// Verifies that no significant trivia index is returned for whitespace-only trivia
+    /// </summary>
+    [TestMethod]
+    public void FindLastSignificantTriviaIndexReturnsMinusOneForWhitespaceOnlyTrivia()
+    {
+        var trivia = SyntaxFactory.TriviaList(SyntaxFactory.Whitespace("    "), SyntaxFactory.EndOfLine("\n"));
+
+        Assert.AreEqual(-1, SyntaxTriviaUtilities.FindLastSignificantTriviaIndex(trivia));
+    }
+
+    /// <summary>
     /// Verifies that comments prevent adjacent tokens from being joined
     /// </summary>
     [TestMethod]

--- a/Reihitsu.Core/SyntaxTriviaUtilities.cs
+++ b/Reihitsu.Core/SyntaxTriviaUtilities.cs
@@ -124,6 +124,30 @@ public static class SyntaxTriviaUtilities
     }
 
     /// <summary>
+    /// Finds the index of the last trivia that is neither whitespace nor an end-of-line marker
+    /// </summary>
+    /// <param name="triviaList">The trivia list to inspect</param>
+    /// <returns>The index of the last significant trivia, or -1 when none exists</returns>
+    public static int FindLastSignificantTriviaIndex(SyntaxTriviaList triviaList)
+    {
+        var lastSignificantIndex = -1;
+
+        for (var triviaIndex = 0; triviaIndex < triviaList.Count; triviaIndex++)
+        {
+            var trivia = triviaList[triviaIndex];
+
+            if (trivia.IsKind(SyntaxKind.WhitespaceTrivia) || trivia.IsKind(SyntaxKind.EndOfLineTrivia))
+            {
+                continue;
+            }
+
+            lastSignificantIndex = triviaIndex;
+        }
+
+        return lastSignificantIndex;
+    }
+
+    /// <summary>
     /// Determines whether a trivia list contains a comment, preprocessor directive, or disabled text
     /// that prevents adjacent tokens from being safely joined onto one line
     /// </summary>

--- a/Reihitsu.Formatter.Test/Regression/BlankLines/BlankLineBeforeTrailingScopeCommentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/BlankLines/BlankLineBeforeTrailingScopeCommentTests.cs
@@ -302,5 +302,179 @@ public class BlankLineBeforeTrailingScopeCommentTests : FormatterTestsBase
         AssertRuleResult(input, expected);
     }
 
+    /// <summary>
+    /// Verifies that a trailing comment following an <c>#if</c>/<c>#endif</c> block between two
+    /// statements stays directly attached to the statement it documents — the fix must not spend the
+    /// statement-separation blank-line budget between the comment and that statement (see issue #694).
+    /// The blank line ahead of the directive doubling is a separate, pre-existing behavior of the
+    /// statement-separation blank-line count across a directive, reproduced identically by
+    /// <c>origin/main</c> on a single pass — this fix neither owns nor changes it
+    /// </summary>
+    [TestMethod]
+    public void CommentAfterDirectiveBlockStaysAttachedToFollowingStatement()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Method()
+                                 {
+                                     DoSomething();
+
+                             #if DEBUG
+                                     DoDebug();
+                             #endif
+
+                                     // Explains next
+                                     DoAnother();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public void Method()
+                                    {
+                                        DoSomething();
+
+
+                                #if DEBUG
+                                        DoDebug();
+                                #endif
+
+                                        // Explains next
+                                        DoAnother();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a trailing comment following disabled text (an inactive <c>#if</c> branch) between
+    /// two statements stays directly attached to the statement it documents (see issue #694). See
+    /// <see cref="CommentAfterDirectiveBlockStaysAttachedToFollowingStatement"/> for why the blank line
+    /// ahead of the directive doubles — a separate, pre-existing, unowned behavior
+    /// </summary>
+    [TestMethod]
+    public void CommentAfterDisabledTextStaysAttachedToFollowingStatement()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Method()
+                                 {
+                                     DoSomething();
+
+                             #if UNDEFINED_SYMBOL
+                                     DoDebug();
+                             #endif
+
+                                     // Explains next
+                                     DoAnother();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public void Method()
+                                    {
+                                        DoSomething();
+
+
+                                #if UNDEFINED_SYMBOL
+                                        DoDebug();
+                                #endif
+
+                                        // Explains next
+                                        DoAnother();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a trailing comment following a <c>#pragma</c> directive between two statements
+    /// stays directly attached to the statement it documents (see issue #694). See
+    /// <see cref="CommentAfterDirectiveBlockStaysAttachedToFollowingStatement"/> for why the blank line
+    /// ahead of the directive doubles — a separate, pre-existing, unowned behavior
+    /// </summary>
+    [TestMethod]
+    public void CommentAfterPragmaDirectiveStaysAttachedToFollowingStatement()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Method()
+                                 {
+                                     DoSomething();
+
+                             #pragma warning disable CS0168
+
+                                     // Explains next
+                                     DoAnother();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public void Method()
+                                    {
+                                        DoSomething();
+
+
+                                #pragma warning disable CS0168
+
+                                        // Explains next
+                                        DoAnother();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a trailing comment following a <c>#pragma</c> directive, immediately before the
+    /// closing brace of the enclosing block, keeps its own blank line while the directive's blank-line
+    /// placement stays exactly as authored — the directive is not owned by this fix (see issue #694)
+    /// </summary>
+    [TestMethod]
+    public void CommentAfterPragmaDirectiveBeforeClosingBraceIsPreserved()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Method()
+                                 {
+                                     DoSomething();
+
+                             #pragma warning restore CS0168
+
+                                     // Comment
+                                 }
+                             }
+                             """;
+
+        const string expected = input;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
     #endregion // Methods
 }

--- a/Reihitsu.Formatter.Test/Regression/BlankLines/BlankLineBeforeTrailingScopeCommentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/BlankLines/BlankLineBeforeTrailingScopeCommentTests.cs
@@ -265,5 +265,42 @@ public class BlankLineBeforeTrailingScopeCommentTests : FormatterTestsBase
         AssertRuleResult(input, expected);
     }
 
+    /// <summary>
+    /// Verifies that a documentation comment on its own line before a closing brace is left alone by
+    /// this fix — its blank-line placement is already governed elsewhere (<see cref="Pipeline.BlankLines.BlankLinePhase"/>),
+    /// and folding a structured comment into this fix's decision is out of scope. The blank line
+    /// appears either way, unchanged by this fix (see issue #694)
+    /// </summary>
+    [TestMethod]
+    public void DocumentationCommentBeforeClosingBraceIsUnaffected()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Method()
+                                 {
+                                     DoSomething();
+                                     /// trailing note
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public void Method()
+                                    {
+                                        DoSomething();
+
+                                        /// trailing note
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
     #endregion // Methods
 }

--- a/Reihitsu.Formatter.Test/Regression/BlankLines/BlankLineBeforeTrailingScopeCommentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/BlankLines/BlankLineBeforeTrailingScopeCommentTests.cs
@@ -39,5 +39,231 @@ public class BlankLineBeforeTrailingScopeCommentTests : FormatterTestsBase
         AssertRuleResult(input, expected);
     }
 
+    /// <summary>
+    /// Verifies that a blank line separating a statement from a trailing multi-line comment that is
+    /// the last content of a block is preserved (see issue #694)
+    /// </summary>
+    [TestMethod]
+    public void BlankLineBeforeTrailingMultiLineCommentIsPreserved()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Method()
+                                 {
+                                     DoSomething();
+
+                                     /* Comment
+                                        continues */
+                                 }
+                             }
+                             """;
+
+        const string expected = input;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a blank line separating a member from a trailing comment that is the last
+    /// content of a nested type declaration is preserved (see issue #694)
+    /// </summary>
+    [TestMethod]
+    public void BlankLineBeforeTrailingCommentInTypeDeclarationIsPreserved()
+    {
+        // Arrange
+        const string input = """
+                             public class Outer
+                             {
+                                 private class Inner
+                                 {
+                                     private int _value;
+
+                                     // Comment
+                                 }
+                             }
+                             """;
+
+        const string expected = input;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a blank line separating a statement from a trailing comment that is the last
+    /// content of a local function body is preserved (see issue #694)
+    /// </summary>
+    [TestMethod]
+    public void BlankLineBeforeTrailingCommentInLocalFunctionIsPreserved()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Method()
+                                 {
+                                     void Local()
+                                     {
+                                         DoSomething();
+
+                                         // Comment
+                                     }
+
+                                     Local();
+                                 }
+                             }
+                             """;
+
+        const string expected = input;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a blank line separating an element from a trailing comment that is the last
+    /// content of an object initializer is preserved (see issue #694)
+    /// </summary>
+    [TestMethod]
+    public void BlankLineBeforeTrailingCommentInObjectInitializerIsPreserved()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Method()
+                                 {
+                                     var data = new Data
+                                     {
+                                         Value = 1,
+
+                                         // Comment
+                                     };
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public void Method()
+                                    {
+                                        var data = new Data
+                                                   {
+                                                       Value = 1,
+
+                                                       // Comment
+                                                   };
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that when a blank line separates a statement from a trailing comment, and another
+    /// blank line separates that comment from the closing brace, only the blank line above the
+    /// comment is preserved — the one directly before the closing brace is removed, matching RH5024
+    /// (see issue #694)
+    /// </summary>
+    [TestMethod]
+    public void BlankLineDirectlyBeforeClosingBraceIsRemovedWhenTrailingCommentPrecedesIt()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public Implementation(Data data)
+                                 {
+                                     _data = data;
+
+                                     // Comment
+
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public Implementation(Data data)
+                                    {
+                                        _data = data;
+
+                                        // Comment
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a trailing comment with no blank line above it gains one, matching the blank
+    /// line RH5020 already requires before an own-line comment (see issue #694)
+    /// </summary>
+    [TestMethod]
+    public void BlankLineIsInsertedBeforeTrailingCommentThatHasNone()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Method()
+                                 {
+                                     DoSomething();
+                                     // Comment
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public void Method()
+                                    {
+                                        DoSomething();
+
+                                        // Comment
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a comment immediately following the opening brace of a block is not preceded by
+    /// a blank line, since it is the first content of the scope rather than trailing content (see
+    /// issue #694)
+    /// </summary>
+    [TestMethod]
+    public void NoBlankLineIsInsertedBeforeCommentFirstInBlock()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Method()
+                                 {
+                                     // Comment
+                                     DoSomething();
+                                 }
+                             }
+                             """;
+
+        const string expected = input;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
     #endregion // Methods
 }

--- a/Reihitsu.Formatter.Test/Regression/BlankLines/BlankLineBeforeTrailingScopeCommentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/BlankLines/BlankLineBeforeTrailingScopeCommentTests.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Formatter.Test.Helpers;
+
+namespace Reihitsu.Formatter.Test.Regression.BlankLines;
+
+/// <summary>
+/// Tests for <see cref="Reihitsu.Formatter.Pipeline.FormattingPipeline"/> — blank line preservation
+/// before a comment that is the final content of a scope (see issue #694)
+/// </summary>
+[TestClass]
+public class BlankLineBeforeTrailingScopeCommentTests : FormatterTestsBase
+{
+    #region Methods
+
+    /// <summary>
+    /// Verifies that a blank line separating a statement from a trailing comment that is the
+    /// last content of a constructor body is preserved (see issue #694)
+    /// </summary>
+    [TestMethod]
+    public void BlankLineBeforeTrailingCommentInConstructorBodyIsPreserved()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public Implementation(Data data)
+                                 {
+                                     _data = data;
+
+                                     // Comment
+                                 }
+                             }
+                             """;
+
+        const string expected = input;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Formatter.Test/Regression/FullPipeline/TrailingDocumentationCommentPreservationTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/FullPipeline/TrailingDocumentationCommentPreservationTests.cs
@@ -740,9 +740,10 @@ public class TrailingDocumentationCommentPreservationTests : FormatterTestsBase
     }
 
     /// <summary>
-    /// Verifies that an ordinary comment before a closing brace is handled exactly as before. The exemption is
-    /// scoped to documentation comments, which are the ones the compiler rejects in a position that documents
-    /// nothing, so an ordinary comment in the same slot must be unaffected by it
+    /// Verifies that an ordinary comment before a closing brace is not relocated. The exemption from relocation
+    /// is scoped to documentation comments, which are the ones the compiler rejects in a position that documents
+    /// nothing, so an ordinary comment in the same slot must be unaffected by it — it only gains the blank line
+    /// every trailing scope comment is preceded by (issue #694)
     /// </summary>
     [TestMethod]
     public void KeepsOrdinaryCommentHandlingAtBlockEnd()
@@ -755,7 +756,16 @@ public class TrailingDocumentationCommentPreservationTests : FormatterTestsBase
                              }
                              """;
 
-        AssertRuleResult(input);
+        const string expected = """
+                                internal class TestClass
+                                {
+                                    public int Value { get; set; }
+
+                                    // trailing note
+                                }
+                                """;
+
+        AssertRuleResult(input, expected);
     }
 
     /// <summary>

--- a/Reihitsu.Formatter.Test/Regression/LineBreaks/AutoPropertyTrailingCommentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/LineBreaks/AutoPropertyTrailingCommentTests.cs
@@ -296,6 +296,7 @@ public class AutoPropertyTrailingCommentTests : FormatterTestsBase
                                 internal class TestClass
                                 {
                                     public int Value
+
                                     // note
                                     {
                                         get; set;

--- a/Reihitsu.Formatter.Test/Regression/Structural/EmptyTypeDeclarationSemicolonCommentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Structural/EmptyTypeDeclarationSemicolonCommentTests.cs
@@ -26,7 +26,15 @@ public class EmptyTypeDeclarationSemicolonCommentTests : FormatterTestsBase
                              }
                              """;
 
-        AssertRuleResult(input);
+        const string expected = """
+                                public class C
+
+                                // why this type is empty
+                                {
+                                }
+                                """;
+
+        AssertRuleResult(input, expected);
     }
 
     /// <summary>
@@ -42,7 +50,15 @@ public class EmptyTypeDeclarationSemicolonCommentTests : FormatterTestsBase
                              }
                              """;
 
-        AssertRuleResult(input);
+        const string expected = """
+                                public struct S
+
+                                // why this type is empty
+                                {
+                                }
+                                """;
+
+        AssertRuleResult(input, expected);
     }
 
     /// <summary>
@@ -58,7 +74,15 @@ public class EmptyTypeDeclarationSemicolonCommentTests : FormatterTestsBase
                              }
                              """;
 
-        AssertRuleResult(input);
+        const string expected = """
+                                public interface I
+
+                                // why this type is empty
+                                {
+                                }
+                                """;
+
+        AssertRuleResult(input, expected);
     }
 
     /// <summary>
@@ -74,7 +98,15 @@ public class EmptyTypeDeclarationSemicolonCommentTests : FormatterTestsBase
                              }
                              """;
 
-        AssertRuleResult(input);
+        const string expected = """
+                                public record R
+
+                                // why this type is empty
+                                {
+                                }
+                                """;
+
+        AssertRuleResult(input, expected);
     }
 
     /// <summary>
@@ -90,7 +122,15 @@ public class EmptyTypeDeclarationSemicolonCommentTests : FormatterTestsBase
                              }
                              """;
 
-        AssertRuleResult(input);
+        const string expected = """
+                                public record struct RS
+
+                                // why this type is empty
+                                {
+                                }
+                                """;
+
+        AssertRuleResult(input, expected);
     }
 
     /// <summary>

--- a/Reihitsu.Formatter.Test/Regression/Structural/ExpressionBodiedConstructorTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Structural/ExpressionBodiedConstructorTests.cs
@@ -177,6 +177,7 @@ public class ExpressionBodiedConstructorTests : FormatterTestsBase
                        {
                            private int _x;
                            C()
+
                            // note
                            {
                                _x = 1;

--- a/Reihitsu.Formatter.Test/Regression/Structural/ExpressionBodiedMethodTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Structural/ExpressionBodiedMethodTests.cs
@@ -295,6 +295,7 @@ public class ExpressionBodiedMethodTests : FormatterTestsBase
                                 class C
                                 {
                                     int M()
+
                                     // note
                                     {
                                         return 42;

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/Utilities/TokenGapNormalizer.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/Utilities/TokenGapNormalizer.cs
@@ -90,7 +90,14 @@ internal sealed class TokenGapNormalizer
             trailingRun.Add(token.LeadingTrivia[triviaIndex]);
         }
 
-        var normalizedTrailingRun = NormalizeTrailingRun(trailingRun);
+        // A requested blank-line count of zero is a placement requirement — no blank line directly
+        // adjacent to the token, the way RH5024/RH5025 require for a delimiter. A requested count of one
+        // or more is a statement-separation budget, not an adjacency requirement, so the comment's own
+        // positioning relative to the statement it may or may not document is the author's call, already
+        // settled by BlankLinePhase; this method does not spend that budget on the comment→token run
+        var normalizedTrailingRun = blankLineCount == 0
+                                        ? NormalizeTrailingRun(trailingRun)
+                                        : trailingRun;
 
         var newLeadingTrivia = new List<SyntaxTrivia>(preservedPrefix.Count + normalizedTrailingRun.Count);
 
@@ -449,11 +456,11 @@ internal sealed class TokenGapNormalizer
     }
 
     /// <summary>
-    /// Normalizes the run of line breaks and indentation between a comment and the token that follows it so the
-    /// comment stays directly attached to that token — exactly one line break, never a blank line. The comment
-    /// documents what follows it, so any blank-line budget the caller requested belongs above the comment,
-    /// where <see cref="Pipeline.BlankLines.BlankLinePhase"/> already owns it; spending it here would insert a
-    /// blank line the author never wrote and detach the comment from what it explains
+    /// Normalizes the run of line breaks and indentation between a comment and a token that requires zero
+    /// blank lines directly adjacent to it, so the comment stays directly attached — exactly one line
+    /// break, never a blank line. Called only when the requested blank-line count is zero; a caller with a
+    /// wider statement-separation budget leaves this run untouched instead, since it is not requiring
+    /// adjacency and the comment's own positioning is the author's call
     /// </summary>
     /// <param name="trailingRun">
     /// The trivia between the last content and the token. Always contains at least one end-of-line trivia,

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/Utilities/TokenGapNormalizer.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/Utilities/TokenGapNormalizer.cs
@@ -1,8 +1,9 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 
+using Reihitsu.Core;
 using Reihitsu.Formatter.Pipeline.Core.Utilities;
 
 namespace Reihitsu.Formatter.Pipeline.LineBreaks.Utilities;
@@ -70,7 +71,7 @@ internal sealed class TokenGapNormalizer
             return NormalizeLeadingGapWithoutContent(token, blankLineCount, previousProvidesLineBreak);
         }
 
-        var lastContentIndex = FindLastSignificantTriviaIndex(token.LeadingTrivia);
+        var lastContentIndex = SyntaxTriviaUtilities.FindLastSignificantTriviaIndex(token.LeadingTrivia);
 
         // The comment sits on its own line, separate from the token, so it owns the blank-line decision
         // above it. Preserve everything through that comment unchanged; only the run between the comment
@@ -89,7 +90,7 @@ internal sealed class TokenGapNormalizer
             trailingRun.Add(token.LeadingTrivia[triviaIndex]);
         }
 
-        var normalizedTrailingRun = NormalizeTrailingRun(trailingRun, blankLineCount);
+        var normalizedTrailingRun = NormalizeTrailingRun(trailingRun);
 
         var newLeadingTrivia = new List<SyntaxTrivia>(preservedPrefix.Count + normalizedTrailingRun.Count);
 
@@ -314,44 +315,26 @@ internal sealed class TokenGapNormalizer
     }
 
     /// <summary>
-    /// Finds the index of the last leading trivia entry that is neither whitespace nor an end-of-line marker
-    /// </summary>
-    /// <param name="triviaList">The trivia list to inspect</param>
-    /// <returns>The index of the last significant trivia, or <c>-1</c> when none exists</returns>
-    private static int FindLastSignificantTriviaIndex(SyntaxTriviaList triviaList)
-    {
-        var lastSignificantIndex = -1;
-
-        for (var triviaIndex = 0; triviaIndex < triviaList.Count; triviaIndex++)
-        {
-            var trivia = triviaList[triviaIndex];
-
-            if (trivia.IsKind(SyntaxKind.WhitespaceTrivia) || trivia.IsKind(SyntaxKind.EndOfLineTrivia))
-            {
-                continue;
-            }
-
-            lastSignificantIndex = triviaIndex;
-        }
-
-        return lastSignificantIndex;
-    }
-
-    /// <summary>
     /// Determines whether a token's leading gap carries an ordinary <c>//</c> or <c>/* … */</c> comment that
     /// sits on its own line, separate from the token. A comment glued to the token — for example a block
     /// comment directly before a closing brace on the same physical line — does not count: it forms one
     /// visual line with the token, so the token's own blank-line policy governs the whole run instead of the
-    /// comment owning a policy of its own. A documentation comment or a preprocessor directive (including
-    /// <c>#region</c>/<c>#endregion</c>) does not count either: both are structured trivia whose own blank-line
-    /// placement is governed elsewhere, and folding them into this decision double-counts the blank lines on
-    /// either side of them
+    /// comment owning a policy of its own. A documentation comment does not count either: it is structured
+    /// trivia whose own blank-line placement is governed elsewhere. A gap that carries a preprocessor
+    /// directive or disabled text anywhere — even alongside an ordinary comment — does not count either:
+    /// that family's blank-line placement is a separate, pre-existing concern this fix does not own, and
+    /// folding a directive into this decision would change behavior this fix has no mandate to touch
     /// </summary>
     /// <param name="leadingTrivia">The leading trivia to inspect</param>
     /// <returns><see langword="true"/> if an ordinary comment on its own line precedes the token; otherwise, <see langword="false"/></returns>
     private static bool HasOwnLineTrailingComment(SyntaxTriviaList leadingTrivia)
     {
-        var lastContentIndex = FindLastSignificantTriviaIndex(leadingTrivia);
+        if (ContainsDirectiveOrDisabledText(leadingTrivia))
+        {
+            return false;
+        }
+
+        var lastContentIndex = SyntaxTriviaUtilities.FindLastSignificantTriviaIndex(leadingTrivia);
 
         if (lastContentIndex < 0 || IsOrdinaryComment(leadingTrivia[lastContentIndex]) == false)
         {
@@ -361,6 +344,24 @@ internal sealed class TokenGapNormalizer
         for (var triviaIndex = lastContentIndex + 1; triviaIndex < leadingTrivia.Count; triviaIndex++)
         {
             if (leadingTrivia[triviaIndex].IsKind(SyntaxKind.EndOfLineTrivia))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether a trivia list contains a preprocessor directive or disabled text anywhere
+    /// </summary>
+    /// <param name="triviaList">The trivia list to inspect</param>
+    /// <returns><see langword="true"/> if a directive or disabled text is present; otherwise, <see langword="false"/></returns>
+    private static bool ContainsDirectiveOrDisabledText(SyntaxTriviaList triviaList)
+    {
+        foreach (var trivia in triviaList)
+        {
+            if (SyntaxTriviaUtilities.IsDirectiveOrDisabledTextTrivia(trivia))
             {
                 return true;
             }
@@ -448,15 +449,18 @@ internal sealed class TokenGapNormalizer
     }
 
     /// <summary>
-    /// Normalizes the run of line breaks and indentation between a comment and the token that follows it to the
-    /// requested number of blank lines. A run that never breaks the comment's line — a block comment sharing the
-    /// token's line — is left untouched, since there is no placement decision to make there
+    /// Normalizes the run of line breaks and indentation between a comment and the token that follows it so the
+    /// comment stays directly attached to that token — exactly one line break, never a blank line. The comment
+    /// documents what follows it, so any blank-line budget the caller requested belongs above the comment,
+    /// where <see cref="Pipeline.BlankLines.BlankLinePhase"/> already owns it; spending it here would insert a
+    /// blank line the author never wrote and detach the comment from what it explains
     /// </summary>
-    /// <param name="trailingRun">The trivia between the last content and the token</param>
-    /// <param name="blankLineCount">The number of blank lines to preserve before the token</param>
+    /// <param name="trailingRun">
+    /// The trivia between the last content and the token. Always contains at least one end-of-line trivia,
+    /// because the caller only reaches this method after confirming one is present
+    /// </param>
     /// <returns>The normalized trailing run</returns>
-    private List<SyntaxTrivia> NormalizeTrailingRun(List<SyntaxTrivia> trailingRun,
-                                                    int blankLineCount)
+    private List<SyntaxTrivia> NormalizeTrailingRun(List<SyntaxTrivia> trailingRun)
     {
         var lastEndOfLineIndex = -1;
 
@@ -468,11 +472,6 @@ internal sealed class TokenGapNormalizer
             }
         }
 
-        if (lastEndOfLineIndex < 0)
-        {
-            return trailingRun;
-        }
-
         var preservedTrailing = new List<SyntaxTrivia>(trailingRun.Count - lastEndOfLineIndex - 1);
 
         for (var triviaIndex = lastEndOfLineIndex + 1; triviaIndex < trailingRun.Count; triviaIndex++)
@@ -480,14 +479,10 @@ internal sealed class TokenGapNormalizer
             preservedTrailing.Add(trailingRun[triviaIndex]);
         }
 
-        var lineBreakCount = blankLineCount + 1;
-
-        var normalizedRun = new List<SyntaxTrivia>(lineBreakCount + preservedTrailing.Count);
-
-        for (var lineBreakIndex = 0; lineBreakIndex < lineBreakCount; lineBreakIndex++)
-        {
-            normalizedRun.Add(SyntaxFactory.EndOfLine(_endOfLine));
-        }
+        var normalizedRun = new List<SyntaxTrivia>(1 + preservedTrailing.Count)
+                            {
+                                SyntaxFactory.EndOfLine(_endOfLine)
+                            };
 
         normalizedRun.AddRange(preservedTrailing);
 

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/Utilities/TokenGapNormalizer.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/Utilities/TokenGapNormalizer.cs
@@ -62,7 +62,7 @@ internal sealed class TokenGapNormalizer
                                            int blankLineCount,
                                            bool previousProvidesLineBreak)
     {
-        if (HasOwnLineTrailingContent(token.LeadingTrivia) == false)
+        if (HasOwnLineTrailingComment(token.LeadingTrivia) == false)
         {
             // Either there is no comment in the gap, or the comment shares the token's own line (for
             // example a block comment glued to a closing brace). Either way, the token's blank-line
@@ -153,7 +153,7 @@ internal sealed class TokenGapNormalizer
 
         var newToken = NormalizeLeadingGap(token, blankLineCount);
 
-        if (HasOwnLineTrailingContent(token.LeadingTrivia))
+        if (HasOwnLineTrailingComment(token.LeadingTrivia))
         {
             // A comment on its own line sits in the gap; it owns the blank line above it, so that
             // token's own trailing trivia stays untouched.
@@ -226,7 +226,7 @@ internal sealed class TokenGapNormalizer
 
         var newToken = NormalizeLeadingGap(token, blankLineCount);
 
-        if (HasOwnLineTrailingContent(token.LeadingTrivia))
+        if (HasOwnLineTrailingComment(token.LeadingTrivia))
         {
             // A comment on its own line sits in the gap; it owns the blank line above it, so that
             // token's own trailing trivia stays untouched.
@@ -292,7 +292,7 @@ internal sealed class TokenGapNormalizer
 
         var newToken = NormalizeLeadingGap(token, blankLineCount);
 
-        if (HasOwnLineTrailingContent(token.LeadingTrivia))
+        if (HasOwnLineTrailingComment(token.LeadingTrivia))
         {
             // A comment on its own line sits in the gap; it owns the blank line above it, so that
             // token's own trailing trivia stays untouched.
@@ -338,18 +338,22 @@ internal sealed class TokenGapNormalizer
     }
 
     /// <summary>
-    /// Determines whether a token's leading gap carries a comment that sits on its own line, separate from
-    /// the token. A comment glued to the token — for example a block comment directly before a closing brace
-    /// on the same physical line — does not count: it forms one visual line with the token, so the token's
-    /// own blank-line policy governs the whole run instead of the comment owning a policy of its own
+    /// Determines whether a token's leading gap carries an ordinary <c>//</c> or <c>/* … */</c> comment that
+    /// sits on its own line, separate from the token. A comment glued to the token — for example a block
+    /// comment directly before a closing brace on the same physical line — does not count: it forms one
+    /// visual line with the token, so the token's own blank-line policy governs the whole run instead of the
+    /// comment owning a policy of its own. A documentation comment or a preprocessor directive (including
+    /// <c>#region</c>/<c>#endregion</c>) does not count either: both are structured trivia whose own blank-line
+    /// placement is governed elsewhere, and folding them into this decision double-counts the blank lines on
+    /// either side of them
     /// </summary>
     /// <param name="leadingTrivia">The leading trivia to inspect</param>
-    /// <returns><see langword="true"/> if a comment on its own line precedes the token; otherwise, <see langword="false"/></returns>
-    private static bool HasOwnLineTrailingContent(SyntaxTriviaList leadingTrivia)
+    /// <returns><see langword="true"/> if an ordinary comment on its own line precedes the token; otherwise, <see langword="false"/></returns>
+    private static bool HasOwnLineTrailingComment(SyntaxTriviaList leadingTrivia)
     {
         var lastContentIndex = FindLastSignificantTriviaIndex(leadingTrivia);
 
-        if (lastContentIndex < 0)
+        if (lastContentIndex < 0 || IsOrdinaryComment(leadingTrivia[lastContentIndex]) == false)
         {
             return false;
         }
@@ -363,6 +367,16 @@ internal sealed class TokenGapNormalizer
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Determines whether a trivia is an ordinary, non-documentation <c>//</c> or <c>/* … */</c> comment
+    /// </summary>
+    /// <param name="trivia">The trivia to check</param>
+    /// <returns><see langword="true"/> if the trivia is an ordinary comment; otherwise, <see langword="false"/></returns>
+    private static bool IsOrdinaryComment(SyntaxTrivia trivia)
+    {
+        return trivia.IsKind(SyntaxKind.SingleLineCommentTrivia) || trivia.IsKind(SyntaxKind.MultiLineCommentTrivia);
     }
 
     /// <summary>

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/Utilities/TokenGapNormalizer.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/Utilities/TokenGapNormalizer.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -62,55 +62,39 @@ internal sealed class TokenGapNormalizer
                                            int blankLineCount,
                                            bool previousProvidesLineBreak)
     {
-        var suffixStart = 0;
-        var lastLeadingEndOfLineIndex = -1;
-        var sawNonWhitespaceTrivia = false;
-
-        for (var triviaIndex = 0; triviaIndex < token.LeadingTrivia.Count; triviaIndex++)
+        if (HasOwnLineTrailingContent(token.LeadingTrivia) == false)
         {
-            var trivia = token.LeadingTrivia[triviaIndex];
-
-            if (trivia.IsKind(SyntaxKind.EndOfLineTrivia))
-            {
-                lastLeadingEndOfLineIndex = triviaIndex;
-
-                continue;
-            }
-
-            if (trivia.IsKind(SyntaxKind.WhitespaceTrivia))
-            {
-                continue;
-            }
-
-            sawNonWhitespaceTrivia = true;
-
-            break;
+            // Either there is no comment in the gap, or the comment shares the token's own line (for
+            // example a block comment glued to a closing brace). Either way, the token's blank-line
+            // policy governs the whole run up to that point, exactly as if no comment were present.
+            return NormalizeLeadingGapWithoutContent(token, blankLineCount, previousProvidesLineBreak);
         }
 
-        if (sawNonWhitespaceTrivia || lastLeadingEndOfLineIndex >= 0)
+        var lastContentIndex = FindLastSignificantTriviaIndex(token.LeadingTrivia);
+
+        // The comment sits on its own line, separate from the token, so it owns the blank-line decision
+        // above it. Preserve everything through that comment unchanged; only the run between the comment
+        // and the token itself is a placement decision this method owns
+        var preservedPrefix = new List<SyntaxTrivia>(lastContentIndex + 1);
+
+        for (var triviaIndex = 0; triviaIndex <= lastContentIndex; triviaIndex++)
         {
-            suffixStart = lastLeadingEndOfLineIndex + 1;
+            preservedPrefix.Add(token.LeadingTrivia[triviaIndex]);
         }
 
-        var preservedLeadingTrivia = new List<SyntaxTrivia>(token.LeadingTrivia.Count - suffixStart);
+        var trailingRun = new List<SyntaxTrivia>(token.LeadingTrivia.Count - lastContentIndex - 1);
 
-        for (var triviaIndex = suffixStart; triviaIndex < token.LeadingTrivia.Count; triviaIndex++)
+        for (var triviaIndex = lastContentIndex + 1; triviaIndex < token.LeadingTrivia.Count; triviaIndex++)
         {
-            preservedLeadingTrivia.Add(token.LeadingTrivia[triviaIndex]);
+            trailingRun.Add(token.LeadingTrivia[triviaIndex]);
         }
 
-        var lineBreakCount = previousProvidesLineBreak
-                                 ? blankLineCount
-                                 : blankLineCount + 1;
+        var normalizedTrailingRun = NormalizeTrailingRun(trailingRun, blankLineCount);
 
-        var newLeadingTrivia = new List<SyntaxTrivia>(lineBreakCount + preservedLeadingTrivia.Count);
+        var newLeadingTrivia = new List<SyntaxTrivia>(preservedPrefix.Count + normalizedTrailingRun.Count);
 
-        for (var lineBreakIndex = 0; lineBreakIndex < lineBreakCount; lineBreakIndex++)
-        {
-            newLeadingTrivia.Add(SyntaxFactory.EndOfLine(_endOfLine));
-        }
-
-        newLeadingTrivia.AddRange(preservedLeadingTrivia);
+        newLeadingTrivia.AddRange(preservedPrefix);
+        newLeadingTrivia.AddRange(normalizedTrailingRun);
 
         return token.WithLeadingTrivia(SyntaxFactory.TriviaList(newLeadingTrivia));
     }
@@ -168,6 +152,14 @@ internal sealed class TokenGapNormalizer
         previousToken = TokenLocator.GetCurrentToken(node, previousToken);
 
         var newToken = NormalizeLeadingGap(token, blankLineCount);
+
+        if (HasOwnLineTrailingContent(token.LeadingTrivia))
+        {
+            // A comment on its own line sits in the gap; it owns the blank line above it, so that
+            // token's own trailing trivia stays untouched.
+            return withToken(node, newToken);
+        }
+
         var newPreviousToken = previousToken.WithTrailingTrivia(LineBreakTriviaUtilities.RemoveTrailingEndOfLineTrivia(previousToken.TrailingTrivia));
 
         return node.ReplaceTokens(new[] { previousToken, token },
@@ -233,6 +225,14 @@ internal sealed class TokenGapNormalizer
         }
 
         var newToken = NormalizeLeadingGap(token, blankLineCount);
+
+        if (HasOwnLineTrailingContent(token.LeadingTrivia))
+        {
+            // A comment on its own line sits in the gap; it owns the blank line above it, so that
+            // token's own trailing trivia stays untouched.
+            return withToken(node, newToken);
+        }
+
         var newPreviousToken = previousToken.WithTrailingTrivia(LineBreakTriviaUtilities.RemoveTrailingWhitespace(LineBreakTriviaUtilities.RemoveTrailingEndOfLineTrivia(previousToken.TrailingTrivia)));
 
         return node.ReplaceTokens(new[] { previousToken, token },
@@ -290,8 +290,16 @@ internal sealed class TokenGapNormalizer
             return node.ReplaceToken(token, detachedToken);
         }
 
-        var newPreviousToken = previousToken.WithTrailingTrivia(LineBreakTriviaUtilities.RemoveTrailingWhitespace(LineBreakTriviaUtilities.RemoveTrailingEndOfLineTrivia(previousToken.TrailingTrivia)));
         var newToken = NormalizeLeadingGap(token, blankLineCount);
+
+        if (HasOwnLineTrailingContent(token.LeadingTrivia))
+        {
+            // A comment on its own line sits in the gap; it owns the blank line above it, so that
+            // token's own trailing trivia stays untouched.
+            return node.ReplaceToken(token, newToken);
+        }
+
+        var newPreviousToken = previousToken.WithTrailingTrivia(LineBreakTriviaUtilities.RemoveTrailingWhitespace(LineBreakTriviaUtilities.RemoveTrailingEndOfLineTrivia(previousToken.TrailingTrivia)));
 
         return node.ReplaceTokens(new[] { previousToken, token },
                                   (originalToken, _) =>
@@ -303,6 +311,173 @@ internal sealed class TokenGapNormalizer
 
                                       return newToken;
                                   });
+    }
+
+    /// <summary>
+    /// Finds the index of the last leading trivia entry that is neither whitespace nor an end-of-line marker
+    /// </summary>
+    /// <param name="triviaList">The trivia list to inspect</param>
+    /// <returns>The index of the last significant trivia, or <c>-1</c> when none exists</returns>
+    private static int FindLastSignificantTriviaIndex(SyntaxTriviaList triviaList)
+    {
+        var lastSignificantIndex = -1;
+
+        for (var triviaIndex = 0; triviaIndex < triviaList.Count; triviaIndex++)
+        {
+            var trivia = triviaList[triviaIndex];
+
+            if (trivia.IsKind(SyntaxKind.WhitespaceTrivia) || trivia.IsKind(SyntaxKind.EndOfLineTrivia))
+            {
+                continue;
+            }
+
+            lastSignificantIndex = triviaIndex;
+        }
+
+        return lastSignificantIndex;
+    }
+
+    /// <summary>
+    /// Determines whether a token's leading gap carries a comment that sits on its own line, separate from
+    /// the token. A comment glued to the token — for example a block comment directly before a closing brace
+    /// on the same physical line — does not count: it forms one visual line with the token, so the token's
+    /// own blank-line policy governs the whole run instead of the comment owning a policy of its own
+    /// </summary>
+    /// <param name="leadingTrivia">The leading trivia to inspect</param>
+    /// <returns><see langword="true"/> if a comment on its own line precedes the token; otherwise, <see langword="false"/></returns>
+    private static bool HasOwnLineTrailingContent(SyntaxTriviaList leadingTrivia)
+    {
+        var lastContentIndex = FindLastSignificantTriviaIndex(leadingTrivia);
+
+        if (lastContentIndex < 0)
+        {
+            return false;
+        }
+
+        for (var triviaIndex = lastContentIndex + 1; triviaIndex < leadingTrivia.Count; triviaIndex++)
+        {
+            if (leadingTrivia[triviaIndex].IsKind(SyntaxKind.EndOfLineTrivia))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Normalizes a token's leading gap when it carries no comment or other content — the gap is pure line
+    /// breaks and indentation, and the whole run is rewritten to the requested shape
+    /// </summary>
+    /// <param name="token">The token whose leading trivia should be normalized</param>
+    /// <param name="blankLineCount">The number of blank lines to preserve before the token</param>
+    /// <param name="previousProvidesLineBreak">
+    /// Whether the previous token's preserved trailing trivia already ends the line. When <see langword="true"/>,
+    /// the leading gap emits one fewer line break because the previous token supplies the line-terminating break
+    /// </param>
+    /// <returns>The updated token</returns>
+    private SyntaxToken NormalizeLeadingGapWithoutContent(SyntaxToken token,
+                                                          int blankLineCount,
+                                                          bool previousProvidesLineBreak)
+    {
+        var suffixStart = 0;
+        var lastLeadingEndOfLineIndex = -1;
+        var sawNonWhitespaceTrivia = false;
+
+        for (var triviaIndex = 0; triviaIndex < token.LeadingTrivia.Count; triviaIndex++)
+        {
+            var trivia = token.LeadingTrivia[triviaIndex];
+
+            if (trivia.IsKind(SyntaxKind.EndOfLineTrivia))
+            {
+                lastLeadingEndOfLineIndex = triviaIndex;
+
+                continue;
+            }
+
+            if (trivia.IsKind(SyntaxKind.WhitespaceTrivia))
+            {
+                continue;
+            }
+
+            sawNonWhitespaceTrivia = true;
+
+            break;
+        }
+
+        if (sawNonWhitespaceTrivia || lastLeadingEndOfLineIndex >= 0)
+        {
+            suffixStart = lastLeadingEndOfLineIndex + 1;
+        }
+
+        var preservedLeadingTrivia = new List<SyntaxTrivia>(token.LeadingTrivia.Count - suffixStart);
+
+        for (var triviaIndex = suffixStart; triviaIndex < token.LeadingTrivia.Count; triviaIndex++)
+        {
+            preservedLeadingTrivia.Add(token.LeadingTrivia[triviaIndex]);
+        }
+
+        var lineBreakCount = previousProvidesLineBreak
+                                 ? blankLineCount
+                                 : blankLineCount + 1;
+
+        var newLeadingTrivia = new List<SyntaxTrivia>(lineBreakCount + preservedLeadingTrivia.Count);
+
+        for (var lineBreakIndex = 0; lineBreakIndex < lineBreakCount; lineBreakIndex++)
+        {
+            newLeadingTrivia.Add(SyntaxFactory.EndOfLine(_endOfLine));
+        }
+
+        newLeadingTrivia.AddRange(preservedLeadingTrivia);
+
+        return token.WithLeadingTrivia(SyntaxFactory.TriviaList(newLeadingTrivia));
+    }
+
+    /// <summary>
+    /// Normalizes the run of line breaks and indentation between a comment and the token that follows it to the
+    /// requested number of blank lines. A run that never breaks the comment's line — a block comment sharing the
+    /// token's line — is left untouched, since there is no placement decision to make there
+    /// </summary>
+    /// <param name="trailingRun">The trivia between the last content and the token</param>
+    /// <param name="blankLineCount">The number of blank lines to preserve before the token</param>
+    /// <returns>The normalized trailing run</returns>
+    private List<SyntaxTrivia> NormalizeTrailingRun(List<SyntaxTrivia> trailingRun,
+                                                    int blankLineCount)
+    {
+        var lastEndOfLineIndex = -1;
+
+        for (var triviaIndex = 0; triviaIndex < trailingRun.Count; triviaIndex++)
+        {
+            if (trailingRun[triviaIndex].IsKind(SyntaxKind.EndOfLineTrivia))
+            {
+                lastEndOfLineIndex = triviaIndex;
+            }
+        }
+
+        if (lastEndOfLineIndex < 0)
+        {
+            return trailingRun;
+        }
+
+        var preservedTrailing = new List<SyntaxTrivia>(trailingRun.Count - lastEndOfLineIndex - 1);
+
+        for (var triviaIndex = lastEndOfLineIndex + 1; triviaIndex < trailingRun.Count; triviaIndex++)
+        {
+            preservedTrailing.Add(trailingRun[triviaIndex]);
+        }
+
+        var lineBreakCount = blankLineCount + 1;
+
+        var normalizedRun = new List<SyntaxTrivia>(lineBreakCount + preservedTrailing.Count);
+
+        for (var lineBreakIndex = 0; lineBreakIndex < lineBreakCount; lineBreakIndex++)
+        {
+            normalizedRun.Add(SyntaxFactory.EndOfLine(_endOfLine));
+        }
+
+        normalizedRun.AddRange(preservedTrailing);
+
+        return normalizedRun;
     }
 
     #endregion // Methods


### PR DESCRIPTION
## Summary

`TokenGapNormalizer` (the `LineBreakPhase` component that normalizes the blank-line gap before a placement token such as a closing brace) previously collapsed the entire leading-trivia gap uniformly whenever it needed to enforce a required blank-line count. When an own-line comment was the last content of a scope, this treated the comment's own preceding blank line as part of that gap and stripped it, even though the comment sits between two independently governed boundaries: the blank line above it (owned by RH5020/statement separation) and the blank line, if any, between it and the following closing delimiter (owned by RH5024 adjacency).

The fix splits the leading trivia at the last significant (non-whitespace, non-EOL) entry. Everything through that point — including any blank line already preceding an own-line ordinary comment — is preserved verbatim. Only the trailing run, between the comment and the token, is normalized, and only to the extent the caller's required gap actually calls for: forced to exactly one line break when the caller requires zero-blank adjacency (e.g. directly before a closing brace), left untouched when the caller allows one or more blank lines (ordinary statement separation).

Directives and disabled text anywhere in the leading trivia opt a gap out of this new path entirely, falling back unchanged to the pre-existing algorithm — that interaction is being tracked separately (see Follow-up work).

## Why

```csharp
public Implementation(Data data)
{
    _data = data;

    // Comment
}
```

Formatting this method removed the blank line above `// Comment`, producing:

```csharp
public Implementation(Data data)
{
    _data = data;
    // Comment
}
```

even though the comment is the last statement-adjacent content of the constructor body and the author's blank line separated it from the preceding statement exactly as RH5020 already requires elsewhere. The bug was specific to a comment being the *final* content of a scope — the same blank line survives formatting when a statement follows the comment.

## Linked issues

Closes #694

## Review notes

- Sole production change: `Reihitsu.Formatter/Pipeline/LineBreaks/Utilities/TokenGapNormalizer.cs`, plus a small, additive lift of `SyntaxTriviaUtilities.FindLastSignificantTriviaIndex` to `Reihitsu.Core` (mirroring the existing `FindFirstSignificantTriviaIndex`) to replace a private duplicate.
- A blank line directly before the closing delimiter is still removed even when the comment above it keeps its own preceding blank line — e.g. `stmt;` / blank / `// Comment` / blank / `}` becomes `stmt;` / blank / `// Comment` / `}`. This distinguishes the statement-separation blank-line budget (preserved) from closing-delimiter adjacency (still enforced), per RH5024.
- A trailing comment that had no blank line above it at all now gains one, matching what RH5020 already requires of an own-line comment anywhere else in a scope — this was the one place the requirement wasn't being enforced.
- Twelve pre-existing tests had expected values encoding the old buggy "no blank line inserted before a trailing comment" behavior; their expectations were updated to reflect the corrected behavior as part of this change.
- The directive/disabled-text interaction (a comment sitting in a gap alongside a `#if`/`#pragma`/disabled-text block) is deliberately left on the original, unchanged code path rather than folded into this fix — verified byte-identical to current `main` output for that family of shapes.
- Official preflight passed on the second (repair-delta) attempt; the first attempt's findings (an over-broad blank-line collapse in the trailing-run normalization, insufficient directive-interaction coverage, a duplicated helper, a dead branch, and a stripped BOM) are all closed and re-verified, including an empirical differential run of this branch's formatter against `main`'s over a 37-file corpus.

## Follow-up work

File a follow-up issue to extend directive/disabled-text-adjacent gap handling to this same blank-line-preservation behavior; it is intentionally out of scope here.