### PR TITLE
Align method-chain continuation dots to the first invoked link (#699, #698)

### DIFF
--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5201Issue698ReproductionTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5201Issue698ReproductionTests.cs
@@ -1,0 +1,83 @@
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Analyzer.Rules.Layout;
+using Reihitsu.Analyzer.Test.Base;
+using Reihitsu.Formatter;
+
+namespace Reihitsu.Analyzer.Test.Formatter.Formatting;
+
+/// <summary>
+/// Reproduction test for issue #698: a comment-exempt chain aligns its continuation dots to the
+/// chain root token, while <see cref="RH5201MethodChainsShouldBeAlignedAnalyzer"/> measures its
+/// reference column from the first invoked link. For a chain that carries a non-invoked prefix dot
+/// on the commented line, the two columns can differ
+/// </summary>
+[TestClass]
+public class RH5201Issue698ReproductionTests : FormatterTestsBase<RH5201MethodChainsShouldBeAlignedAnalyzer>
+{
+    #region Properties
+
+    /// <summary>
+    /// Test context
+    /// </summary>
+    public TestContext TestContext { get; set; } = null!;
+
+    #endregion // Properties
+
+    #region Tests
+
+    /// <summary>
+    /// Runs the actual formatter over the issue's reported input (a chain root token, a wrapping
+    /// comment, a non-invoked <c>.Prop</c> prefix on the commented line, then the invoked
+    /// <c>.Foo()</c>/<c>.Bar()</c>/<c>.Baz()</c> links) and asserts that the formatter's own output is
+    /// reported clean by <see cref="RH5201MethodChainsShouldBeAlignedAnalyzer"/>
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFormatterOutputForCommentExemptChainWithNonInvokedPrefixIsRH5201Clean()
+    {
+        const string source = """
+                              internal class Example
+                              {
+                                  internal Example Prop { get; set; }
+
+                                  internal Example Foo()
+                                  {
+                                      return this;
+                                  }
+
+                                  internal Example Bar()
+                                  {
+                                      return this;
+                                  }
+
+                                  internal Example Baz()
+                                  {
+                                      return this;
+                                  }
+
+                                  internal static Example Run(Example a)
+                                  {
+                                      var x = a
+                                          // keep wrapped
+                                          .Prop.Foo()
+                                          .Bar().Baz();
+
+                                      return x;
+                                  }
+                              }
+                              """;
+
+        var tree = CSharpSyntaxTree.ParseText(source, cancellationToken: TestContext.CancellationToken);
+        var formatted = ReihitsuFormatter.FormatSyntaxTree(tree, TestContext.CancellationToken)
+                                         .GetRoot(TestContext.CancellationToken)
+                                         .ToFullString();
+
+        await Verify(formatted);
+    }
+
+    #endregion // Tests
+}

--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5201Issue698ReproductionTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5201Issue698ReproductionTests.cs
@@ -79,5 +79,85 @@ public class RH5201Issue698ReproductionTests : FormatterTestsBase<RH5201MethodCh
         await Verify(formatted);
     }
 
+    /// <summary>
+    /// Verifies the full round trip: the raw, as-typed source reports <c>RH5201</c> on the two
+    /// invoked links that do not match the first invoked link's column, the formatter's fixed
+    /// output clears the diagnostic by aligning every continuation dot to that first invoked
+    /// link's own rendered column (not the chain-root column), and a second formatter pass is a
+    /// no-op under both LF and CRLF
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFormatterFixesCommentExemptChainWithNonInvokedPrefixAndStaysIdempotent()
+    {
+        const string source = """
+                              internal class Example
+                              {
+                                  internal Example Prop { get; set; }
+
+                                  internal Example Foo()
+                                  {
+                                      return this;
+                                  }
+
+                                  internal Example Bar()
+                                  {
+                                      return this;
+                                  }
+
+                                  internal Example Baz()
+                                  {
+                                      return this;
+                                  }
+
+                                  internal static Example Run(Example a)
+                                  {
+                                      var x = a
+                                          // keep wrapped
+                                          .Prop.Foo()
+                                          {|#0:.|}Bar(){|#1:.|}Baz();
+
+                                      return x;
+                                  }
+                              }
+                              """;
+
+        const string fixedSource = """
+                                   internal class Example
+                                   {
+                                       internal Example Prop { get; set; }
+
+                                       internal Example Foo()
+                                       {
+                                           return this;
+                                       }
+
+                                       internal Example Bar()
+                                       {
+                                           return this;
+                                       }
+
+                                       internal Example Baz()
+                                       {
+                                           return this;
+                                       }
+
+                                       internal static Example Run(Example a)
+                                       {
+                                           var x = a
+
+                                                   // keep wrapped
+                                                   .Prop.Foo()
+                                                        .Bar()
+                                                        .Baz();
+
+                                           return x;
+                                       }
+                                   }
+                                   """;
+
+        await VerifyFormatterFixAndIdempotency(source, fixedSource, Diagnostics(RH5201MethodChainsShouldBeAlignedAnalyzer.DiagnosticId, "Method chains should be aligned.", 2));
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5201Issue699Tests.cs
+++ b/Reihitsu.Analyzer.Test/Formatter/Formatting/RH5201Issue699Tests.cs
@@ -1,0 +1,91 @@
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Reihitsu.Analyzer.Rules.Layout;
+using Reihitsu.Analyzer.Test.Base;
+
+namespace Reihitsu.Analyzer.Test.Formatter.Formatting;
+
+/// <summary>
+/// Verifies issue #699: once an uncommented, separately wrapped non-invoked prefix dot collapses
+/// onto the chain root even though a comment sits above the first invoked link, both the raw,
+/// as-typed source and the formatter's fixed output stay <see cref="RH5201MethodChainsShouldBeAlignedAnalyzer"/>-clean,
+/// and a second formatter pass is a no-op
+/// </summary>
+[TestClass]
+public class RH5201Issue699Tests : FormatterTestsBase<RH5201MethodChainsShouldBeAlignedAnalyzer>
+{
+    #region Tests
+
+    /// <summary>
+    /// Runs the formatter over the issue's reported input (a wrapped, uncommented non-invoked
+    /// <c>.Prop</c> prefix dot, then a comment directly above the first invoked link) and asserts
+    /// that both the raw and the fixed source are analyzer-clean, and that the fixed source is
+    /// stable on a second formatter pass, under both LF and CRLF
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyFormatterCollapsesWrappedPrefixDotAndStaysAnalyzerClean()
+    {
+        const string source = """
+                              internal class Example
+                              {
+                                  internal Example Prop { get; set; }
+
+                                  internal Example Foo()
+                                  {
+                                      return this;
+                                  }
+
+                                  internal Example Bar()
+                                  {
+                                      return this;
+                                  }
+
+                                  internal static Example Run(Example a)
+                                  {
+                                      var x = a
+                                          .Prop
+                                          // keep wrapped
+                                          .Foo()
+                                          .Bar();
+
+                                      return x;
+                                  }
+                              }
+                              """;
+
+        const string fixedSource = """
+                                   internal class Example
+                                   {
+                                       internal Example Prop { get; set; }
+
+                                       internal Example Foo()
+                                       {
+                                           return this;
+                                       }
+
+                                       internal Example Bar()
+                                       {
+                                           return this;
+                                       }
+
+                                       internal static Example Run(Example a)
+                                       {
+                                           var x = a.Prop
+
+                                                    // keep wrapped
+                                                    .Foo()
+                                                    .Bar();
+
+                                           return x;
+                                       }
+                                   }
+                                   """;
+
+        await VerifyFormatterTransformStaysAnalyzerClean(source, fixedSource);
+    }
+
+    #endregion // Tests
+}

--- a/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
@@ -2660,6 +2660,86 @@ public class MethodChainAlignmentTests : FormatterTestsBase
     }
 
     /// <summary>
+    /// Verify that the exempt-chain anchor fix applies when the first invoked link sharing the
+    /// commented line is a conditional-access operator rather than a plain dot (issue #698 coverage)
+    /// </summary>
+    [TestMethod]
+    public void CommentExemptChainWithConditionalAccessSharingFirstInvokedLinkLineAlignsToInvokedLink()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                                         // keep wrapped
+                                         .Prop?.Foo()
+                                         .Bar().Baz();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a
+
+                                                // keep wrapped
+                                                .Prop?.Foo()
+                                                     .Bar()
+                                                     .Baz();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verify that the exempt-chain anchor fix applies when the first invoked link sharing the
+    /// commented line is a null-forgiving link rather than a plain dot (issue #698 coverage)
+    /// </summary>
+    [TestMethod]
+    public void CommentExemptChainWithNullForgivingLinkSharingFirstInvokedLinkLineAlignsToInvokedLink()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                                         // keep wrapped
+                                         .Prop!.Foo()
+                                         .Bar().Baz();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a
+
+                                                // keep wrapped
+                                                .Prop!.Foo()
+                                                     .Bar()
+                                                     .Baz();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
     /// Verify that a chain rooted in a multi-line implicit array initializer whose closing brace
     /// shares its line with an element aligns its continuation dot to the first invoked link
     /// </summary>
@@ -3128,6 +3208,131 @@ public class MethodChainAlignmentTests : FormatterTestsBase
                                                  // keep wrapped
                                                  .Foo()
                                                  .Bar();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verify that a comment above a wrapped null-forgiving operator on the chain root refuses the
+    /// collapse and leaves every invoked link on its own line, the same way a comment above any other
+    /// collapse candidate does. Regression for the collapse-candidate search returning a link past
+    /// the wrapped null-forgiving operator, which never terminates (issue #699 repair)
+    /// </summary>
+    [TestMethod]
+    public void CommentAboveWrappedNullForgivingRootRefusesCollapseWithTwoLinks()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                                         // keep wrapped
+                                         !
+                                         .Foo()
+                                         .Bar();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a
+
+                                                // keep wrapped
+                                                !.Foo()
+                                                .Bar();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Same as <see cref="CommentAboveWrappedNullForgivingRootRefusesCollapseWithTwoLinks"/> with a
+    /// third invoked link, so the search has more than one later link to (incorrectly) return before
+    /// the fix (issue #699 repair)
+    /// </summary>
+    [TestMethod]
+    public void CommentAboveWrappedNullForgivingRootRefusesCollapseWithThreeLinks()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                                         // keep wrapped
+                                         !
+                                         .Foo()
+                                         .Bar()
+                                         .Baz();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a
+
+                                                // keep wrapped
+                                                !.Foo()
+                                                .Bar()
+                                                .Baz();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verify that an uncommented, wrapped null-forgiving operator on the chain root still collapses
+    /// onto the root line, and the remaining invoked links align to its own column — the other side
+    /// of the boundary from the two tests above, proving the fix refuses only the commented case
+    /// rather than every null-forgiving-root chain (issue #699 repair)
+    /// </summary>
+    [TestMethod]
+    public void WrappedNullForgivingRootWithoutCommentStillCollapsesOntoChainRoot()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                                         !
+                                         .Foo()
+                                         .Bar()
+                                         .Baz();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a!.Foo()
+                                                 .Bar()
+                                                 .Baz();
                                     }
                                 }
                                 """;

--- a/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
@@ -2488,6 +2488,178 @@ public class MethodChainAlignmentTests : FormatterTestsBase
     }
 
     /// <summary>
+    /// Verify that a comment-exempt chain whose first collected dot is a non-invoked prefix sharing
+    /// its line with the first invoked link aligns every later continuation dot to that invoked
+    /// link's own rendered column instead of the chain-root column, matching
+    /// <c>RH5201MethodChainsShouldBeAlignedAnalyzer</c>'s reference column (issue #698)
+    /// </summary>
+    [TestMethod]
+    public void CommentExemptChainWithPrefixSharingFirstInvokedLinkLineAlignsToInvokedLink()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                                         // keep wrapped
+                                         .Prop.Foo()
+                                         .Bar().Baz();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a
+
+                                                // keep wrapped
+                                                .Prop.Foo()
+                                                     .Bar()
+                                                     .Baz();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verify that the exempt-chain fix in <see cref="CommentExemptChainWithPrefixSharingFirstInvokedLinkLineAlignsToInvokedLink"/>
+    /// also applies to a trailing non-invoked property after the first invoked link — parity with
+    /// <see cref="TrailingPropertyAfterConditionalAccessChainAlignsToInvokedLink"/>, even though
+    /// RH5201 itself stays silent for a single invoked link (issue #698)
+    /// </summary>
+    [TestMethod]
+    public void CommentExemptChainWithTrailingNonInvokedPropertyAlignsToInvokedLink()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                                         // keep wrapped
+                                         .Prop.Foo()
+                                         .Result;
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a
+
+                                                // keep wrapped
+                                                .Prop.Foo()
+                                                     .Result;
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verify that the exempt-chain anchor fix applies regardless of which unjoinable-trivia kind
+    /// keeps the chain's first dot wrapped — a <c>#region</c> directive here rather than a comment
+    /// (issue #698, mirroring issue #489's trivia-kind-agnostic exemption)
+    /// </summary>
+    [TestMethod]
+    public void RegionAboveCommentExemptChainWithSharedInvokedLinkLineAlignsToInvokedLink()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                                         #region Chain
+                                         .Prop.Foo()
+                                         .Bar().Baz();
+                                         #endregion
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a
+
+                                        #region Chain
+
+                                                .Prop.Foo()
+                                                     .Bar()
+                                                     .Baz();
+
+                                        #endregion // Chain
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verify that the exempt-chain anchor fix applies above disabled text (an <c>#if false</c>
+    /// body), which also counts as unjoinable trivia for the exemption (issue #698, mirroring
+    /// issue #489)
+    /// </summary>
+    [TestMethod]
+    public void DisabledTextAboveCommentExemptChainWithSharedInvokedLinkLineAlignsToInvokedLink()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                             #if false
+                                         .Disabled()
+                             #endif
+                                         .Prop.Foo()
+                                         .Bar().Baz();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a
+                                #if false
+                                            .Disabled()
+                                #endif
+                                                .Prop.Foo()
+                                                     .Bar()
+                                                     .Baz();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
     /// Verify that a chain rooted in a multi-line implicit array initializer whose closing brace
     /// shares its line with an element aligns its continuation dot to the first invoked link
     /// </summary>
@@ -2881,11 +3053,12 @@ public class MethodChainAlignmentTests : FormatterTestsBase
     }
 
     /// <summary>
-    /// Verify that a comment above the first invoked link still suppresses the collapse of a
-    /// separately wrapped non-invoked prefix dot
+    /// Verify that a comment above the first invoked link no longer suppresses the collapse of an
+    /// uncommented, separately wrapped non-invoked prefix dot (issue #699). The bail now inspects
+    /// the trivia above the collapse candidate itself, matching the directive arm below
     /// </summary>
     [TestMethod]
-    public void CommentAboveFirstInvokedLinkKeepsWrappedPrefixDotUncollapsed()
+    public void CommentAboveFirstInvokedLinkStillCollapsesWrappedPrefixDot()
     {
         // Arrange
         const string input = """
@@ -2907,12 +3080,54 @@ public class MethodChainAlignmentTests : FormatterTestsBase
                                 {
                                     void M()
                                     {
-                                        var x = a
-                                        .Prop
+                                        var x = a.Prop
 
-                                        // keep wrapped
-                                        .Foo()
-                                        .Bar();
+                                                 // keep wrapped
+                                                 .Foo()
+                                                 .Bar();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verify that only the chain's own first wrapped dot collapses onto the root line when a comment
+    /// sits above the first invoked link and more than one non-invoked prefix dot is wrapped; the
+    /// remaining prefix stays on its own line but aligns to the anchor column (issue #699)
+    /// </summary>
+    [TestMethod]
+    public void CommentAboveFirstInvokedLinkCollapsesOnlyFirstOfTwoWrappedPrefixDots()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                                         .Prop
+                                         .Other
+                                         // keep wrapped
+                                         .Foo()
+                                         .Bar();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a.Prop
+                                                 .Other
+
+                                                 // keep wrapped
+                                                 .Foo()
+                                                 .Bar();
                                     }
                                 }
                                 """;

--- a/Reihitsu.Formatter/Pipeline/Indentation/Contributors/MethodChainAlignmentContributor.cs
+++ b/Reihitsu.Formatter/Pipeline/Indentation/Contributors/MethodChainAlignmentContributor.cs
@@ -123,13 +123,15 @@ internal sealed class MethodChainAlignmentContributor : ILayoutContributor
 
     /// <summary>
     /// Computes the starting continuation column for a chain that a preceding comment keeps wrapped.
-    /// The chain's own collected dots up to and including the first invoked link have no anchor to
-    /// their left, so they line up with the chain root token itself. Measuring from the root rather
-    /// than from the continuation line's block indentation keeps the chain under its root even when
-    /// the root sits far into the line, for example inside an argument or a lambda body. Once the
-    /// first invoked link is reached, it does have an anchor — itself — so every collected dot after
-    /// it aligns to that link's own rendered column instead, matching the column
-    /// <c>RH5201MethodChainsShouldBeAlignedAnalyzer</c> requires (issue #698)
+    /// The chain's collected dots that precede the first invoked link have no anchor to their left, so
+    /// they line up with the chain root token itself; the first invoked link takes this same root
+    /// column only when it starts its own line — when it instead shares a line with an earlier,
+    /// non-invoked prefix dot, it is never itself moved and simply renders wherever that prefix left
+    /// it. Measuring from the root rather than from the continuation line's block indentation keeps
+    /// the chain under its root even when the root sits far into the line, for example inside an
+    /// argument or a lambda body. Once the first invoked link's own line is final, it does have an
+    /// anchor — itself — so every collected dot after it aligns to that link's own rendered column
+    /// instead, matching the column <c>RH5201MethodChainsShouldBeAlignedAnalyzer</c> requires (issue #698)
     /// </summary>
     /// <param name="node">The chain node being laid out</param>
     /// <param name="model">The layout model</param>

--- a/Reihitsu.Formatter/Pipeline/Indentation/Contributors/MethodChainAlignmentContributor.cs
+++ b/Reihitsu.Formatter/Pipeline/Indentation/Contributors/MethodChainAlignmentContributor.cs
@@ -122,15 +122,18 @@ internal sealed class MethodChainAlignmentContributor : ILayoutContributor
     }
 
     /// <summary>
-    /// Computes the continuation column for a chain that a preceding comment keeps wrapped. Such a
-    /// chain has no first dot to align against, so the continuation dots line up with the chain root
-    /// token itself. Measuring from the root rather than from the continuation line's block
-    /// indentation keeps the chain under its root even when the root sits far into the line, for
-    /// example inside an argument or a lambda body
+    /// Computes the starting continuation column for a chain that a preceding comment keeps wrapped.
+    /// The chain's own collected dots up to and including the first invoked link have no anchor to
+    /// their left, so they line up with the chain root token itself. Measuring from the root rather
+    /// than from the continuation line's block indentation keeps the chain under its root even when
+    /// the root sits far into the line, for example inside an argument or a lambda body. Once the
+    /// first invoked link is reached, it does have an anchor — itself — so every collected dot after
+    /// it aligns to that link's own rendered column instead, matching the column
+    /// <c>RH5201MethodChainsShouldBeAlignedAnalyzer</c> requires (issue #698)
     /// </summary>
     /// <param name="node">The chain node being laid out</param>
     /// <param name="model">The layout model</param>
-    /// <returns>The column for the chain's continuation lines</returns>
+    /// <returns>The column for the chain's leading continuation lines, up to the first invoked link</returns>
     private static int GetCommentExemptContinuationColumn(SyntaxNode node, LayoutModel model)
     {
         return LayoutComputer.GetAdjustedColumn(node.GetFirstToken(), model);
@@ -153,10 +156,22 @@ internal sealed class MethodChainAlignmentContributor : ILayoutContributor
         if (ShouldKeepFirstWrappedCallOnContinuationLine(dots[0]))
         {
             var continuationColumn = GetCommentExemptContinuationColumn(node, model);
+            var passedFirstInvokedLink = false;
 
             foreach (var dot in dots)
             {
                 LayoutComputer.SetIfFirstOnLine(dot, continuationColumn, "MethodChainCommentExempt", model);
+
+                // Once the first invoked link is set (or, if it already shared a line with an
+                // earlier collected dot, resolved through that dot's now-final line), it becomes the
+                // anchor for every dot after it — the same "first invoked link" column RH5201 measures,
+                // rather than the chain-root column used up to this point (issue #698)
+                if (passedFirstInvokedLink == false
+                    && ChainWalker.IsInvokedLinkDot(dot))
+                {
+                    passedFirstInvokedLink = true;
+                    continuationColumn = LayoutComputer.GetAdjustedColumn(dot, model);
+                }
             }
 
             return;

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/Rewriter/ChainLineBreakRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/Rewriter/ChainLineBreakRewriter.cs
@@ -129,8 +129,15 @@ internal sealed class ChainLineBreakRewriter : CSharpSyntaxRewriter
     /// chain wrapped.
     /// </para>
     /// <para>
-    /// A postfix null-forgiving operator is not a chain dot: <c>a!</c> is the chain's root, not its
-    /// first link, so the search skips it and considers the <c>.</c> that follows
+    /// A postfix null-forgiving operator on the chain root (<c>a!</c>) is not itself a candidate — the
+    /// search skips it and considers the next collected dot. When that root's invoked link is a
+    /// directly-invoked member access (<c>a!.Foo()</c>), <c>!</c> stands in for the whole link and no
+    /// dot for <c>.Foo()</c> is ever collected, so the next entry the search would otherwise land on is
+    /// already a <em>later</em> link (<c>.Bar()</c>), not the chain's own first dot. Returning it would
+    /// let the collapse join across a link the rest of the chain still treats as wrapped, which never
+    /// settles (issue #699's escaped guard). The position check below refuses any candidate that does
+    /// not sit at or before <paramref name="firstInvokedDot"/> and falls back to it instead — for
+    /// <c>a!.Foo()</c> that fallback is <c>!</c> itself, matching the shape's own first invoked link
     /// </para>
     /// </summary>
     /// <param name="node">The outermost chain node</param>
@@ -151,7 +158,8 @@ internal sealed class ChainLineBreakRewriter : CSharpSyntaxRewriter
         var firstChainDot = spineDots.Find(static dot => dot.Parent is not PostfixUnaryExpressionSyntax);
 
         if (firstChainDot.IsKind(SyntaxKind.None) == false
-            && LineBreakTriviaUtilities.HasLeadingEndOfLine(firstChainDot))
+            && LineBreakTriviaUtilities.HasLeadingEndOfLine(firstChainDot)
+            && firstChainDot.SpanStart <= firstInvokedDot.SpanStart)
         {
             return firstChainDot;
         }

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/Rewriter/ChainLineBreakRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/Rewriter/ChainLineBreakRewriter.cs
@@ -381,9 +381,12 @@ internal sealed class ChainLineBreakRewriter : CSharpSyntaxRewriter
     /// back onto one line and must not have breaks inserted into it.
     /// </para>
     /// <para>
-    /// A comment above the first invoked link is likewise a decision about one of the three, not
-    /// about the chain as a whole: it keeps the author's wrapping by suppressing the collapse, and
-    /// leaves the rejoin and the continuation breaks to their own trivia guards (issues #685, #689)
+    /// A comment directly above the collapse candidate is likewise a decision about one of the three,
+    /// not about the chain as a whole: it refuses that one join, and leaves the rejoin and the
+    /// continuation breaks to their own trivia guards (issues #685, #689). A comment further down the
+    /// chain — for example above the first invoked link, while an earlier, uncommented non-invoked
+    /// prefix dot is the actual collapse candidate — no longer suppresses the collapse (issue #699):
+    /// the gap it occupies is never the one <see cref="TryCollapseFirstChainDot"/> would join across.
     /// </para>
     /// </summary>
     /// <param name="node">The outermost chain node (invocation or conditional access)</param>
@@ -399,32 +402,20 @@ internal sealed class ChainLineBreakRewriter : CSharpSyntaxRewriter
             return node;
         }
 
-        // A comment above the chain's first invoked link keeps the chain wrapped the way the author
-        // wrote it, so the collapse must not run. It gates that step alone: the rejoin joins a dot to
-        // its own member name and the continuation-break pass only inserts end-of-line trivia, and
-        // neither touches the gap the comment occupies.
-        // The predicate stays comment-only and deliberately does not use the wider
-        // WouldJoinAcrossUnjoinableTrivia that the alignment phase applies (issue #489). Widening it
-        // would newly suppress the collapse for a chain carrying a directive above its first invoked
-        // link, which today collapses a wrapped prefix dot and aligns the remaining links under it —
-        // a strictly better layout than the block-level one the comment arm produces. Issues #685 and
-        // #689 asked for the divergence to be settled; it is settled here in favour of leaving the
-        // directive arm alone, and both arms are pinned by tests.
-        var keepsAuthoredWrapping = LineBreakTriviaUtilities.HasLeadingEndOfLine(chainDots[0])
-                                    && ReihitsuFormatterHelpers.HasCommentDirectlyAbove(chainDots[0]);
-
         var firstWrappedDot = FindFirstWrappedChainOperator(node, chainDots[0]);
         var hasWrappedCandidate = firstWrappedDot.IsKind(SyntaxKind.None) == false;
         var replacements = new Dictionary<SyntaxToken, SyntaxToken>();
 
         CollectMemberNameRejoinReplacements(node, replacements);
 
-        // A comment above the collapse candidate refuses that one join; it must not suppress the
-        // rejoin or the continuation-break pass, which do not touch the commented gap. Only a comment
-        // above the chain's first invoked link keeps the whole chain as the author wrote it, and that
-        // is the pre-existing bail above.
-        if (keepsAuthoredWrapping == false
-            && hasWrappedCandidate
+        // A comment directly above the collapse candidate refuses that one join; it must not
+        // suppress the rejoin or the continuation-break pass, which do not touch the commented gap.
+        // The predicate stays comment-only and deliberately does not use the wider
+        // WouldJoinAcrossUnjoinableTrivia that the alignment phase applies (issue #489): widening it
+        // would newly suppress the collapse for a chain carrying a directive above the candidate,
+        // which today collapses the wrapped prefix dot and aligns the remaining links under it — a
+        // strictly better layout than leaving it wrapped at block indentation.
+        if (hasWrappedCandidate
             && ReihitsuFormatterHelpers.HasCommentDirectlyAbove(firstWrappedDot) == false)
         {
             TryCollapseFirstChainDot(firstWrappedDot, replacements);


### PR DESCRIPTION
## Summary

Fixes two related method-chain continuation-dot alignment defects in `Reihitsu.Formatter`:

- **#698**: A comment-exempt chain (one whose first collected dot is kept wrapped by a comment, directive, or disabled text) pinned every continuation dot to the chain-root column, even past the first invoked link. When a non-invoked prefix (`.Prop`) shares a line with the first invoked link (`.Foo()`), that root column differs from `RH5201MethodChainsShouldBeAlignedAnalyzer`'s reference column, so the formatter's own output failed its own rule. Fixed by switching the anchor to the first invoked link's rendered column once the layout walk passes it.
- **#699**: The line-break phase's collapse guard suppressed collapsing a wrapped, uncommented, non-invoked prefix dot (`.Prop`) whenever a comment sat above the chain's first *invoked* link further down — even though that comment never occupied the gap the collapse would actually join across. Fixed by narrowing the guard to the trivia directly above the collapse candidate itself, matching the existing directive-arm behavior.

During the official preflight audit, the #699 fix's narrowed guard was found to let a stale collapse-candidate search return a dot *past* the first invoked link for a postfix null-forgiving (`a!`) chain, causing a non-terminating collapse/line-break cycle and RH5201-dirty output. That was repaired in the same PR by bounding the candidate search to never return a dot after the chain's first invoked link.

## Why

Both issues concern the same two formatter files (`MethodChainAlignmentContributor`, `ChainLineBreakRewriter`) but are distinct, independently-triggered mechanisms, confirmed by a Behavior Contract analysis before implementation. The repository owner confirmed the target behavior for both in chat: #699's wrapped prefix should collapse onto the root line with later links aligned to it; #698's continuation dots should all land in one column matching RH5201.

## Linked issues

Closes #699
Closes #698

## Review notes

- Reproduction gate confirmed #698 (`RH5201Issue698ReproductionTests`, red before the fix, green after).
- Regression matrix (8 tests) added before the production change, all deliberately red against unmodified code, covering #698's comment/region/disabled-text/trailing-property/`?.`/`!.` variants and #699's collapse boundary.
- Official preflight attempt 1 found one high-severity regression (the `a!`-rooted non-termination described above) plus a coverage gap and a doc-wording nit; all three were repaired in one cycle with 5 additional tests. Preflight retry (attempt 2) passed with no new findings.
- Full validation green on the final tree: 4,886 tests across all 7 projects (build 0 warnings/0 errors).
- A separate, pre-existing formatter defect remains open on `a!.Prop`-rooted chains with a comment above the first invoked link (merges continuation links onto one line at block indentation) — verified byte-identical before and after this PR by both preflight passes, so it is genuinely untouched. Filed as #719.

## Follow-up work

#719 — a comment above the first invoked link still pins a chain rooted in a wrapped null-forgiving prefix (`a` ⏎ `!.Prop` ⏎ comment ⏎ `.Foo()` ⏎ `.Bar()`) at block indentation. Distinct from the shapes this PR fixes; needs its own Behavior Contract pass.