### PR TITLE
Add GitHub link to Playground page

### DIFF
--- a/Reihitsu.Playground/Layout/MainLayout.razor
+++ b/Reihitsu.Playground/Layout/MainLayout.razor
@@ -4,6 +4,7 @@
     <header class="app-header">
         <div class="app-header-inner">
             <span class="app-title">Reihitsu Playground</span>
+            <a class="app-github-link" href="https://github.com/thoenissen/Reihitsu" target="_blank" rel="noopener noreferrer">GitHub</a>
         </div>
     </header>
 

--- a/Reihitsu.Playground/wwwroot/css/app.css
+++ b/Reihitsu.Playground/wwwroot/css/app.css
@@ -50,6 +50,9 @@ html, body {
 }
 
 .app-header-inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
     max-width: 1200px;
     margin: 0 auto;
     padding: 0.9rem 1.5rem;
@@ -59,6 +62,17 @@ html, body {
     font-weight: 600;
     font-size: 1rem;
     letter-spacing: 0.01em;
+}
+
+.app-github-link {
+    color: var(--color-fg-muted);
+    font-size: 0.85rem;
+    text-decoration: none;
+}
+
+.app-github-link:hover {
+    color: var(--color-fg);
+    text-decoration: underline;
 }
 
 .app-main {


### PR DESCRIPTION
## Summary

Adds a link to the GitHub repository (`https://github.com/thoenissen/Reihitsu`) in the Playground page's header.

## Why

The Playground page had no link back to the project's GitHub repository.

## Linked issues

None.

## Review notes

Purely additive UI change: a header link plus matching CSS in `Reihitsu.Playground`. No analyzer, formatter, or core behavior touched.

## Follow-up work

None.

---
_Generated by [Claude Code](https://claude.ai/code/session_013FZqPTgJvXCGMatST96DZj)_