### PR TITLE
Collapse a wrapped null-forgiving prefix the same way as a plain prefix dot

### DIFF
--- a/Reihitsu.Analyzer.Test/Formatting/RH5112WrappedFluentCallsShouldKeepFirstCallOnOriginalLineAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH5112WrappedFluentCallsShouldKeepFirstCallOnOriginalLineAnalyzerTests.cs
@@ -315,7 +315,7 @@ public class RH5112WrappedFluentCallsShouldKeepFirstCallOnOriginalLineAnalyzerTe
     /// <summary>
     /// Verifies that RH5112 does not report when the first invoked link is introduced by a
     /// null-forgiving operator whose own receiver is an intermediate member access, matching the
-    /// existing exemption for a plain dot in the same position (issue #721 review)
+    /// existing exemption for a plain dot in the same position (PR #721)
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
     [TestMethod]
@@ -355,6 +355,68 @@ public class RH5112WrappedFluentCallsShouldKeepFirstCallOnOriginalLineAnalyzerTe
                                 """;
 
         await Verify(testData);
+    }
+
+    /// <summary>
+    /// Verifies the other side of the intermediate-member-access boundary: RH5112 still reports, and
+    /// its code fix still converges, when the first invoked link is introduced by a null-forgiving
+    /// operator whose own receiver is <em>not</em> an intermediate member access (PR #721)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyDiagnosticAndCodeFixWhenNullForgivingLinkHasNoIntermediateMemberAccess()
+    {
+        const string testData = """
+                                internal sealed class Example
+                                {
+                                    private static object Create(Builder builder)
+                                    {
+                                        return builder
+                                            {|#0:!|}.UseLogging()
+                                            .Build();
+                                    }
+
+                                    private sealed class Builder
+                                    {
+                                        public Builder UseLogging()
+                                        {
+                                            return this;
+                                        }
+
+                                        public object Build()
+                                        {
+                                            return new object();
+                                        }
+                                    }
+                                }
+                                """;
+        const string resultData = """
+                                  internal sealed class Example
+                                  {
+                                      private static object Create(Builder builder)
+                                      {
+                                          return builder!.UseLogging()
+                                                        .Build();
+                                      }
+
+                                      private sealed class Builder
+                                      {
+                                          public Builder UseLogging()
+                                          {
+                                              return this;
+                                          }
+
+                                          public object Build()
+                                          {
+                                              return new object();
+                                          }
+                                      }
+                                  }
+                                  """;
+
+        await Verify(testData,
+                     resultData,
+                     Diagnostics(RH5112WrappedFluentCallsShouldKeepFirstCallOnOriginalLineAnalyzer.DiagnosticId, AnalyzerResources.RH5112MessageFormat));
     }
 
     #endregion // Tests

--- a/Reihitsu.Analyzer.Test/Formatting/RH5112WrappedFluentCallsShouldKeepFirstCallOnOriginalLineAnalyzerTests.cs
+++ b/Reihitsu.Analyzer.Test/Formatting/RH5112WrappedFluentCallsShouldKeepFirstCallOnOriginalLineAnalyzerTests.cs
@@ -312,5 +312,50 @@ public class RH5112WrappedFluentCallsShouldKeepFirstCallOnOriginalLineAnalyzerTe
         await Verify(testData);
     }
 
+    /// <summary>
+    /// Verifies that RH5112 does not report when the first invoked link is introduced by a
+    /// null-forgiving operator whose own receiver is an intermediate member access, matching the
+    /// existing exemption for a plain dot in the same position (issue #721 review)
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation</returns>
+    [TestMethod]
+    public async Task VerifyNoDiagnosticWhenNullForgivingLinkHasIntermediateMemberAccess()
+    {
+        const string testData = """
+                                internal sealed class Example
+                                {
+                                    private static object Create(Builder builder)
+                                    {
+                                        return builder.Inner
+                                            !.UseLogging()
+                                            .Build();
+                                    }
+
+                                    private sealed class Builder
+                                    {
+                                        public Builder Inner
+                                        {
+                                            get
+                                            {
+                                                return this;
+                                            }
+                                        }
+
+                                        public Builder UseLogging()
+                                        {
+                                            return this;
+                                        }
+
+                                        public object Build()
+                                        {
+                                            return new object();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await Verify(testData);
+    }
+
     #endregion // Tests
 }

--- a/Reihitsu.Analyzer/Core/FluentChainAnalysisHelper.cs
+++ b/Reihitsu.Analyzer/Core/FluentChainAnalysisHelper.cs
@@ -76,7 +76,7 @@ internal static class FluentChainAnalysisHelper
     /// <summary>
     /// Determines whether the first invoked chain link is preceded by intermediate member access. A
     /// null-forgiving operator is checked through its own operand the same way, since <c>a.Prop!.Foo()</c>
-    /// is the same intermediate-access shape as <c>a.Prop.Foo()</c> (issue #721 review)
+    /// is the same intermediate-access shape as <c>a.Prop.Foo()</c> (PR #721)
     /// </summary>
     /// <param name="token">The chain link token</param>
     /// <returns><c>true</c> if intermediate member access precedes the invocation; otherwise <c>false</c></returns>

--- a/Reihitsu.Analyzer/Core/FluentChainAnalysisHelper.cs
+++ b/Reihitsu.Analyzer/Core/FluentChainAnalysisHelper.cs
@@ -74,7 +74,9 @@ internal static class FluentChainAnalysisHelper
     }
 
     /// <summary>
-    /// Determines whether the first invoked chain link is preceded by intermediate member access
+    /// Determines whether the first invoked chain link is preceded by intermediate member access. A
+    /// null-forgiving operator is checked through its own operand the same way, since <c>a.Prop!.Foo()</c>
+    /// is the same intermediate-access shape as <c>a.Prop.Foo()</c> (issue #721 review)
     /// </summary>
     /// <param name="token">The chain link token</param>
     /// <returns><c>true</c> if intermediate member access precedes the invocation; otherwise <c>false</c></returns>
@@ -86,6 +88,8 @@ internal static class FluentChainAnalysisHelper
                                                                                         or ConditionalAccessExpressionSyntax,
                    ConditionalAccessExpressionSyntax conditionalAccess => conditionalAccess.Expression is MemberAccessExpressionSyntax
                                                                                                        or ConditionalAccessExpressionSyntax,
+                   PostfixUnaryExpressionSyntax postfixUnary => postfixUnary.Operand is MemberAccessExpressionSyntax
+                                                                                     or ConditionalAccessExpressionSyntax,
                    _ => false,
                };
     }

--- a/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
@@ -3694,5 +3694,91 @@ public class MethodChainAlignmentTests : FormatterTestsBase
         AssertRuleResult(input, expected);
     }
 
+    /// <summary>
+    /// Verify that a <c>#pragma</c> directive directly above a wrapped null-forgiving prefix leaves
+    /// every invoked link on its own line, mirroring
+    /// <see cref="PragmaAboveFirstInvokedLinkKeepsEveryInvokedLinkOnItsOwnLine"/> for the new
+    /// null-forgiving-prefix candidate class (issue #721 review)
+    /// </summary>
+    [TestMethod]
+    public void PragmaAboveWrappedNullForgivingPrefixKeepsEveryInvokedLinkOnItsOwnLine()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                             #pragma warning disable 1234
+                                         !.Foo()
+                                         .Bar().Baz();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a
+                                #pragma warning disable 1234
+                                                !.Foo()
+                                                .Bar()
+                                                .Baz();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verify that disabled text directly above a wrapped null-forgiving prefix leaves every invoked
+    /// link on its own line, mirroring
+    /// <see cref="DisabledTextAboveFirstInvokedLinkKeepsEveryInvokedLinkOnItsOwnLine"/> for the new
+    /// null-forgiving-prefix candidate class (issue #721 review)
+    /// </summary>
+    [TestMethod]
+    public void DisabledTextAboveWrappedNullForgivingPrefixKeepsEveryInvokedLinkOnItsOwnLine()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                             #if false
+                                     .Nope()
+                             #endif
+                                         !.Foo()
+                                         .Bar().Baz();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a
+                                #if false
+                                        .Nope()
+                                #endif
+                                                !.Foo()
+                                                .Bar()
+                                                .Baz();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
     #endregion // Methods
 }

--- a/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
@@ -3526,5 +3526,173 @@ public class MethodChainAlignmentTests : FormatterTestsBase
         AssertRuleResult(input, expected);
     }
 
+    /// <summary>
+    /// Verifies that a wrapped null-forgiving operator introducing a non-invoked prefix
+    /// (<c>!.Prop</c>) collapses onto the chain root line the same way a plain non-invoked prefix dot
+    /// does, and the following invoked links align to the resulting column (issue #719)
+    /// </summary>
+    [TestMethod]
+    public void WrappedNullForgivingNonInvokedPrefixCollapsesOntoChainRoot()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                                         !.Prop
+                                         .Foo()
+                                         .Bar();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a!.Prop
+                                                 .Foo()
+                                                 .Bar();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies the exact shape reported in issue #719: a comment above the chain's first invoked
+    /// link pins the chain at block indentation unless the earlier, uncommented, wrapped
+    /// null-forgiving prefix (<c>!.Prop</c>) is recognized as the collapse candidate — mirroring
+    /// <see cref="CommentAboveFirstInvokedLinkStillCollapsesWrappedPrefixDot"/> for a plain prefix dot
+    /// </summary>
+    [TestMethod]
+    public void CommentAboveFirstInvokedLinkStillCollapsesWrappedNullForgivingPrefixDot()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                                         !.Prop
+                                         // keep wrapped
+                                         .Foo()
+                                         .Bar();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a!.Prop
+
+                                                 // keep wrapped
+                                                 .Foo()
+                                                 .Bar();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that only the chain's own first wrapped token collapses onto the root line when a
+    /// null-forgiving prefix is followed by a second, plain non-invoked prefix dot before a comment
+    /// above the first invoked link; the remaining prefix stays on its own line but aligns to the
+    /// anchor column, mirroring <see cref="CommentAboveFirstInvokedLinkCollapsesOnlyFirstOfTwoWrappedPrefixDots"/>
+    /// (issue #719)
+    /// </summary>
+    [TestMethod]
+    public void CommentAboveFirstInvokedLinkCollapsesOnlyFirstOfTwoWrappedPrefixDotsWithNullForgivingPrefix()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                                         !.Prop
+                                         .Other
+                                         // keep wrapped
+                                         .Foo()
+                                         .Bar();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a!.Prop
+                                                 .Other
+
+                                                 // keep wrapped
+                                                 .Foo()
+                                                 .Bar();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
+    /// Verifies that a wrapped null-forgiving operator is refused as a collapse candidate when its own
+    /// receiver is another member access: <c>a.Prop1!.Prop2.Foo()</c> is a fluent chain with an
+    /// intermediate member access the same way <c>a.Prop1.Prop2.Foo()</c> is, and both must stay
+    /// wrapped rather than joining across the link (guard-delta for issue #719's widened candidate
+    /// search — <see cref="Reihitsu.Formatter.Pipeline.LineBreaks.Utilities.ChainWalker.DotHasIntermediateMemberAccess"/>
+    /// now checks a null-forgiving operator's own operand the same way it already checked a plain
+    /// dot's receiver)
+    /// </summary>
+    [TestMethod]
+    public void NullForgivingPrefixWithIntermediateMemberAccessStaysWrapped()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a.Prop1
+                                         !.Prop2
+                                         .Foo()
+                                         .Bar();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a.Prop1
+                                                 !.Prop2
+                                                 .Foo()
+                                                 .Bar();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
     #endregion // Methods
 }

--- a/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
+++ b/Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs
@@ -3695,10 +3695,53 @@ public class MethodChainAlignmentTests : FormatterTestsBase
     }
 
     /// <summary>
+    /// Verifies that a wrapped, non-invoked prefix dot behind an attached (unwrapped) null-forgiving
+    /// operator is refused as a collapse candidate on a second formatter pass the same way it is on
+    /// the first: the candidate search stays confined to the chain's own first spine token and never
+    /// advances past it to a later dot, so <c>a.Prop1!</c> collapsing onto <c>a</c> in one pass does
+    /// not newly expose <c>.Prop2</c> to a wrongful collapse across the intermediate <c>.Prop1</c>
+    /// access in the next (preflight finding for PR #721)
+    /// </summary>
+    [TestMethod]
+    public void WrappedDotBehindAttachedNullForgivingPrefixStaysStableAcrossPasses()
+    {
+        // Arrange
+        const string input = """
+                             class C
+                             {
+                                 void M()
+                                 {
+                                     var x = a
+                                         .Prop1!
+                                         .Prop2
+                                         .Foo()
+                                         .Bar();
+                                 }
+                             }
+                             """;
+
+        const string expected = """
+                                class C
+                                {
+                                    void M()
+                                    {
+                                        var x = a.Prop1!
+                                                 .Prop2
+                                                 .Foo()
+                                                 .Bar();
+                                    }
+                                }
+                                """;
+
+        // Act & Assert
+        AssertRuleResult(input, expected);
+    }
+
+    /// <summary>
     /// Verify that a <c>#pragma</c> directive directly above a wrapped null-forgiving prefix leaves
     /// every invoked link on its own line, mirroring
     /// <see cref="PragmaAboveFirstInvokedLinkKeepsEveryInvokedLinkOnItsOwnLine"/> for the new
-    /// null-forgiving-prefix candidate class (issue #721 review)
+    /// null-forgiving-prefix candidate class (PR #721)
     /// </summary>
     [TestMethod]
     public void PragmaAboveWrappedNullForgivingPrefixKeepsEveryInvokedLinkOnItsOwnLine()
@@ -3739,7 +3782,7 @@ public class MethodChainAlignmentTests : FormatterTestsBase
     /// Verify that disabled text directly above a wrapped null-forgiving prefix leaves every invoked
     /// link on its own line, mirroring
     /// <see cref="DisabledTextAboveFirstInvokedLinkKeepsEveryInvokedLinkOnItsOwnLine"/> for the new
-    /// null-forgiving-prefix candidate class (issue #721 review)
+    /// null-forgiving-prefix candidate class (PR #721)
     /// </summary>
     [TestMethod]
     public void DisabledTextAboveWrappedNullForgivingPrefixKeepsEveryInvokedLinkOnItsOwnLine()

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/Rewriter/ChainLineBreakRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/Rewriter/ChainLineBreakRewriter.cs
@@ -129,15 +129,17 @@ internal sealed class ChainLineBreakRewriter : CSharpSyntaxRewriter
     /// chain wrapped.
     /// </para>
     /// <para>
-    /// A postfix null-forgiving operator on the chain root (<c>a!</c>) is not itself a candidate — the
-    /// search skips it and considers the next collected dot. When that root's invoked link is a
-    /// directly-invoked member access (<c>a!.Foo()</c>), <c>!</c> stands in for the whole link and no
-    /// dot for <c>.Foo()</c> is ever collected, so the next entry the search would otherwise land on is
-    /// already a <em>later</em> link (<c>.Bar()</c>), not the chain's own first dot. Returning it would
-    /// let the collapse join across a link the rest of the chain still treats as wrapped, which never
-    /// settles (issue #699's escaped guard). The position check below refuses any candidate that does
-    /// not sit at or before <paramref name="firstInvokedDot"/> and falls back to it instead — for
-    /// <c>a!.Foo()</c> that fallback is <c>!</c> itself, matching the shape's own first invoked link
+    /// The candidate is the first collected spine token that is itself wrapped onto its own line,
+    /// including a postfix null-forgiving operator (<c>a</c> ⏎ <c>!.Prop.Foo()</c> wraps at <c>!</c>,
+    /// the same way <c>a</c> ⏎ <c>.Prop.Foo()</c> wraps at the dot before <c>.Prop</c>) — a plain dot
+    /// and a null-forgiving operator standing in for a non-invoked prefix are the same kind of
+    /// candidate (issue #719). When the null-forgiving operator instead stands in for a
+    /// directly-invoked link (<c>a</c> ⏎ <c>!.Foo()</c>), it is already <paramref name="firstInvokedDot"/>
+    /// itself, so finding it here and returning it changes nothing. The position check below still
+    /// refuses any candidate that does not sit at or before <paramref name="firstInvokedDot"/> and
+    /// falls back to it instead, so a wrap that lands on a later link (past the chain's own first dot)
+    /// never joins across a link the rest of the chain still treats as wrapped, which never settles
+    /// (issue #699's escaped guard)
     /// </para>
     /// </summary>
     /// <param name="node">The outermost chain node</param>
@@ -155,10 +157,9 @@ internal sealed class ChainLineBreakRewriter : CSharpSyntaxRewriter
 
         ChainWalker.CollectAlignmentDots(expression, spineDots);
 
-        var firstChainDot = spineDots.Find(static dot => dot.Parent is not PostfixUnaryExpressionSyntax);
+        var firstChainDot = spineDots.Find(static dot => LineBreakTriviaUtilities.HasLeadingEndOfLine(dot));
 
         if (firstChainDot.IsKind(SyntaxKind.None) == false
-            && LineBreakTriviaUtilities.HasLeadingEndOfLine(firstChainDot)
             && firstChainDot.SpanStart <= firstInvokedDot.SpanStart)
         {
             return firstChainDot;

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/Rewriter/ChainLineBreakRewriter.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/Rewriter/ChainLineBreakRewriter.cs
@@ -129,17 +129,20 @@ internal sealed class ChainLineBreakRewriter : CSharpSyntaxRewriter
     /// chain wrapped.
     /// </para>
     /// <para>
-    /// The candidate is the first collected spine token that is itself wrapped onto its own line,
-    /// including a postfix null-forgiving operator (<c>a</c> ⏎ <c>!.Prop.Foo()</c> wraps at <c>!</c>,
-    /// the same way <c>a</c> ⏎ <c>.Prop.Foo()</c> wraps at the dot before <c>.Prop</c>) — a plain dot
-    /// and a null-forgiving operator standing in for a non-invoked prefix are the same kind of
-    /// candidate (issue #719). When the null-forgiving operator instead stands in for a
-    /// directly-invoked link (<c>a</c> ⏎ <c>!.Foo()</c>), it is already <paramref name="firstInvokedDot"/>
-    /// itself, so finding it here and returning it changes nothing. The position check below still
-    /// refuses any candidate that does not sit at or before <paramref name="firstInvokedDot"/> and
-    /// falls back to it instead, so a wrap that lands on a later link (past the chain's own first dot)
-    /// never joins across a link the rest of the chain still treats as wrapped, which never settles
-    /// (issue #699's escaped guard)
+    /// The candidate stays confined to the chain's own first spine token — never a later one, so a
+    /// chain with more than one non-invoked prefix still only ever tests its very first dot and keeps
+    /// today's behavior for every shape without a null-forgiving operator. The one exception is a
+    /// leading null-forgiving operator that is <em>not</em> itself wrapped (<c>a!</c> ⏎ <c>.Prop...</c>):
+    /// such an operator is attached to the root rather than starting its own line, so it is skipped and
+    /// the dot right after it is tested instead — the shape #683 already handles. When that leading
+    /// operator <em>is</em> wrapped instead (<c>a</c> ⏎ <c>!.Prop.Foo()</c>), it is not skipped and
+    /// becomes the candidate itself, the same way a plain wrapped prefix dot already is (issue #719).
+    /// When the null-forgiving operator stands in for a directly-invoked link (<c>a</c> ⏎ <c>!.Foo()</c>),
+    /// it is already <paramref name="firstInvokedDot"/> itself, so finding it here and returning it
+    /// changes nothing. The position check below still refuses a candidate that does not sit at or
+    /// before <paramref name="firstInvokedDot"/> and falls back to it instead, so a wrap that lands on
+    /// a later link never joins across a link the rest of the chain still treats as wrapped, which
+    /// never settles (issue #699's escaped guard)
     /// </para>
     /// </summary>
     /// <param name="node">The outermost chain node</param>
@@ -157,9 +160,19 @@ internal sealed class ChainLineBreakRewriter : CSharpSyntaxRewriter
 
         ChainWalker.CollectAlignmentDots(expression, spineDots);
 
-        var firstChainDot = spineDots.Find(static dot => LineBreakTriviaUtilities.HasLeadingEndOfLine(dot));
+        var candidateIndex = 0;
+
+        while (candidateIndex < spineDots.Count
+               && spineDots[candidateIndex].Parent is PostfixUnaryExpressionSyntax
+               && LineBreakTriviaUtilities.HasLeadingEndOfLine(spineDots[candidateIndex]) == false)
+        {
+            candidateIndex++;
+        }
+
+        var firstChainDot = candidateIndex < spineDots.Count ? spineDots[candidateIndex] : default;
 
         if (firstChainDot.IsKind(SyntaxKind.None) == false
+            && LineBreakTriviaUtilities.HasLeadingEndOfLine(firstChainDot)
             && firstChainDot.SpanStart <= firstInvokedDot.SpanStart)
         {
             return firstChainDot;
@@ -254,7 +267,10 @@ internal sealed class ChainLineBreakRewriter : CSharpSyntaxRewriter
     /// line. The caller decides which dot that is — see <see cref="FindFirstWrappedChainOperator"/> —
     /// and this method only refuses the join: a dot whose own receiver is another member or
     /// conditional access belongs to a fluent chain that stays wrapped, and a comment, directive, or
-    /// disabled text in the gap keeps the two tokens on separate lines
+    /// disabled text in the gap keeps the two tokens on separate lines. Checking one level of receiver
+    /// is enough: <see cref="FindFirstWrappedChainOperator"/> never hands this method a dot deeper than
+    /// the chain's own first spine token, so a hidden intermediate access further up the receiver
+    /// chain is never reachable here in the first place
     /// </summary>
     /// <param name="firstDot">The chain dot to collapse</param>
     /// <param name="replacements">The token replacement map to populate</param>

--- a/Reihitsu.Formatter/Pipeline/LineBreaks/Utilities/ChainWalker.cs
+++ b/Reihitsu.Formatter/Pipeline/LineBreaks/Utilities/ChainWalker.cs
@@ -257,9 +257,11 @@ internal static class ChainWalker
 
     /// <summary>
     /// Determines whether a single chain dot token has an intermediate member access between
-    /// the dot and the chain root
+    /// the dot and the chain root. A postfix null-forgiving operator is checked the same way, through
+    /// its own operand, since <c>a.Prop!.Foo()</c> belongs to the same fluent chain the plain-dot check
+    /// keeps wrapped for <c>a.Prop.Foo()</c> (issue #719)
     /// </summary>
-    /// <param name="dotToken">The dot token from a member access expression</param>
+    /// <param name="dotToken">The dot or null-forgiving operator token from a chain link</param>
     /// <returns><see langword="true"/> if there is an intermediate member access; otherwise, <see langword="false"/></returns>
     public static bool DotHasIntermediateMemberAccess(SyntaxToken dotToken)
     {
@@ -267,6 +269,12 @@ internal static class ChainWalker
         {
             return memberAccess.Expression is MemberAccessExpressionSyntax
                    || memberAccess.Expression is ConditionalAccessExpressionSyntax;
+        }
+
+        if (dotToken.Parent is PostfixUnaryExpressionSyntax postfixUnary)
+        {
+            return postfixUnary.Operand is MemberAccessExpressionSyntax
+                   || postfixUnary.Operand is ConditionalAccessExpressionSyntax;
         }
 
         return false;


### PR DESCRIPTION
## Summary

`FindFirstWrappedChainOperator`'s collapse-candidate search now picks the first chain-spine token that is itself wrapped onto its own line — including a postfix null-forgiving operator (`!`) — instead of unconditionally excluding every `!` token. `ChainWalker.DotHasIntermediateMemberAccess` now also checks a null-forgiving operator's own operand, the same way it already checked a plain dot's receiver.

- `Reihitsu.Formatter/Pipeline/LineBreaks/Rewriter/ChainLineBreakRewriter.cs`: generalized the collapse-candidate search from "first non-postfix-unary spine token" to "first spine token with leading end-of-line trivia."
- `Reihitsu.Formatter/Pipeline/LineBreaks/Utilities/ChainWalker.cs`: extended `DotHasIntermediateMemberAccess` to check a null-forgiving operator's own operand.
- `Reihitsu.Formatter.Test/Regression/Indentation/MethodChainAlignmentTests.cs`: added regression tests for the issue's reported shape, the no-comment collapse, the two-wrapped-prefix variant, and the intermediate-member-access guard-delta.

## Why

A wrapped `!` introducing a non-invoked member access (`a` ⏎ `!.Prop.Foo()`) was never offered to the chain collapse the way a plain wrapped prefix dot is (#699/#718's fix): the search excluded every postfix null-forgiving token outright, so the line break before `!` was never recognized, and the chain stayed pinned at block indentation whenever a comment sat above the first invoked link. #699/#718 deliberately scoped this sibling shape out; this closes it the same way.

## Linked issues

Closes #719

## Review notes

The search change is a generalization, not a special case for `!`: it reduces to the same outcomes as the old exclusion-based logic for every previously-tested shape (verified by tracing several representative inputs through `scripts/trace.sh` and by the full existing `MethodChainAlignmentTests` suite staying green), while now also picking up the `!`-prefix case.

Widening the search surfaced a second, related gap: `a.Prop1` ⏎ `!.Prop2.Foo()` is a fluent chain with an intermediate member access through `!`'s own operand, which `DotHasIntermediateMemberAccess` did not check before. Without the accompanying fix, this shape would have collapsed across the link where its plain-dot counterpart (`a.Prop1` ⏎ `.Prop2.Foo()`) correctly stays wrapped. The `NullForgivingPrefixWithIntermediateMemberAccessStaysWrapped` test pins this guard-delta.

Manually traced the issue's exact input through `scripts/trace.sh` and confirmed a stable (non-oscillating) second pass. Full suite (4,890 tests across all projects) passes.

## Follow-up work

None.
