### PR TITLE
Stop doubling the blank line before a directive after a statement

### DIFF
--- a/Reihitsu.Formatter.Test/Regression/BlankLines/BlankLineBeforeIfDirectiveAfterStatementTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/BlankLines/BlankLineBeforeIfDirectiveAfterStatementTests.cs
@@ -1,11 +1,13 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Reihitsu.Formatter.Test.Helpers;
 
 namespace Reihitsu.Formatter.Test.Regression.BlankLines;
 
 /// <summary>
-/// Tests for <see cref="Reihitsu.Formatter.Pipeline.FormattingPipeline"/>
+/// Tests for <see cref="Reihitsu.Formatter.Pipeline.FormattingPipeline"/> — the number of blank lines
+/// separating a statement from a following preprocessor directive or disabled text (issue #695)
 /// </summary>
 [TestClass]
 public class BlankLineBeforeIfDirectiveAfterStatementTests : FormatterTestsBase
@@ -38,6 +40,720 @@ public class BlankLineBeforeIfDirectiveAfterStatementTests : FormatterTestsBase
 
         // Act & Assert
         AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that two blank lines before an <c>#if</c> directive collapse to one when a single
+    /// blank line already follows the directive block (issue #695)
+    /// </summary>
+    [TestMethod]
+    public void ExcessBlankLinesBeforeIfDirectiveCollapseToOneWhenOneBlankLineFollows()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     var bar = "foo1";
+
+
+                             #if DEBUG
+                                     bar = "foo2";
+                             #endif
+
+                                     bar = "foo2";
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public void Start()
+                                    {
+                                        var bar = "foo1";
+
+                                #if DEBUG
+                                        bar = "foo2";
+                                #endif
+
+                                        bar = "foo2";
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that two blank lines after an <c>#if</c> directive block collapse to one when a
+    /// single blank line already precedes the directive (issue #695)
+    /// </summary>
+    [TestMethod]
+    public void ExcessBlankLinesAfterIfDirectiveCollapseToOneWhenOneBlankLinePrecedes()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     var bar = "foo1";
+
+                             #if DEBUG
+                                     bar = "foo2";
+                             #endif
+
+
+                                     bar = "foo2";
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public void Start()
+                                    {
+                                        var bar = "foo1";
+
+                                #if DEBUG
+                                        bar = "foo2";
+                                #endif
+
+                                        bar = "foo2";
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that excess blank lines on both sides of an <c>#if</c> directive block each
+    /// independently collapse to one (issue #695)
+    /// </summary>
+    [TestMethod]
+    public void ExcessBlankLinesOnBothSidesOfIfDirectiveCollapseToOne()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     var bar = "foo1";
+
+
+                             #if DEBUG
+                                     bar = "foo2";
+                             #endif
+
+
+                                     bar = "foo2";
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public void Start()
+                                    {
+                                        var bar = "foo1";
+
+                                #if DEBUG
+                                        bar = "foo2";
+                                #endif
+
+                                        bar = "foo2";
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that no blank line before an <c>#if</c> directive is left alone when exactly one
+    /// blank line follows the directive block (issue #695)
+    /// </summary>
+    [TestMethod]
+    public void NoBlankLineBeforeIfDirectiveIsPreservedWhenOneBlankLineFollows()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     var bar = "foo1";
+                             #if DEBUG
+                                     bar = "foo2";
+                             #endif
+
+                                     bar = "foo2";
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that one blank line before an <c>#if</c> directive is left alone when no blank line
+    /// follows the directive block (issue #695)
+    /// </summary>
+    [TestMethod]
+    public void OneBlankLineBeforeIfDirectiveIsPreservedWhenNoneFollows()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     var bar = "foo1";
+
+                             #if DEBUG
+                                     bar = "foo2";
+                             #endif
+                                     bar = "foo2";
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a directive block with no blank line on either side is left alone (issue #695)
+    /// </summary>
+    [TestMethod]
+    public void NoBlankLinesAroundIfDirectiveArePreserved()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     var bar = "foo1";
+                             #if DEBUG
+                                     bar = "foo2";
+                             #endif
+                                     bar = "foo2";
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that excess blank lines before an <c>#if</c> directive still collapse to one when no
+    /// blank line follows the directive block — already correct before issue #695's fix, and must not
+    /// regress
+    /// </summary>
+    [TestMethod]
+    public void ExcessBlankLinesBeforeIfDirectiveCollapseToOneWhenNoneFollow()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     var bar = "foo1";
+
+
+                             #if DEBUG
+                                     bar = "foo2";
+                             #endif
+                                     bar = "foo2";
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public void Start()
+                                    {
+                                        var bar = "foo1";
+
+                                #if DEBUG
+                                        bar = "foo2";
+                                #endif
+                                        bar = "foo2";
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that excess blank lines after an <c>#if</c> directive block still collapse to one
+    /// when no blank line precedes the directive — already correct before issue #695's fix, and must
+    /// not regress
+    /// </summary>
+    [TestMethod]
+    public void ExcessBlankLinesAfterIfDirectiveCollapseToOneWhenNonePrecede()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     var bar = "foo1";
+                             #if DEBUG
+                                     bar = "foo2";
+                             #endif
+
+
+                                     bar = "foo2";
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public void Start()
+                                    {
+                                        var bar = "foo1";
+                                #if DEBUG
+                                        bar = "foo2";
+                                #endif
+
+                                        bar = "foo2";
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a single blank line before an <c>#if</c> directive inside a switch section is
+    /// preserved rather than doubled (issue #695)
+    /// </summary>
+    [TestMethod]
+    public void SingleBlankLineBeforeIfDirectiveIsPreservedInSwitchSection()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start(int value)
+                                 {
+                                     switch (value)
+                                     {
+                                         case 1:
+                                             var bar = "foo1";
+
+                             #if DEBUG
+                                             bar = "foo2";
+                             #endif
+
+                                             bar = "foo2";
+                                             break;
+                                     }
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that excess blank lines before an <c>#if</c> directive inside a switch section
+    /// collapse to one (issue #695)
+    /// </summary>
+    [TestMethod]
+    public void ExcessBlankLinesBeforeIfDirectiveCollapseToOneInSwitchSection()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start(int value)
+                                 {
+                                     switch (value)
+                                     {
+                                         case 1:
+                                             var bar = "foo1";
+
+
+                             #if DEBUG
+                                             bar = "foo2";
+                             #endif
+
+                                             bar = "foo2";
+                                             break;
+                                     }
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public void Start(int value)
+                                    {
+                                        switch (value)
+                                        {
+                                            case 1:
+                                                var bar = "foo1";
+
+                                #if DEBUG
+                                                bar = "foo2";
+                                #endif
+
+                                                bar = "foo2";
+                                                break;
+                                        }
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a single blank line before a <c>#pragma</c> directive is preserved rather than
+    /// doubled — the mechanism is directive-kind agnostic, not specific to <c>#if</c> (issue #695)
+    /// </summary>
+    [TestMethod]
+    public void SingleBlankLineBeforePragmaDirectiveIsPreserved()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     var bar = "foo1";
+
+                             #pragma warning disable CS0168
+
+                                     bar = "foo2";
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a single blank line before a <c>#nullable</c> directive is preserved rather than
+    /// doubled (issue #695)
+    /// </summary>
+    [TestMethod]
+    public void SingleBlankLineBeforeNullableDirectiveIsPreserved()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     var bar = "foo1";
+
+                             #nullable enable
+
+                                     bar = "foo2";
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a single blank line before a <c>#line</c> directive is preserved rather than
+    /// doubled (issue #695)
+    /// </summary>
+    [TestMethod]
+    public void SingleBlankLineBeforeLineDirectiveIsPreserved()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     var bar = "foo1";
+
+                             #line 42
+
+                                     bar = "foo2";
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a single blank line before a <c>#warning</c> directive is preserved rather than
+    /// doubled (issue #695)
+    /// </summary>
+    [TestMethod]
+    public void SingleBlankLineBeforeWarningDirectiveIsPreserved()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     var bar = "foo1";
+
+                             #warning Remove this before shipping
+
+                                     bar = "foo2";
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a <c>#region</c>/<c>#endregion</c> block between two statements still receives
+    /// its own required blank lines without any run holding two consecutive blank lines (issue #695)
+    /// </summary>
+    [TestMethod]
+    public void RegionDirectiveBetweenStatementsHoldsNoDoubledBlankLine()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     var bar = "foo1";
+
+                                     #region Detail
+                                     bar = "foo2";
+                                     #endregion
+
+                                     bar = "foo2";
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public void Start()
+                                    {
+                                        var bar = "foo1";
+
+                                        #region Detail
+
+                                        bar = "foo2";
+
+                                        #endregion // Detail
+
+                                        bar = "foo2";
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that an <c>#if</c> directive whose active branch supplies a real statement is
+    /// unaffected — the active statement splits the gap into two one-blank-line gaps, so the doubling
+    /// mechanism never applies (issue #695)
+    /// </summary>
+    [TestMethod]
+    public void ActiveIfBranchStatementSeparatesGapAndIsUnaffected()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     var bar = "foo1";
+
+                             #if true
+                                     bar = "foo2";
+                             #endif
+
+                                     bar = "foo3";
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that an <c>#if</c> directive whose symbol is defined is unaffected in the same way as
+    /// a literal <c>#if true</c> — the active branch again supplies a real statement (issue #695)
+    /// </summary>
+    [TestMethod]
+    public void DefinedSymbolIfBranchStatementSeparatesGapAndIsUnaffected()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     var bar = "foo1";
+
+                             #if DEBUG
+                                     bar = "foo2";
+                             #endif
+
+                                     bar = "foo3";
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected: null, parseOptions: CSharpParseOptions.Default.WithPreprocessorSymbols("DEBUG"));
+    }
+
+    /// <summary>
+    /// Verifies that a directive block between two type members is unaffected — the changed rewriter
+    /// only visits block and switch-section statement lists, not a member list (issue #695)
+    /// </summary>
+    [TestMethod]
+    public void DirectiveBlockBetweenTypeMembersIsUnaffected()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 private int _a;
+
+                             #if DEBUG
+                                 private int _b;
+                             #endif
+
+                                 private int _c;
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a directive block between top-level statements is unaffected — top-level
+    /// statements live directly on the compilation unit, not inside a block (issue #695)
+    /// </summary>
+    [TestMethod]
+    public void DirectiveBlockBetweenTopLevelStatementsIsUnaffected()
+    {
+        // Arrange
+        const string input = """
+                             var bar = "foo1";
+
+                             #if DEBUG
+                             bar = "foo2";
+                             #endif
+
+                             bar = "foo2";
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that an empty statement adjacent to a directive-carrying gap keeps the pair exempt
+    /// from the excess-blank-line correction, unaffected by issue #695's fix
+    /// </summary>
+    [TestMethod]
+    public void EmptyStatementSiblingWithDirectiveGapIsUnaffected()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     var bar = "foo1";
+                                     ;
+
+                             #if DEBUG
+                                     bar = "foo2";
+                             #endif
+
+                                     bar = "foo2";
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a directive block that is the last content of a block still loses the blank line
+    /// above it — a separate, pre-existing behavior of <see cref="Pipeline.BlankLines.Rewriter.BlankLineTokenCleanupRewriter"/>
+    /// that issue #695 does not own or change, frozen here so a future change cannot alter it silently
+    /// </summary>
+    [TestMethod]
+    public void TrailingDirectiveWithNoFollowingStatementStillLosesItsBlankLine()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     var bar = "foo1";
+
+                             #if DEBUG
+                                     bar = "foo2";
+                             #endif
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public void Start()
+                                    {
+                                        var bar = "foo1";
+                                #if DEBUG
+                                        bar = "foo2";
+                                #endif
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
     }
 
     #endregion // Methods

--- a/Reihitsu.Formatter.Test/Regression/BlankLines/BlankLineBeforeIfDirectiveAfterStatementTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/BlankLines/BlankLineBeforeIfDirectiveAfterStatementTests.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Formatter.Test.Helpers;
+
+namespace Reihitsu.Formatter.Test.Regression.BlankLines;
+
+/// <summary>
+/// Tests for <see cref="Reihitsu.Formatter.Pipeline.FormattingPipeline"/>
+/// </summary>
+[TestClass]
+public class BlankLineBeforeIfDirectiveAfterStatementTests : FormatterTestsBase
+{
+    #region Methods
+
+    /// <summary>
+    /// Verifies that a single blank line already present between a statement and a following
+    /// <c>#if</c> directive is preserved rather than doubled (issue #695)
+    /// </summary>
+    [TestMethod]
+    public void SingleBlankLineBeforeIfDirectiveIsPreserved()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     var bar = "foo1";
+
+                             #if DEBUG
+                                     bar = "foo2";
+                             #endif
+
+                                     bar = "foo2";
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    #endregion // Methods
+}

--- a/Reihitsu.Formatter.Test/Regression/BlankLines/BlankLineBeforeTrailingScopeCommentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/BlankLines/BlankLineBeforeTrailingScopeCommentTests.cs
@@ -305,10 +305,8 @@ public class BlankLineBeforeTrailingScopeCommentTests : FormatterTestsBase
     /// <summary>
     /// Verifies that a trailing comment following an <c>#if</c>/<c>#endif</c> block between two
     /// statements stays directly attached to the statement it documents — the fix must not spend the
-    /// statement-separation blank-line budget between the comment and that statement (see issue #694).
-    /// The blank line ahead of the directive doubling is a separate, pre-existing behavior of the
-    /// statement-separation blank-line count across a directive, reproduced identically by
-    /// <c>origin/main</c> on a single pass — this fix neither owns nor changes it
+    /// statement-separation blank-line budget between the comment and that statement (see issue #694),
+    /// and the single blank line ahead of the directive is preserved rather than doubled (issue #695)
     /// </summary>
     [TestMethod]
     public void CommentAfterDirectiveBlockStaysAttachedToFollowingStatement()
@@ -338,7 +336,6 @@ public class BlankLineBeforeTrailingScopeCommentTests : FormatterTestsBase
                                     {
                                         DoSomething();
 
-
                                 #if DEBUG
                                         DoDebug();
                                 #endif
@@ -355,9 +352,8 @@ public class BlankLineBeforeTrailingScopeCommentTests : FormatterTestsBase
 
     /// <summary>
     /// Verifies that a trailing comment following disabled text (an inactive <c>#if</c> branch) between
-    /// two statements stays directly attached to the statement it documents (see issue #694). See
-    /// <see cref="CommentAfterDirectiveBlockStaysAttachedToFollowingStatement"/> for why the blank line
-    /// ahead of the directive doubles — a separate, pre-existing, unowned behavior
+    /// two statements stays directly attached to the statement it documents (see issue #694), and the
+    /// single blank line ahead of the directive is preserved rather than doubled (issue #695)
     /// </summary>
     [TestMethod]
     public void CommentAfterDisabledTextStaysAttachedToFollowingStatement()
@@ -387,7 +383,6 @@ public class BlankLineBeforeTrailingScopeCommentTests : FormatterTestsBase
                                     {
                                         DoSomething();
 
-
                                 #if UNDEFINED_SYMBOL
                                         DoDebug();
                                 #endif
@@ -404,9 +399,8 @@ public class BlankLineBeforeTrailingScopeCommentTests : FormatterTestsBase
 
     /// <summary>
     /// Verifies that a trailing comment following a <c>#pragma</c> directive between two statements
-    /// stays directly attached to the statement it documents (see issue #694). See
-    /// <see cref="CommentAfterDirectiveBlockStaysAttachedToFollowingStatement"/> for why the blank line
-    /// ahead of the directive doubles — a separate, pre-existing, unowned behavior
+    /// stays directly attached to the statement it documents (see issue #694), and the single blank
+    /// line ahead of the directive is preserved rather than doubled (issue #695)
     /// </summary>
     [TestMethod]
     public void CommentAfterPragmaDirectiveStaysAttachedToFollowingStatement()
@@ -433,7 +427,6 @@ public class BlankLineBeforeTrailingScopeCommentTests : FormatterTestsBase
                                     public void Method()
                                     {
                                         DoSomething();
-
 
                                 #pragma warning disable CS0168
 

--- a/Reihitsu.Formatter.Test/Regression/FullPipeline/RegionFormattingFullPipelineTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/FullPipeline/RegionFormattingFullPipelineTests.cs
@@ -570,7 +570,6 @@ public class RegionFormattingFullPipelineTests : FormatterTestsBase
                                             return 1;
                                         }
 
-
                                         #endregion // Local
 
                                         return Local();

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/Rewriter/LineBreakBlockRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/Rewriter/LineBreakBlockRewriter.cs
@@ -2,6 +2,7 @@
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
+using Reihitsu.Core;
 using Reihitsu.Formatter.Pipeline.Core.Utilities;
 using Reihitsu.Formatter.Pipeline.LineBreaks.Utilities;
 
@@ -53,6 +54,42 @@ internal sealed class LineBreakBlockRewriter : CSharpSyntaxRewriter
     #region Methods
 
     /// <summary>
+    /// Determines whether the gap between two adjacent statement tokens carries a preprocessor directive or
+    /// disabled text
+    /// </summary>
+    /// <param name="previousToken">The token that ends the preceding statement</param>
+    /// <param name="currentToken">The token that starts the following statement</param>
+    /// <returns><see langword="true"/> if the gap contains a directive or disabled-text trivia; otherwise, <see langword="false"/></returns>
+    /// <remarks>
+    /// A directive splits the gap into independent blank-line runs on either side of it, which
+    /// <see cref="Pipeline.BlankLines.BlankLinePhase"/> already collapses correctly, one run at a time.
+    /// <see cref="TokenGapUtilities.CountBlankLinesBetween"/> sums the blank lines on both sides into one
+    /// number, so a single blank line on each side is miscounted as two — exactly the excess this method's
+    /// caller is trying to detect. Withholding the correction here leaves the earlier, run-aware phase's
+    /// answer standing instead of adding a blank line the gap never actually had (issue #695)
+    /// </remarks>
+    private static bool GapCarriesDirectiveOrDisabledText(SyntaxToken previousToken, SyntaxToken currentToken)
+    {
+        foreach (var trivia in previousToken.TrailingTrivia)
+        {
+            if (SyntaxTriviaUtilities.IsDirectiveOrDisabledTextTrivia(trivia))
+            {
+                return true;
+            }
+        }
+
+        foreach (var trivia in currentToken.LeadingTrivia)
+        {
+            if (SyntaxTriviaUtilities.IsDirectiveOrDisabledTextTrivia(trivia))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Ensures sibling statements in a block start on separate lines
     /// </summary>
     /// <param name="node">The block node</param>
@@ -86,7 +123,8 @@ internal sealed class LineBreakBlockRewriter : CSharpSyntaxRewriter
                 continue;
             }
 
-            if (TokenGapUtilities.CountBlankLinesBetween(previousToken, currentToken) > 1)
+            if (TokenGapUtilities.CountBlankLinesBetween(previousToken, currentToken) > 1
+                && GapCarriesDirectiveOrDisabledText(previousToken, currentToken) == false)
             {
                 statements[statementIndex] = _gapNormalizer.NormalizeGapBeforeToken(statements[statementIndex], currentToken, blankLineCount: 1);
                 modified = true;
@@ -132,7 +170,8 @@ internal sealed class LineBreakBlockRewriter : CSharpSyntaxRewriter
                 continue;
             }
 
-            if (TokenGapUtilities.CountBlankLinesBetween(previousToken, currentToken) > 1)
+            if (TokenGapUtilities.CountBlankLinesBetween(previousToken, currentToken) > 1
+                && GapCarriesDirectiveOrDisabledText(previousToken, currentToken) == false)
             {
                 statements[statementIndex] = _gapNormalizer.NormalizeGapBeforeToken(statements[statementIndex], currentToken, blankLineCount: 1);
                 modified = true;


### PR DESCRIPTION
## Summary

Fixes a formatter defect where a single, correctly-authored blank line between a statement and a following preprocessor directive (`#if`, `#pragma`, `#nullable`, `#line`, `#warning`, `#region`, disabled text) was doubled on format. The doubling only occurred when a blank line already existed on **both** sides of the directive block — an `#if` whose active branch supplies a real statement was never affected.

## Why

Closes #695. `LineBreakBlockRewriter.EnsureStatementsStartOnSeparateLines` decides whether a statement gap has "too many" blank lines by summing blank lines across the *entire* gap, including both sides of any directive/disabled-text trivia in between. Two independent single-blank-line runs (one before the directive, one after) summed to 2, tripping the "collapse to one" correction — which then rewrote only the leading run and re-added a line break the earlier `BlankLinePhase` had already gotten right, since `BlankLinePhase` correctly collapses each blank-line run independently and runs earlier in the same formatting pass. The fix withholds this rewriter's own correction whenever the gap contains a directive or disabled text, deferring entirely to `BlankLinePhase`'s already-correct, per-run answer.

As a side effect, the formatter's previous output for this shape actually violated its own `RH5023` (no multiple blank lines in a row) analyzer — this closes that formatter/analyzer parity gap too.

## Linked issues

Closes #695

## Review notes

- Fix is scoped to `Reihitsu.Formatter/Pipeline/LineBreaks/Rewriter/LineBreakBlockRewriter.cs` only (both the block and switch-section overloads) — the shared `TokenGapNormalizer` used by other line-break rewriters is untouched.
- Three existing tests in `BlankLineBeforeTrailingScopeCommentTests.cs` had asserted the doubled blank line as their expected output on purpose, with a comment noting it as "a separate, pre-existing, unowned behavior" left over from #703/#694; their expected strings and doc comments are updated here. One test in `RegionFormattingFullPipelineTests.cs` had the same doubled-blank-line artifact before `#endregion` and is corrected the same way.
- A full regression matrix covers: the numeric blank-line boundary combinations on each side of the directive (collapsing correctly without regressing the already-correct one-sided cases), switch sections, every relevant directive kind, `#region`/`#endregion`, an active `#if` branch (unaffected), member lists and top-level statements (unaffected — different node kinds entirely), an adjacent empty statement (unaffected), and the trailing-directive-with-no-following-statement shape (deliberately unchanged — a different, unrelated existing behavior, frozen here as a non-goal).
- An independent preflight audit passed with no findings; a full solution validation (5216 tests across all 6 projects, including the whole-repository formatter idempotency self-hosting suite) is green.

## Follow-up work

- #711 — a directive block that is the *last* content of a block still loses its own blank line entirely (a different, pre-existing defect owned by `BlankLineTokenCleanupRewriter`, in the opposite direction of this issue) — frozen here by a regression test.
- #712 — a possible trailing-comma loss in conditionally-compiled array/object initializers, observed but not independently reproduced during this issue's investigation.