### PR TITLE
Modernize the Playground UI

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "reihitsu-playground",
+      "runtimeExecutable": "dotnet",
+      "runtimeArgs": ["run", "--project", "Reihitsu.Playground/Reihitsu.Playground.csproj", "--launch-profile", "http"],
+      "port": 5110
+    }
+  ]
+}

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -5,11 +5,6 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 concurrency:
   group: pages
   cancel-in-progress: true
@@ -17,6 +12,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
@@ -44,6 +41,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/Reihitsu.Formatter/Pipeline/Indentation/Utilities/LayoutModel.cs
+++ b/Reihitsu.Formatter/Pipeline/Indentation/Utilities/LayoutModel.cs
@@ -53,6 +53,19 @@ internal sealed class LayoutModel
     }
 
     /// <summary>
+    /// Tries to get the layout for the given token by looking up its line number
+    /// </summary>
+    /// <param name="token">The syntax token</param>
+    /// <param name="layout">The layout if found</param>
+    /// <returns><see langword="true"/> if a layout was found; otherwise, <see langword="false"/></returns>
+    public bool TryGetLayout(SyntaxToken token, out TokenLayout layout)
+    {
+        var lineNumber = token.GetLocation().GetLineSpan().StartLinePosition.Line;
+
+        return _layouts.TryGetValue(lineNumber, out layout);
+    }
+
+    /// <summary>
     /// Captures the current column of every entry, so a later state can be compared against it.
     /// Only the columns are captured: the <see cref="TokenLayout.Source"/> label is a debug aid and
     /// two states that differ only in which contributor last wrote the same column are equivalent
@@ -92,19 +105,6 @@ internal sealed class LayoutModel
         }
 
         return true;
-    }
-
-    /// <summary>
-    /// Tries to get the layout for the given token by looking up its line number
-    /// </summary>
-    /// <param name="token">The syntax token</param>
-    /// <param name="layout">The layout if found</param>
-    /// <returns><see langword="true"/> if a layout was found; otherwise, <see langword="false"/></returns>
-    public bool TryGetLayout(SyntaxToken token, out TokenLayout layout)
-    {
-        var lineNumber = token.GetLocation().GetLineSpan().StartLinePosition.Line;
-
-        return _layouts.TryGetValue(lineNumber, out layout);
     }
 
     /// <summary>

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/Rewriter/LineBreakBlockRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/Rewriter/LineBreakBlockRewriter.cs
@@ -70,23 +70,8 @@ internal sealed class LineBreakBlockRewriter : CSharpSyntaxRewriter
     /// </remarks>
     private static bool GapCarriesDirectiveOrDisabledText(SyntaxToken previousToken, SyntaxToken currentToken)
     {
-        foreach (var trivia in previousToken.TrailingTrivia)
-        {
-            if (SyntaxTriviaUtilities.IsDirectiveOrDisabledTextTrivia(trivia))
-            {
-                return true;
-            }
-        }
-
-        foreach (var trivia in currentToken.LeadingTrivia)
-        {
-            if (SyntaxTriviaUtilities.IsDirectiveOrDisabledTextTrivia(trivia))
-            {
-                return true;
-            }
-        }
-
-        return false;
+        return previousToken.TrailingTrivia.Any(SyntaxTriviaUtilities.IsDirectiveOrDisabledTextTrivia)
+               || currentToken.LeadingTrivia.Any(SyntaxTriviaUtilities.IsDirectiveOrDisabledTextTrivia);
     }
 
     /// <summary>

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/Utilities/TokenGapNormalizer.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/Utilities/TokenGapNormalizer.cs
@@ -366,15 +366,7 @@ internal sealed class TokenGapNormalizer
     /// <returns><see langword="true"/> if a directive or disabled text is present; otherwise, <see langword="false"/></returns>
     private static bool ContainsDirectiveOrDisabledText(SyntaxTriviaList triviaList)
     {
-        foreach (var trivia in triviaList)
-        {
-            if (SyntaxTriviaUtilities.IsDirectiveOrDisabledTextTrivia(trivia))
-            {
-                return true;
-            }
-        }
-
-        return false;
+        return triviaList.Any(SyntaxTriviaUtilities.IsDirectiveOrDisabledTextTrivia);
     }
 
     /// <summary>

--- a/Reihitsu.Formatter/Pipeline/SwitchCaseBraces/Rewriter/SwitchCaseBraceRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/SwitchCaseBraces/Rewriter/SwitchCaseBraceRewriter.cs
@@ -414,6 +414,29 @@ internal sealed class SwitchCaseBraceRewriter : CSharpSyntaxRewriter
     }
 
     /// <summary>
+    /// Determines whether any non-fall-through section in the switch spans multiple lines
+    /// </summary>
+    /// <param name="sections">The switch sections to inspect</param>
+    /// <returns><see langword="true"/> if at least one non-fall-through section is multi-line; otherwise, <see langword="false"/></returns>
+    private static bool HasAnyMultiLineSection(SyntaxList<SwitchSectionSyntax> sections)
+    {
+        foreach (var section in sections)
+        {
+            if (IsFallThroughSection(section))
+            {
+                continue;
+            }
+
+            if (IsMultiLineSection(section))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Adds braces around the non-terminal statements of a switch section.
     /// If braces already exist, the section is returned as-is
     /// </summary>
@@ -512,6 +535,45 @@ internal sealed class SwitchCaseBraceRewriter : CSharpSyntaxRewriter
         return section.WithStatements(SyntaxFactory.List(sectionStatements));
     }
 
+    /// <summary>
+    /// Builds the rewritten sections for a switch statement, adding or removing braces as appropriate
+    /// </summary>
+    /// <param name="sections">The original switch sections</param>
+    /// <param name="anyMultiLine">Whether any non-fall-through section in the switch is multi-line</param>
+    /// <returns>The rewritten sections</returns>
+    private List<SwitchSectionSyntax> BuildSections(SyntaxList<SwitchSectionSyntax> sections, bool anyMultiLine)
+    {
+        var newSections = new List<SwitchSectionSyntax>(sections.Count);
+
+        foreach (var section in sections)
+        {
+            newSections.Add(BuildSection(section, anyMultiLine));
+        }
+
+        return newSections;
+    }
+
+    /// <summary>
+    /// Builds the rewritten form of a single switch section
+    /// </summary>
+    /// <param name="section">The original switch section</param>
+    /// <param name="anyMultiLine">Whether any non-fall-through section in the switch is multi-line</param>
+    /// <returns>The rewritten section</returns>
+    private SwitchSectionSyntax BuildSection(SwitchSectionSyntax section, bool anyMultiLine)
+    {
+        if (IsFallThroughSection(section))
+        {
+            return section;
+        }
+
+        if (anyMultiLine == false)
+        {
+            return RemoveBraces(section);
+        }
+
+        return IsEmptySection(section) ? section : AddBraces(section);
+    }
+
     #endregion // Methods
 
     #region CSharpSyntaxVisitor
@@ -535,55 +597,14 @@ internal sealed class SwitchCaseBraceRewriter : CSharpSyntaxRewriter
             return node;
         }
 
-        var anyMultiLine = false;
-
-        foreach (var section in sections)
-        {
-            if (IsFallThroughSection(section))
-            {
-                continue;
-            }
-
-            if (IsMultiLineSection(section))
-            {
-                anyMultiLine = true;
-
-                break;
-            }
-        }
+        var anyMultiLine = HasAnyMultiLineSection(sections);
 
         if (anyMultiLine && HasCrossSectionGotoTarget(node))
         {
             return node;
         }
 
-        var newSections = new List<SwitchSectionSyntax>(sections.Count);
-
-        foreach (var section in sections)
-        {
-            if (IsFallThroughSection(section))
-            {
-                newSections.Add(section);
-
-                continue;
-            }
-
-            if (anyMultiLine)
-            {
-                var newSection = section;
-
-                if (IsEmptySection(section) == false)
-                {
-                    newSection = AddBraces(section);
-                }
-
-                newSections.Add(newSection);
-            }
-            else
-            {
-                newSections.Add(RemoveBraces(section));
-            }
-        }
+        var newSections = BuildSections(sections, anyMultiLine);
 
         return node.WithSections(SyntaxFactory.List(newSections));
     }

--- a/Reihitsu.Playground/App.razor
+++ b/Reihitsu.Playground/App.razor
@@ -1,6 +1,5 @@
 ﻿<Router AppAssembly="@typeof(App).Assembly" NotFoundPage="typeof(Pages.NotFound)">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)"/>
-        <FocusOnNavigate RouteData="@routeData" Selector="h1" />
     </Found>
 </Router>

--- a/Reihitsu.Playground/Layout/MainLayout.razor
+++ b/Reihitsu.Playground/Layout/MainLayout.razor
@@ -1,3 +1,21 @@
-﻿@inherits LayoutComponentBase
+@inherits LayoutComponentBase
 
-@Body
+<div class="app-shell">
+    <header class="app-header">
+        <div class="app-header-inner">
+            <span class="app-title">Reihitsu Playground</span>
+        </div>
+    </header>
+
+    <main class="app-main">
+        @Body
+    </main>
+
+    <footer class="app-footer">
+        <span>Reihitsu</span>
+        <span class="app-footer-sep">&middot;</span>
+        <span>v@(PlaygroundVersion.FormatterVersion)</span>
+        <span class="app-footer-sep">&middot;</span>
+        <span>&copy; 2026 Seth (thoenissen)</span>
+    </footer>
+</div>

--- a/Reihitsu.Playground/Pages/Home.razor
+++ b/Reihitsu.Playground/Pages/Home.razor
@@ -2,9 +2,9 @@
 
 <PageTitle>Reihitsu Playground</PageTitle>
 
-<h1>Reihitsu Playground</h1>
+<h1>Format C# with Reihitsu</h1>
 <p>
-    Paste C# source below and format it with the Reihitsu formatter, built from the latest commit on <code>main</code>.
+    Paste C# source below and format it with the Reihitsu formatter.
     Formatting runs entirely in your browser; nothing is uploaded anywhere.
 </p>
 

--- a/Reihitsu.Playground/Pages/Home.razor.cs
+++ b/Reihitsu.Playground/Pages/Home.razor.cs
@@ -8,9 +8,14 @@ public partial class Home
     #region Fields
 
     /// <summary>
+    /// Example C# source shown on first load, before the user edits it
+    /// </summary>
+    private const string ExampleSource = "public class Sample{public int Add(int a,int b){return a+b;}}";
+
+    /// <summary>
     /// The user-entered C# source
     /// </summary>
-    private string _input = string.Empty;
+    private string _input = ExampleSource;
 
     /// <summary>
     /// The most recently formatted output
@@ -38,4 +43,14 @@ public partial class Home
     }
 
     #endregion // Methods
+
+    #region ComponentBase
+
+    /// <inheritdoc/>
+    protected override void OnInitialized()
+    {
+        FormatInput();
+    }
+
+    #endregion // ComponentBase
 }

--- a/Reihitsu.Playground/PlaygroundVersion.cs
+++ b/Reihitsu.Playground/PlaygroundVersion.cs
@@ -1,0 +1,20 @@
+﻿using System.Reflection;
+
+using Reihitsu.Formatter;
+
+namespace Reihitsu.Playground;
+
+/// <summary>
+/// Exposes version information about the underlying Reihitsu formatter for display in the UI
+/// </summary>
+public static class PlaygroundVersion
+{
+    #region Properties
+
+    /// <summary>
+    /// The informational version of the Reihitsu formatter assembly, or an empty string if it could not be determined
+    /// </summary>
+    public static string FormatterVersion { get; } = typeof(ReihitsuFormatter).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? string.Empty;
+
+    #endregion // Properties
+}

--- a/Reihitsu.Playground/wwwroot/css/app.css
+++ b/Reihitsu.Playground/wwwroot/css/app.css
@@ -1,7 +1,114 @@
+:root {
+    --color-canvas: #ffffff;
+    --color-canvas-subtle: #f6f8fa;
+    --color-border: #d0d7de;
+    --color-fg: #1f2328;
+    --color-fg-muted: #59636e;
+    --color-accent: #0969da;
+    --color-accent-emphasis: #0550ae;
+    --color-success: #2da44e;
+    --color-success-emphasis: #2c974b;
+    --color-danger: #cf222e;
+    --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif;
+    --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", monospace;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --color-canvas: #0d1117;
+        --color-canvas-subtle: #161b22;
+        --color-border: #30363d;
+        --color-fg: #e6edf3;
+        --color-fg-muted: #8b949e;
+        --color-accent: #4493f8;
+        --color-accent-emphasis: #58a6ff;
+        --color-success: #238636;
+        --color-success-emphasis: #2ea043;
+    }
+}
+
+html, body {
+    margin: 0;
+    background: var(--color-canvas);
+    color: var(--color-fg);
+    font-family: var(--font-sans);
+}
+
+#app {
+    min-height: 100vh;
+}
+
+.app-shell {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+.app-header {
+    border-bottom: 1px solid var(--color-border);
+    background: var(--color-canvas-subtle);
+}
+
+.app-header-inner {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0.9rem 1.5rem;
+}
+
+.app-title {
+    font-weight: 600;
+    font-size: 1rem;
+    letter-spacing: 0.01em;
+}
+
+.app-main {
+    flex: 1 0 auto;
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 1.75rem 1.5rem;
+    box-sizing: border-box;
+}
+
+.app-main h1 {
+    font-size: 1.375rem;
+    font-weight: 600;
+    margin: 0 0 0.5rem;
+}
+
+.app-main > p {
+    color: var(--color-fg-muted);
+    margin: 0 0 1.5rem;
+}
+
+.app-footer {
+    flex-shrink: 0;
+    border-top: 1px solid var(--color-border);
+    background: var(--color-canvas-subtle);
+    color: var(--color-fg-muted);
+    font-size: 0.75rem;
+    text-align: center;
+    padding: 0.85rem 1.5rem;
+}
+
+.app-footer-sep {
+    margin: 0 0.4rem;
+}
+
 .playground-grid {
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 1rem;
+}
+
+@media (max-width: 700px) {
+    .playground-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .playground-column textarea {
+        height: 40vh;
+    }
 }
 
 .playground-column {
@@ -10,20 +117,50 @@
 }
 
 .playground-column label {
-    font-weight: bold;
-    margin-bottom: 0.25rem;
+    font-weight: 600;
+    font-size: 0.85rem;
+    color: var(--color-fg-muted);
+    margin-bottom: 0.4rem;
 }
 
 .playground-column textarea {
     height: 60vh;
-    font-family: ui-monospace, Consolas, "Courier New", monospace;
+    font-family: var(--font-mono);
     font-size: 0.875rem;
     tab-size: 4;
-    resize: vertical;
+    resize: none;
+    background: var(--color-canvas);
+    color: var(--color-fg);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    padding: 0.75rem;
+    box-sizing: border-box;
+}
+
+.playground-column textarea:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: -1px;
+}
+
+button[type="button"] {
+    margin-top: 1rem;
+    padding: 0.5rem 1.1rem;
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #ffffff;
+    background: var(--color-success);
+    border: 1px solid transparent;
+    border-radius: 6px;
+    cursor: pointer;
+}
+
+button[type="button"]:hover {
+    background: var(--color-success-emphasis);
 }
 
 .playground-message {
-    color: #b32121;
+    color: var(--color-danger);
+    font-size: 0.875rem;
 }
 
 .valid.modified:not([type=checkbox]) {

--- a/Reihitsu.Playground/wwwroot/index.html
+++ b/Reihitsu.Playground/wwwroot/index.html
@@ -8,8 +8,6 @@
     <base href="/" />
     <link rel="preload" id="webassembly" />
     <link rel="stylesheet" href="css/app.css" />
-    <!-- If you add any scoped CSS files, uncomment the following to load them
-    <link href="Reihitsu.Playground.styles.css" rel="stylesheet" /> -->
     <script type="importmap"></script>
 </head>
 


### PR DESCRIPTION
## Summary

Redesigns `Reihitsu.Playground` (the GitHub Pages formatter demo) with a GitHub/sharplab-inspired look and fixes the rough edges from the initial cut:

- Header/footer chrome; footer shows the Reihitsu.Formatter version, name, and copyright instead of the old "built from latest commit on main" line
- Cleaner H1, GitHub-green Format button, full-width intro text
- Both editor panes preload with example C# source (input and its formatted output) instead of starting empty
- No unwanted auto-focus on page load
- Textareas can no longer drift to different sizes (`resize: none`)
- Responsive: panes stack vertically below 700px