### PR TITLE
Preserve blank line before a trailing directive with no following statement

### DIFF
--- a/Reihitsu.Formatter.Test/Regression/BlankLines/BlankLineBeforeIfDirectiveAfterStatementTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/BlankLines/BlankLineBeforeIfDirectiveAfterStatementTests.cs
@@ -1147,6 +1147,185 @@ public class BlankLineBeforeIfDirectiveAfterStatementTests : FormatterTestsBase
     }
 
     /// <summary>
+    /// Verifies that a blank line directly above a chained <c>else</c> keyword, after a trailing
+    /// directive, is removed — the same rule as <see cref="BlankLineOnlyAfterTrailingDirectiveWritesNeitherBlankLine"/>,
+    /// but for an anchor that <see cref="Pipeline.LineBreaks.Utilities.TokenGapNormalizer"/>'s node-scoped
+    /// calls cannot reach, so <see cref="Pipeline.BlankLines.Rewriter.BlankLineTokenCleanupRewriter"/> must
+    /// enforce it directly (issue #711)
+    /// </summary>
+    [TestMethod]
+    public void BlankLineOnlyAfterTrailingDirectiveBeforeElseIsRemoved()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start(bool flag)
+                                 {
+                                     if (flag)
+                                     {
+                                     }
+                             #pragma warning disable CA1801
+
+                                     else
+                                     {
+                                     }
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public void Start(bool flag)
+                                    {
+                                        if (flag)
+                                        {
+                                        }
+                                #pragma warning disable CA1801
+                                        else
+                                        {
+                                        }
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a blank line directly above a chained <c>catch</c> keyword, after a trailing
+    /// directive, is removed (issue #711)
+    /// </summary>
+    [TestMethod]
+    public void BlankLineOnlyAfterTrailingDirectiveBeforeCatchIsRemoved()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     try
+                                     {
+                                     }
+                             #pragma warning disable CA1801
+
+                                     catch
+                                     {
+                                     }
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public void Start()
+                                    {
+                                        try
+                                        {
+                                        }
+                                #pragma warning disable CA1801
+                                        catch
+                                        {
+                                        }
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a blank line directly above a chained <c>finally</c> keyword, after a trailing
+    /// directive, is removed (issue #711)
+    /// </summary>
+    [TestMethod]
+    public void BlankLineOnlyAfterTrailingDirectiveBeforeFinallyIsRemoved()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     try
+                                     {
+                                     }
+                             #pragma warning disable CA1801
+
+                                     finally
+                                     {
+                                     }
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public void Start()
+                                    {
+                                        try
+                                        {
+                                        }
+                                #pragma warning disable CA1801
+                                        finally
+                                        {
+                                        }
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a blank line directly above a do-<c>while</c> footer, after a trailing directive,
+    /// is removed (issue #711)
+    /// </summary>
+    [TestMethod]
+    public void BlankLineOnlyAfterTrailingDirectiveBeforeDoWhileFooterIsRemoved()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     do
+                                     {
+                                     }
+                             #pragma warning disable CA1801
+
+                                     while (true);
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public void Start()
+                                    {
+                                        do
+                                        {
+                                        }
+                                #pragma warning disable CA1801
+                                        while (true);
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
     /// Verifies that a blank line before a trailing directive ahead of a type declaration's closing
     /// brace is preserved — the same guard reached through a different owning rewriter (issue #711)
     /// </summary>
@@ -1193,6 +1372,51 @@ public class BlankLineBeforeIfDirectiveAfterStatementTests : FormatterTestsBase
                                     Green
 
                                 #pragma warning restore CA1008
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies a gap that carries both a trailing directive and, after it, an own-line ordinary
+    /// comment: the blank line before the directive is preserved (this fix's own rule), and the blank
+    /// line between the comment and the closing brace is removed — the comment stays directly attached,
+    /// matching <see cref="BlankLineBeforeTrailingScopeCommentTests.BlankLineDirectlyBeforeClosingBraceIsRemovedWhenTrailingCommentPrecedesIt"/>.
+    /// Neither behavior is owned by this fix: the leading blank survives because a directive precedes
+    /// it anywhere in the gap, and the trailing blank is removed by the pre-existing own-line-comment
+    /// rule, which the last significant trivia here — the comment, not the directive — still reaches
+    /// (issue #711)
+    /// </summary>
+    [TestMethod]
+    public void BlankLineBeforeDirectiveThenOwnLineCommentKeepsLeadingBlankRemovesTrailingBlank()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     var bar = "foo1";
+
+                             #pragma warning disable CA1801
+                                     // trailing note
+
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public void Start()
+                                    {
+                                        var bar = "foo1";
+
+                                #pragma warning disable CA1801
+                                        // trailing note
+                                    }
                                 }
                                 """;
 

--- a/Reihitsu.Formatter.Test/Regression/BlankLines/BlankLineBeforeIfDirectiveAfterStatementTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/BlankLines/BlankLineBeforeIfDirectiveAfterStatementTests.cs
@@ -717,12 +717,12 @@ public class BlankLineBeforeIfDirectiveAfterStatementTests : FormatterTestsBase
     }
 
     /// <summary>
-    /// Verifies that a directive block that is the last content of a block still loses the blank line
-    /// above it — a separate, pre-existing behavior of <see cref="Pipeline.BlankLines.Rewriter.BlankLineTokenCleanupRewriter"/>
-    /// that issue #695 does not own or change, frozen here so a future change cannot alter it silently
+    /// Verifies that a blank line before a directive block that is the last content of a block is
+    /// preserved, matching the "blank lines are preserved unless there's a reason to change them"
+    /// policy applied everywhere else in the formatter (issue #711)
     /// </summary>
     [TestMethod]
-    public void TrailingDirectiveWithNoFollowingStatementStillLosesItsBlankLine()
+    public void TrailingDirectiveWithNoFollowingStatementKeepsItsBlankLine()
     {
         // Arrange
         const string input = """
@@ -739,6 +739,396 @@ public class BlankLineBeforeIfDirectiveAfterStatementTests : FormatterTestsBase
                              }
                              """;
 
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a blank line before a directive that is the last content ahead of an opening
+    /// brace is preserved (issue #711)
+    /// </summary>
+    [TestMethod]
+    public void TrailingDirectiveBeforeOpenBraceKeepsItsBlankLine()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+
+                             #pragma warning disable CA1801
+                                 {
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a blank line before a directive that is the last content ahead of an <c>else</c>
+    /// keyword is preserved (issue #711)
+    /// </summary>
+    [TestMethod]
+    public void TrailingDirectiveBeforeElseKeepsItsBlankLine()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start(bool flag)
+                                 {
+                                     if (flag)
+                                     {
+                                     }
+
+                             #pragma warning disable CA1801
+                                     else
+                                     {
+                                     }
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a blank line before a directive that is the last content ahead of a <c>catch</c>
+    /// keyword is preserved (issue #711)
+    /// </summary>
+    [TestMethod]
+    public void TrailingDirectiveBeforeCatchKeepsItsBlankLine()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     try
+                                     {
+                                     }
+
+                             #pragma warning disable CA1801
+                                     catch
+                                     {
+                                     }
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a blank line before a directive that is the last content ahead of a
+    /// <c>finally</c> keyword is preserved (issue #711)
+    /// </summary>
+    [TestMethod]
+    public void TrailingDirectiveBeforeFinallyKeepsItsBlankLine()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     try
+                                     {
+                                     }
+
+                             #pragma warning disable CA1801
+                                     finally
+                                     {
+                                     }
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a blank line before a directive that is the last content ahead of a do-<c>while</c>
+    /// footer is preserved (issue #711)
+    /// </summary>
+    [TestMethod]
+    public void TrailingDirectiveBeforeDoWhileFooterKeepsItsBlankLine()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     do
+                                     {
+                                     }
+
+                             #pragma warning disable CA1801
+                                     while (true);
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a blank line before disabled text (an inactive <c>#if false</c> branch) that is
+    /// the last content of a block is preserved (issue #711)
+    /// </summary>
+    [TestMethod]
+    public void TrailingDisabledTextWithNoFollowingStatementKeepsItsBlankLine()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     var bar = "foo1";
+
+                             #if false
+                                     bar = "foo2";
+                             #endif
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a blank line before a <c>#nullable</c> directive that is the last content of a
+    /// block is preserved (issue #711)
+    /// </summary>
+    [TestMethod]
+    public void TrailingNullableDirectiveWithNoFollowingStatementKeepsItsBlankLine()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     var bar = "foo1";
+
+                             #nullable disable
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that two blank lines before a trailing directive collapse to one rather than to zero
+    /// (issue #711)
+    /// </summary>
+    [TestMethod]
+    public void ExcessBlankLinesBeforeTrailingDirectiveCollapseToOne()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     var bar = "foo1";
+
+
+                             #if DEBUG
+                                     bar = "foo2";
+                             #endif
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public void Start()
+                                    {
+                                        var bar = "foo1";
+
+                                #if DEBUG
+                                        bar = "foo2";
+                                #endif
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a blank line directly above a closing brace, with no directive interposed, is
+    /// still removed — the guard's non-exempt boundary, matching RH5024 (issue #711)
+    /// </summary>
+    [TestMethod]
+    public void BlankLineDirectlyAboveClosingBraceWithNoDirectiveIsStillRemoved()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     var bar = "foo1";
+
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public void Start()
+                                    {
+                                        var bar = "foo1";
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a blank line directly after an opening brace, ahead of a directive block that is
+    /// the block's only content, is still removed — RH5022's region, untouched by this fix (issue #711)
+    /// </summary>
+    [TestMethod]
+    public void BlankLineAfterOpenBraceBeforeDirectiveBlockIsStillRemoved()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+
+                             #if DEBUG
+                                     var bar = "foo1";
+                             #endif
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public void Start()
+                                    {
+                                #if DEBUG
+                                        var bar = "foo1";
+                                #endif
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a blank line at the very start of the file, ahead of a directive, is still
+    /// removed — RH5028's region, untouched by this fix (issue #711)
+    /// </summary>
+    [TestMethod]
+    public void BlankLineAtFileStartBeforeDirectiveIsStillRemoved()
+    {
+        // Arrange
+        const string input = """
+
+                             #pragma warning disable CA1801
+                             var bar = "foo1";
+                             """;
+
+        const string expected = """
+                                #pragma warning disable CA1801
+                                var bar = "foo1";
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that when a blank line precedes a trailing directive and another blank line follows it
+    /// directly above the closing brace, the first is preserved and the second is removed — the two
+    /// owners of this fix now agree with each other and with RH5024 (issue #711)
+    /// </summary>
+    [TestMethod]
+    public void BlankLineBeforeAndAfterTrailingDirectiveKeepsOnlyTheFirst()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     var bar = "foo1";
+
+                             #if DEBUG
+                                     bar = "foo2";
+                             #endif
+
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public void Start()
+                                    {
+                                        var bar = "foo1";
+
+                                #if DEBUG
+                                        bar = "foo2";
+                                #endif
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that when no blank line precedes a trailing directive but one follows it directly
+    /// above the closing brace, neither blank line is written — no unauthored insertion, and the
+    /// RH5024-flagged blank line is removed (issue #711)
+    /// </summary>
+    [TestMethod]
+    public void BlankLineOnlyAfterTrailingDirectiveWritesNeitherBlankLine()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     var bar = "foo1";
+                             #if DEBUG
+                                     bar = "foo2";
+                             #endif
+
+                                 }
+                             }
+                             """;
+
         const string expected = """
                                 public class Implementation
                                 {
@@ -748,6 +1138,221 @@ public class BlankLineBeforeIfDirectiveAfterStatementTests : FormatterTestsBase
                                 #if DEBUG
                                         bar = "foo2";
                                 #endif
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a blank line before a trailing directive ahead of a type declaration's closing
+    /// brace is preserved — the same guard reached through a different owning rewriter (issue #711)
+    /// </summary>
+    [TestMethod]
+    public void TrailingDirectiveBeforeTypeDeclarationClosingBraceKeepsItsBlankLine()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 private int _a;
+
+                             #pragma warning restore CA1802
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a blank line before a trailing directive ahead of an enum's closing brace is
+    /// preserved — the trailing comma on the last member is a separate, pre-existing structural
+    /// decision this fix does not own (issue #711)
+    /// </summary>
+    [TestMethod]
+    public void TrailingDirectiveBeforeEnumClosingBraceKeepsItsBlankLine()
+    {
+        // Arrange
+        const string input = """
+                             public enum Color
+                             {
+                                 Red,
+                                 Green,
+
+                             #pragma warning restore CA1008
+                             }
+                             """;
+
+        const string expected = """
+                                public enum Color
+                                {
+                                    Red,
+                                    Green
+
+                                #pragma warning restore CA1008
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a blank line before a trailing directive ahead of a property accessor list's
+    /// closing brace is preserved (issue #711)
+    /// </summary>
+    [TestMethod]
+    public void TrailingDirectiveBeforePropertyAccessorListClosingBraceKeepsItsBlankLine()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public int Value
+                                 {
+                                     get
+                                     {
+                                         return _value;
+                                     }
+
+                             #pragma warning restore CA1822
+                                 }
+                             }
+                             """;
+
+        // Act & Assert
+        AssertRuleResult(input);
+    }
+
+    /// <summary>
+    /// Verifies that a blank line before a trailing directive ahead of an object initializer's closing
+    /// brace is preserved (issue #711)
+    /// </summary>
+    [TestMethod]
+    public void TrailingDirectiveBeforeInitializerClosingBraceKeepsItsBlankLine()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     var data = new Data
+                                     {
+                                         Value = 1
+
+                             #pragma warning restore CA1861
+                                     };
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public void Start()
+                                    {
+                                        var data = new Data
+                                                   {
+                                                       Value = 1
+
+                                #pragma warning restore CA1861
+                                                   };
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a blank line before a trailing directive ahead of a closing bracket is left
+    /// unchanged — a closing bracket is not one of this fix's anchor tokens (issue #711)
+    /// </summary>
+    [TestMethod]
+    public void TrailingDirectiveBeforeCloseBracketIsUnaffected()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     int[] values =
+                                     [
+                                         1,
+                                         2
+
+                             #pragma warning restore CA1861
+                                     ];
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public void Start()
+                                    {
+                                        int[] values = [
+                                                           1,
+                                                           2
+
+                                #pragma warning restore CA1861
+                                                       ];
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a blank line before a trailing directive ahead of a closing parenthesis is left
+    /// unchanged — a closing parenthesis is not one of this fix's anchor tokens (issue #711)
+    /// </summary>
+    [TestMethod]
+    public void TrailingDirectiveBeforeCloseParenIsUnaffected()
+    {
+        // Arrange
+        const string input = """
+                             public class Implementation
+                             {
+                                 public void Start()
+                                 {
+                                     Method(
+                                         1,
+                                         2
+
+                             #pragma warning restore CA1861
+                                     );
+                                 }
+
+                                 private static void Method(int a, int b)
+                                 {
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                public class Implementation
+                                {
+                                    public void Start()
+                                    {
+                                        Method(1,
+                                               2
+
+                                #pragma warning restore CA1861
+                                               );
+                                    }
+
+                                    private static void Method(int a, int b)
+                                    {
                                     }
                                 }
                                 """;

--- a/Reihitsu.Formatter.Test/Unit/LineBreaks/TokenGapNormalizerTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/LineBreaks/TokenGapNormalizerTests.cs
@@ -97,7 +97,7 @@ public class TokenGapNormalizerTests
         var result = normalizer.NormalizeLeadingGap(token, blankLineCount: 0);
 
         // Assert
-        Assert.Contains("\n\n#pragma", result.ToFullString(), "The blank line ahead of the directive must be preserved.");
+        Assert.AreEqual("\n\n#pragma warning disable CA1801\n}", result.ToFullString(), "The blank line ahead of the directive must be preserved.");
     }
 
     /// <summary>
@@ -117,7 +117,7 @@ public class TokenGapNormalizerTests
         var result = normalizer.NormalizeLeadingGap(token, blankLineCount: 0);
 
         // Assert
-        Assert.DoesNotContain("\n\n", result.ToFullString(), "No blank line should remain directly above the token when the directive already ends its own line.");
+        Assert.AreEqual("#pragma warning disable CA1801\n}", result.ToFullString(), "No blank line should remain directly above the token when the directive already ends its own line.");
     }
 
     #endregion // Methods

--- a/Reihitsu.Formatter.Test/Unit/LineBreaks/TokenGapNormalizerTests.cs
+++ b/Reihitsu.Formatter.Test/Unit/LineBreaks/TokenGapNormalizerTests.cs
@@ -79,5 +79,46 @@ public class TokenGapNormalizerTests
         Assert.Contains("\n", result.ToFullString(), "A line break should be inserted before the second statement.");
     }
 
+    /// <summary>
+    /// Verifies that a directive gap whose last significant trivia embeds its own terminating line
+    /// break (a directive always ends its own line, unlike a comment) still keeps the blank-line run
+    /// preceding it, since that run belongs to the directive's own placement, not to the token's
+    /// adjacency requirement (issue #711)
+    /// </summary>
+    [TestMethod]
+    public void NormalizeLeadingGapPreservesBlankLineBeforeDirective()
+    {
+        // Arrange
+        var leadingTrivia = SyntaxFactory.ParseLeadingTrivia("\n\n#pragma warning disable CA1801\n");
+        var token = SyntaxFactory.Token(leadingTrivia, SyntaxKind.CloseBraceToken, SyntaxFactory.TriviaList());
+        var normalizer = new TokenGapNormalizer("\n");
+
+        // Act
+        var result = normalizer.NormalizeLeadingGap(token, blankLineCount: 0);
+
+        // Assert
+        Assert.Contains("\n\n#pragma", result.ToFullString(), "The blank line ahead of the directive must be preserved.");
+    }
+
+    /// <summary>
+    /// Verifies that a directive gap emits no further line break after the directive's own embedded
+    /// terminating newline — emitting one unconditionally would recreate a blank line directly adjacent
+    /// to the token that this fix's guard exists to remove (issue #711)
+    /// </summary>
+    [TestMethod]
+    public void NormalizeLeadingGapEmitsNoExtraBreakAfterDirective()
+    {
+        // Arrange
+        var leadingTrivia = SyntaxFactory.ParseLeadingTrivia("#pragma warning disable CA1801\n\n");
+        var token = SyntaxFactory.Token(leadingTrivia, SyntaxKind.CloseBraceToken, SyntaxFactory.TriviaList());
+        var normalizer = new TokenGapNormalizer("\n");
+
+        // Act
+        var result = normalizer.NormalizeLeadingGap(token, blankLineCount: 0);
+
+        // Assert
+        Assert.DoesNotContain("\n\n", result.ToFullString(), "No blank line should remain directly above the token when the directive already ends its own line.");
+    }
+
     #endregion // Methods
 }

--- a/Reihitsu.Formatter/Pipeline/BlankLines/Rewriter/BlankLineTokenCleanupRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/BlankLines/Rewriter/BlankLineTokenCleanupRewriter.cs
@@ -218,13 +218,55 @@ internal sealed class BlankLineTokenCleanupRewriter : CSharpSyntaxRewriter
             return token;
         }
 
-        // The #endregion directive trivia carries its own trailing line break, so any
+        return RemoveExcessBlankLinesAfterIndex(token, endRegionIndex);
+    }
+
+    /// <summary>
+    /// Removes blank lines that appear between a trailing, non-region directive or disabled-text
+    /// block — the last significant trivia in the leading trivia — and the anchor token itself. Unlike
+    /// <see cref="RemoveBlankLinesAfterTrailingEndRegion"/>, which owns the region-specific case, this
+    /// method is the counterpart that lets an anchor token whose own adjacent run <see cref="CollapseLeadingBlankLines"/>
+    /// cannot reach — because a directive or disabled-text block sits between the run it inspects and
+    /// the token — still enforce the "no blank line directly adjacent" rule RH5024/RH5025/RH5026/RH5027
+    /// require, for every anchor kind including the chained keywords <c>else</c>/<c>catch</c>/<c>finally</c>/
+    /// <c>while</c> that <see cref="Pipeline.LineBreaks.Utilities.TokenGapNormalizer"/>'s node-scoped calls
+    /// cannot reach (issue #711)
+    /// </summary>
+    /// <param name="token">The token to update</param>
+    /// <returns>The updated token</returns>
+    private static SyntaxToken RemoveBlankLinesAfterTrailingDirective(SyntaxToken token)
+    {
+        var trivia = token.LeadingTrivia;
+        var lastContentIndex = SyntaxTriviaUtilities.FindLastSignificantTriviaIndex(trivia);
+
+        if (lastContentIndex < 0)
+        {
+            return token;
+        }
+
+        return RemoveExcessBlankLinesAfterIndex(token, lastContentIndex);
+    }
+
+    /// <summary>
+    /// Removes blank lines that appear between the trivia at <paramref name="anchorIndex"/> and the
+    /// token itself, leaving exactly the line break the anchor trivia's own termination requires — zero
+    /// when it already embeds one (see <see cref="BlankLineTriviaUtilities.EndsWithLineBreak"/>), one
+    /// otherwise
+    /// </summary>
+    /// <param name="token">The token to update</param>
+    /// <param name="anchorIndex">The leading-trivia index whose trailing run should be normalized</param>
+    /// <returns>The updated token</returns>
+    private static SyntaxToken RemoveExcessBlankLinesAfterIndex(SyntaxToken token, int anchorIndex)
+    {
+        var trivia = token.LeadingTrivia;
+
+        // The anchor trivia may carry its own trailing line break (a directive or #endregion), so any
         // end-of-line trivia that follows it in the list represents a blank line
         var endOfLineCount = 0;
         var endOfLineText = Environment.NewLine;
         var indentationTrivia = new List<SyntaxTrivia>();
 
-        for (var triviaIndex = endRegionIndex + 1; triviaIndex < trivia.Count; triviaIndex++)
+        for (var triviaIndex = anchorIndex + 1; triviaIndex < trivia.Count; triviaIndex++)
         {
             if (trivia[triviaIndex].IsKind(SyntaxKind.EndOfLineTrivia))
             {
@@ -238,22 +280,22 @@ internal sealed class BlankLineTokenCleanupRewriter : CSharpSyntaxRewriter
             }
             else
             {
-                // A comment or other directive sits between the #endregion and the token — leave it alone
+                // A comment or other directive sits between the anchor trivia and the token — leave it alone
                 return token;
             }
         }
 
-        var endRegionEndsWithLineBreak = BlankLineTriviaUtilities.EndsWithLineBreak(trivia[endRegionIndex]);
-        var requiredLineBreaks = endRegionEndsWithLineBreak ? 0 : 1;
+        var anchorEndsWithLineBreak = BlankLineTriviaUtilities.EndsWithLineBreak(trivia[anchorIndex]);
+        var requiredLineBreaks = anchorEndsWithLineBreak ? 0 : 1;
 
         if (endOfLineCount <= requiredLineBreaks)
         {
             return token;
         }
 
-        var newTrivia = new List<SyntaxTrivia>(endRegionIndex + 1 + requiredLineBreaks + indentationTrivia.Count);
+        var newTrivia = new List<SyntaxTrivia>(anchorIndex + 1 + requiredLineBreaks + indentationTrivia.Count);
 
-        for (var triviaIndex = 0; triviaIndex <= endRegionIndex; triviaIndex++)
+        for (var triviaIndex = 0; triviaIndex <= anchorIndex; triviaIndex++)
         {
             newTrivia.Add(trivia[triviaIndex]);
         }
@@ -421,21 +463,41 @@ internal sealed class BlankLineTokenCleanupRewriter : CSharpSyntaxRewriter
             token = RemoveLeadingBlankLines(token);
         }
 
-        // CollapseLeadingBlankLines only inspects the run starting at the first leading trivia, which is
-        // the token's own adjacent line only when nothing else precedes it. When a directive or disabled
-        // text interposes, that run is the author's separator in front of the directive, not a blank line
-        // adjacent to this token — collapsing it would delete a blank line RH5024/25/26/27 do not report.
-        // TokenGapNormalizer owns the region that is actually adjacent to the token in that case (issue #711)
-        if ((token.IsKind(SyntaxKind.OpenBraceToken)
-             || token.IsKind(SyntaxKind.CloseBraceToken)
-             || token.IsKind(SyntaxKind.ElseKeyword)
-             || token.IsKind(SyntaxKind.CatchKeyword)
-             || token.IsKind(SyntaxKind.FinallyKeyword)
-             || token.IsKind(SyntaxKind.WhileKeyword))
-            && token.LeadingTrivia.Any(SyntaxTriviaUtilities.IsDirectiveOrDisabledTextTrivia) == false)
+        if (token.IsKind(SyntaxKind.OpenBraceToken)
+            || token.IsKind(SyntaxKind.CloseBraceToken)
+            || token.IsKind(SyntaxKind.ElseKeyword)
+            || token.IsKind(SyntaxKind.CatchKeyword)
+            || token.IsKind(SyntaxKind.FinallyKeyword)
+            || token.IsKind(SyntaxKind.WhileKeyword))
         {
-            var keepSingleLineBreak = previousToken.TrailingTrivia.Any(static trivia => trivia.IsKind(SyntaxKind.EndOfLineTrivia)) == false;
-            token = CollapseLeadingBlankLines(token, keepSingleLineBreak);
+            // These are two independent questions, not alternatives: a non-region directive or disabled
+            // text anywhere in the leading trivia means the run CollapseLeadingBlankLines inspects — the
+            // one starting at the first leading trivia — is the author's separator in front of that
+            // directive, not a blank line adjacent to this token, so collapsing it would delete a blank
+            // line RH5024/25/26/27 do not report; that run must be left alone whenever such a directive
+            // is present anywhere, however far from the token. Separately, when the *last* significant
+            // trivia specifically is a non-region directive, the run that genuinely is adjacent to the
+            // token sits after it, and RemoveBlankLinesAfterTrailingDirective is what enforces the "no
+            // blank line directly adjacent" rule there — including for the chained keywords `else`/
+            // `catch`/`finally`/`while` that TokenGapNormalizer's node-scoped calls cannot reach (issue #711)
+            var hasNonRegionDirective = token.LeadingTrivia.Any(static trivia => SyntaxTriviaUtilities.IsDirectiveOrDisabledTextTrivia(trivia)
+                                                                                 && SyntaxTriviaUtilities.IsRegionDirective(trivia) == false);
+
+            if (hasNonRegionDirective == false)
+            {
+                var keepSingleLineBreak = previousToken.TrailingTrivia.Any(static trivia => trivia.IsKind(SyntaxKind.EndOfLineTrivia)) == false;
+                token = CollapseLeadingBlankLines(token, keepSingleLineBreak);
+            }
+
+            var lastSignificantIndex = SyntaxTriviaUtilities.FindLastSignificantTriviaIndex(token.LeadingTrivia);
+            var lastSignificantIsNonRegionDirective = lastSignificantIndex >= 0
+                                                      && SyntaxTriviaUtilities.IsDirectiveOrDisabledTextTrivia(token.LeadingTrivia[lastSignificantIndex])
+                                                      && SyntaxTriviaUtilities.IsRegionDirective(token.LeadingTrivia[lastSignificantIndex]) == false;
+
+            if (lastSignificantIsNonRegionDirective)
+            {
+                token = RemoveBlankLinesAfterTrailingDirective(token);
+            }
         }
 
         if (token.IsKind(SyntaxKind.CloseBraceToken))

--- a/Reihitsu.Formatter/Pipeline/BlankLines/Rewriter/BlankLineTokenCleanupRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/BlankLines/Rewriter/BlankLineTokenCleanupRewriter.cs
@@ -421,12 +421,18 @@ internal sealed class BlankLineTokenCleanupRewriter : CSharpSyntaxRewriter
             token = RemoveLeadingBlankLines(token);
         }
 
-        if (token.IsKind(SyntaxKind.OpenBraceToken)
-            || token.IsKind(SyntaxKind.CloseBraceToken)
-            || token.IsKind(SyntaxKind.ElseKeyword)
-            || token.IsKind(SyntaxKind.CatchKeyword)
-            || token.IsKind(SyntaxKind.FinallyKeyword)
-            || token.IsKind(SyntaxKind.WhileKeyword))
+        // CollapseLeadingBlankLines only inspects the run starting at the first leading trivia, which is
+        // the token's own adjacent line only when nothing else precedes it. When a directive or disabled
+        // text interposes, that run is the author's separator in front of the directive, not a blank line
+        // adjacent to this token — collapsing it would delete a blank line RH5024/25/26/27 do not report.
+        // TokenGapNormalizer owns the region that is actually adjacent to the token in that case (issue #711)
+        if ((token.IsKind(SyntaxKind.OpenBraceToken)
+             || token.IsKind(SyntaxKind.CloseBraceToken)
+             || token.IsKind(SyntaxKind.ElseKeyword)
+             || token.IsKind(SyntaxKind.CatchKeyword)
+             || token.IsKind(SyntaxKind.FinallyKeyword)
+             || token.IsKind(SyntaxKind.WhileKeyword))
+            && token.LeadingTrivia.Any(SyntaxTriviaUtilities.IsDirectiveOrDisabledTextTrivia) == false)
         {
             var keepSingleLineBreak = previousToken.TrailingTrivia.Any(static trivia => trivia.IsKind(SyntaxKind.EndOfLineTrivia)) == false;
             token = CollapseLeadingBlankLines(token, keepSingleLineBreak);

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/Utilities/TokenGapNormalizer.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/Utilities/TokenGapNormalizer.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 
 using Reihitsu.Core;
+using Reihitsu.Formatter.Pipeline.BlankLines.Utilities;
 using Reihitsu.Formatter.Pipeline.Core.Utilities;
 
 namespace Reihitsu.Formatter.Pipeline.LineBreaks.Utilities;
@@ -96,7 +97,7 @@ internal sealed class TokenGapNormalizer
         // positioning relative to the statement it may or may not document is the author's call, already
         // settled by BlankLinePhase; this method does not spend that budget on the comment→token run
         var normalizedTrailingRun = blankLineCount == 0
-                                        ? NormalizeTrailingRun(trailingRun)
+                                        ? NormalizeTrailingRun(trailingRun, BlankLineTriviaUtilities.EndsWithLineBreak(token.LeadingTrivia[lastContentIndex]))
                                         : trailingRun;
 
         var newLeadingTrivia = new List<SyntaxTrivia>(preservedPrefix.Count + normalizedTrailingRun.Count);
@@ -322,28 +323,40 @@ internal sealed class TokenGapNormalizer
     }
 
     /// <summary>
-    /// Determines whether a token's leading gap carries an ordinary <c>//</c> or <c>/* … */</c> comment that
-    /// sits on its own line, separate from the token. A comment glued to the token — for example a block
-    /// comment directly before a closing brace on the same physical line — does not count: it forms one
-    /// visual line with the token, so the token's own blank-line policy governs the whole run instead of the
-    /// comment owning a policy of its own. A documentation comment does not count either: it is structured
-    /// trivia whose own blank-line placement is governed elsewhere. A gap that carries a preprocessor
-    /// directive or disabled text anywhere — even alongside an ordinary comment — does not count either:
-    /// that family's blank-line placement is a separate, pre-existing concern this fix does not own, and
-    /// folding a directive into this decision would change behavior this fix has no mandate to touch
+    /// Determines whether a token's leading gap carries content that owns its own blank-line placement
+    /// decision, separate from the token's adjacency policy: an ordinary <c>//</c> or <c>/* … */</c> comment
+    /// on its own line, or a preprocessor directive or disabled-text block other than <c>#region</c>/
+    /// <c>#endregion</c> (which, unlike a comment, always occupies its own line and so always owns the
+    /// decision above it, whether or not it embeds an explicit trailing end-of-line trivia — see
+    /// <see cref="BlankLineTriviaUtilities.EndsWithLineBreak"/>). A region directive is excluded: its
+    /// blank-line placement already has a dedicated owner (<see cref="Pipeline.BlankLines.Rewriter.BlankLineRegionDirectiveRewriter"/>,
+    /// <see cref="Pipeline.BlankLines.Rewriter.BlankLineTriviaBoundaryRewriter"/>) with its own exemption rules, and folding it
+    /// into this decision would fight that owner instead of leaving it in sole control. A comment glued to
+    /// the token — for example a block comment directly before a closing brace on the same physical line —
+    /// does not count: it forms one visual line with the token, so the token's own blank-line policy governs
+    /// the whole run instead. A documentation comment does not count either: it is structured trivia whose
+    /// own blank-line placement is governed elsewhere
     /// </summary>
     /// <param name="leadingTrivia">The leading trivia to inspect</param>
-    /// <returns><see langword="true"/> if an ordinary comment on its own line precedes the token; otherwise, <see langword="false"/></returns>
+    /// <returns><see langword="true"/> if the gap carries content that owns its own blank-line placement; otherwise, <see langword="false"/></returns>
     private static bool HasOwnLineTrailingComment(SyntaxTriviaList leadingTrivia)
     {
-        if (ContainsDirectiveOrDisabledText(leadingTrivia))
+        var lastContentIndex = SyntaxTriviaUtilities.FindLastSignificantTriviaIndex(leadingTrivia);
+
+        if (lastContentIndex < 0)
         {
             return false;
         }
 
-        var lastContentIndex = SyntaxTriviaUtilities.FindLastSignificantTriviaIndex(leadingTrivia);
+        var lastContent = leadingTrivia[lastContentIndex];
 
-        if (lastContentIndex < 0 || IsOrdinaryComment(leadingTrivia[lastContentIndex]) == false)
+        if (SyntaxTriviaUtilities.IsDirectiveOrDisabledTextTrivia(lastContent)
+            && SyntaxTriviaUtilities.IsRegionDirective(lastContent) == false)
+        {
+            return true;
+        }
+
+        if (IsOrdinaryComment(lastContent) == false)
         {
             return false;
         }
@@ -357,16 +370,6 @@ internal sealed class TokenGapNormalizer
         }
 
         return false;
-    }
-
-    /// <summary>
-    /// Determines whether a trivia list contains a preprocessor directive or disabled text anywhere
-    /// </summary>
-    /// <param name="triviaList">The trivia list to inspect</param>
-    /// <returns><see langword="true"/> if a directive or disabled text is present; otherwise, <see langword="false"/></returns>
-    private static bool ContainsDirectiveOrDisabledText(SyntaxTriviaList triviaList)
-    {
-        return triviaList.Any(SyntaxTriviaUtilities.IsDirectiveOrDisabledTextTrivia);
     }
 
     /// <summary>
@@ -448,18 +451,22 @@ internal sealed class TokenGapNormalizer
     }
 
     /// <summary>
-    /// Normalizes the run of line breaks and indentation between a comment and a token that requires zero
-    /// blank lines directly adjacent to it, so the comment stays directly attached — exactly one line
-    /// break, never a blank line. Called only when the requested blank-line count is zero; a caller with a
-    /// wider statement-separation budget leaves this run untouched instead, since it is not requiring
-    /// adjacency and the comment's own positioning is the author's call
+    /// Normalizes the run of line breaks and indentation between the gap's last significant trivia and a
+    /// token that requires zero blank lines directly adjacent to it, so that content stays directly
+    /// attached — exactly one line break, never a blank line. Called only when the requested blank-line
+    /// count is zero; a caller with a wider statement-separation budget leaves this run untouched instead,
+    /// since it is not requiring adjacency and the content's own positioning is the author's call
     /// </summary>
-    /// <param name="trailingRun">
-    /// The trivia between the last content and the token. Always contains at least one end-of-line trivia,
-    /// because the caller only reaches this method after confirming one is present
+    /// <param name="trailingRun">The trivia between the last content and the token</param>
+    /// <param name="lastContentEndsWithLineBreak">
+    /// Whether the gap's last significant trivia already embeds its own terminating line break — true for a
+    /// directive or disabled-text block, which always ends its own line, false for an ordinary comment. When
+    /// true, the run's own line break already separates that content from the token, so no further line
+    /// break is emitted here; emitting one unconditionally would recreate a blank line the guard exists to
+    /// remove
     /// </param>
     /// <returns>The normalized trailing run</returns>
-    private List<SyntaxTrivia> NormalizeTrailingRun(List<SyntaxTrivia> trailingRun)
+    private List<SyntaxTrivia> NormalizeTrailingRun(List<SyntaxTrivia> trailingRun, bool lastContentEndsWithLineBreak)
     {
         var lastEndOfLineIndex = -1;
 
@@ -478,10 +485,14 @@ internal sealed class TokenGapNormalizer
             preservedTrailing.Add(trailingRun[triviaIndex]);
         }
 
-        var normalizedRun = new List<SyntaxTrivia>(1 + preservedTrailing.Count)
-                            {
-                                SyntaxFactory.EndOfLine(_endOfLine)
-                            };
+        var requiredLineBreakCount = lastContentEndsWithLineBreak ? 0 : 1;
+
+        var normalizedRun = new List<SyntaxTrivia>(requiredLineBreakCount + preservedTrailing.Count);
+
+        for (var lineBreakIndex = 0; lineBreakIndex < requiredLineBreakCount; lineBreakIndex++)
+        {
+            normalizedRun.Add(SyntaxFactory.EndOfLine(_endOfLine));
+        }
 
         normalizedRun.AddRange(preservedTrailing);
 

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/Utilities/TokenGapNormalizer.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/Utilities/TokenGapNormalizer.cs
@@ -66,17 +66,18 @@ internal sealed class TokenGapNormalizer
     {
         if (HasOwnLineTrailingComment(token.LeadingTrivia) == false)
         {
-            // Either there is no comment in the gap, or the comment shares the token's own line (for
-            // example a block comment glued to a closing brace). Either way, the token's blank-line
-            // policy governs the whole run up to that point, exactly as if no comment were present.
+            // Either there is nothing but whitespace and line breaks in the gap, the content is a
+            // comment that shares the token's own line (for example a block comment glued to a closing
+            // brace), or it is a region directive (a separate, dedicated owner). Either way, the token's
+            // blank-line policy governs the whole run up to that point, exactly as if it were empty.
             return NormalizeLeadingGapWithoutContent(token, blankLineCount, previousProvidesLineBreak);
         }
 
         var lastContentIndex = SyntaxTriviaUtilities.FindLastSignificantTriviaIndex(token.LeadingTrivia);
 
-        // The comment sits on its own line, separate from the token, so it owns the blank-line decision
-        // above it. Preserve everything through that comment unchanged; only the run between the comment
-        // and the token itself is a placement decision this method owns
+        // The comment or directive sits on its own line, separate from the token, so it owns the
+        // blank-line decision above it. Preserve everything through it unchanged; only the run between
+        // it and the token itself is a placement decision this method owns
         var preservedPrefix = new List<SyntaxTrivia>(lastContentIndex + 1);
 
         for (var triviaIndex = 0; triviaIndex <= lastContentIndex; triviaIndex++)
@@ -92,10 +93,11 @@ internal sealed class TokenGapNormalizer
         }
 
         // A requested blank-line count of zero is a placement requirement — no blank line directly
-        // adjacent to the token, the way RH5024/RH5025 require for a delimiter. A requested count of one
-        // or more is a statement-separation budget, not an adjacency requirement, so the comment's own
-        // positioning relative to the statement it may or may not document is the author's call, already
-        // settled by BlankLinePhase; this method does not spend that budget on the comment→token run
+        // adjacent to the token, the way RH5022/RH5024/RH5025/RH5026/RH5027 require for a delimiter. A
+        // requested count of one or more is a statement-separation budget, not an adjacency requirement,
+        // so the content's own positioning relative to the statement it may or may not document is the
+        // author's call, already settled by BlankLinePhase; this method does not spend that budget on
+        // the content→token run
         var normalizedTrailingRun = blankLineCount == 0
                                         ? NormalizeTrailingRun(trailingRun, BlankLineTriviaUtilities.EndsWithLineBreak(token.LeadingTrivia[lastContentIndex]))
                                         : trailingRun;
@@ -164,8 +166,8 @@ internal sealed class TokenGapNormalizer
 
         if (HasOwnLineTrailingComment(token.LeadingTrivia))
         {
-            // A comment on its own line sits in the gap; it owns the blank line above it, so that
-            // token's own trailing trivia stays untouched.
+            // A comment or directive on its own line sits in the gap; it owns the blank line above it,
+            // so that token's own trailing trivia stays untouched.
             return withToken(node, newToken);
         }
 
@@ -237,8 +239,8 @@ internal sealed class TokenGapNormalizer
 
         if (HasOwnLineTrailingComment(token.LeadingTrivia))
         {
-            // A comment on its own line sits in the gap; it owns the blank line above it, so that
-            // token's own trailing trivia stays untouched.
+            // A comment or directive on its own line sits in the gap; it owns the blank line above it,
+            // so that token's own trailing trivia stays untouched.
             return withToken(node, newToken);
         }
 
@@ -303,8 +305,8 @@ internal sealed class TokenGapNormalizer
 
         if (HasOwnLineTrailingComment(token.LeadingTrivia))
         {
-            // A comment on its own line sits in the gap; it owns the blank line above it, so that
-            // token's own trailing trivia stays untouched.
+            // A comment or directive on its own line sits in the gap; it owns the blank line above it,
+            // so that token's own trailing trivia stays untouched.
             return node.ReplaceToken(token, newToken);
         }
 

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/Utilities/TokenGapNormalizer.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/Utilities/TokenGapNormalizer.cs
@@ -64,7 +64,7 @@ internal sealed class TokenGapNormalizer
                                            int blankLineCount,
                                            bool previousProvidesLineBreak)
     {
-        if (HasOwnLineTrailingComment(token.LeadingTrivia) == false)
+        if (HasOwnLinePlacementOwner(token.LeadingTrivia) == false)
         {
             // Either there is nothing but whitespace and line breaks in the gap, the content is a
             // comment that shares the token's own line (for example a block comment glued to a closing
@@ -164,7 +164,7 @@ internal sealed class TokenGapNormalizer
 
         var newToken = NormalizeLeadingGap(token, blankLineCount);
 
-        if (HasOwnLineTrailingComment(token.LeadingTrivia))
+        if (HasOwnLinePlacementOwner(token.LeadingTrivia))
         {
             // A comment or directive on its own line sits in the gap; it owns the blank line above it,
             // so that token's own trailing trivia stays untouched.
@@ -237,7 +237,7 @@ internal sealed class TokenGapNormalizer
 
         var newToken = NormalizeLeadingGap(token, blankLineCount);
 
-        if (HasOwnLineTrailingComment(token.LeadingTrivia))
+        if (HasOwnLinePlacementOwner(token.LeadingTrivia))
         {
             // A comment or directive on its own line sits in the gap; it owns the blank line above it,
             // so that token's own trailing trivia stays untouched.
@@ -303,7 +303,7 @@ internal sealed class TokenGapNormalizer
 
         var newToken = NormalizeLeadingGap(token, blankLineCount);
 
-        if (HasOwnLineTrailingComment(token.LeadingTrivia))
+        if (HasOwnLinePlacementOwner(token.LeadingTrivia))
         {
             // A comment or directive on its own line sits in the gap; it owns the blank line above it,
             // so that token's own trailing trivia stays untouched.
@@ -341,7 +341,7 @@ internal sealed class TokenGapNormalizer
     /// </summary>
     /// <param name="leadingTrivia">The leading trivia to inspect</param>
     /// <returns><see langword="true"/> if the gap carries content that owns its own blank-line placement; otherwise, <see langword="false"/></returns>
-    private static bool HasOwnLineTrailingComment(SyntaxTriviaList leadingTrivia)
+    private static bool HasOwnLinePlacementOwner(SyntaxTriviaList leadingTrivia)
     {
         var lastContentIndex = SyntaxTriviaUtilities.FindLastSignificantTriviaIndex(leadingTrivia);
 


### PR DESCRIPTION
## Summary

Fixes a formatter defect where a blank line before a preprocessor directive block (`#if`, `#pragma`, `#nullable`, `#line`, `#warning`, or disabled text) was silently deleted whenever that directive block was the last content of an enclosing scope, or immediately preceded a chained `else`/`catch`/`finally`/`while` keyword. Also fixes the mirror-image defect the investigation uncovered: a blank line the author never wrote could be inserted after such a directive, or a blank line the analyzers already flag could be left standing directly above the delimiter.

## Why

Closes #711. Two formatter owners computed "no blank line directly adjacent to a delimiter" from the *start* of a token's leading trivia instead of the region genuinely adjacent to it, whenever a directive or disabled-text block interposed:

- `BlankLineTokenCleanupRewriter` deleted the author's blank line in front of a directive, because its collapse logic only ever inspected the run starting at leading-trivia index 0.
- `TokenGapNormalizer` (used across six `LineBreakPhase` rewriters for brace/bracket/paren placement) rewrote the whole gap for a directive-terminated run, inserting a break the author never wrote while leaving a blank line directly adjacent to the anchor untouched.

Both owners now split the gap at the last significant trivia, preserving everything the author wrote up to and including a directive, and only normalizing the run genuinely adjacent to the anchor token. `#region`/`#endregion` are explicitly excluded — their blank-line placement already has dedicated owners (`BlankLineRegionDirectiveRewriter`, `BlankLineTriviaBoundaryRewriter`) and stays unaffected.

`BlankLineTokenCleanupRewriter` additionally enforces the adjacency rule directly for the chained keywords `else`/`catch`/`finally`/`while` when a directive interposes, since `TokenGapNormalizer`'s node-scoped calls structurally cannot reach them (the block node passed to `EnsureCloseBraceContinuation` never contains the keyword that follows it) — an independent preflight audit found this gap and it is closed in this PR.

## Linked issues

Closes #711

## Review notes

- Production changes are confined to `Reihitsu.Formatter/Pipeline/BlankLines/Rewriter/BlankLineTokenCleanupRewriter.cs` and `Reihitsu.Formatter/Pipeline/LineBreaks/Utilities/TokenGapNormalizer.cs`, reusing existing helpers only. No public API, diagnostic, or dependency change; RH5022–RH5028 stay byte-identical.
- Reproduction settled via the characterization carve-out: an existing test committed alongside #710 already asserted the issue's exact reported input and observed (broken) output, and was green on the pre-fix head.
- Full validation is green across all 7 test projects (5,273 tests), including the whole-repository formatter self-hosting idempotency suite and full analyzer parity coverage.
- An independent preflight audit (two rounds) found and the repair closed: the chained-keyword coverage gap above, a directive-plus-own-line-comment gap shape without a test, a predicate name that no longer matched its behavior, and two unit tests using substring instead of exact-output assertions. A region-interaction regression introduced mid-implementation (the naive directive predicate also matched `#region`/`#endregion`) was caught by the full test suite and fixed before the first audit.
- One pre-existing, out-of-scope defect was noted by the retry audit as a hint rather than a finding: a blank line directly above `else`/`catch`/`finally` survives when an own-line ordinary *comment* (not a directive) is the last content before it — byte-identical to `main`, reachable through neither of this PR's changed predicates, and correctly left out of scope.

## Follow-up work

None.